### PR TITLE
fix: checkpoint span corruption and clamping corrupts span start at EOF

### DIFF
--- a/tokit/src/input/checkpoint.rs
+++ b/tokit/src/input/checkpoint.rs
@@ -25,6 +25,13 @@ use super::{Cursor, Lexer};
 /// ```
 pub struct Checkpoint<'a, 'closure, L: Lexer<'a>> {
   cursor: Cursor<'a, 'closure, L>,
+  /// The actual `InputRef::span` at save time.
+  ///
+  /// This is the span of the last consumed token, which may differ from the
+  /// cursor when the cache is non-empty.  Restoring with `self.span` (rather
+  /// than the cursor's span) ensures that the lexer position is placed *before*
+  /// any cached tokens, so they can be re-lexed after a restore.
+  pub(crate) span: L::Span,
   pub(crate) state: L::State,
   _m: PhantomData<fn(&'closure ()) -> &'closure ()>,
 }
@@ -32,9 +39,10 @@ pub struct Checkpoint<'a, 'closure, L: Lexer<'a>> {
 impl<'a, 'closure, L: Lexer<'a>> Checkpoint<'a, 'closure, L> {
   /// Creates a new checkpoint.
   #[cfg_attr(not(tarpaulin), inline(always))]
-  pub(super) const fn new(cursor: Cursor<'a, 'closure, L>, state: L::State) -> Self {
+  pub(super) const fn new(cursor: Cursor<'a, 'closure, L>, span: L::Span, state: L::State) -> Self {
     Self {
       cursor,
+      span,
       state,
       _m: PhantomData,
     }

--- a/tokit/src/input/checkpoint.rs
+++ b/tokit/src/input/checkpoint.rs
@@ -11,6 +11,7 @@ use super::{Cursor, Lexer};
 ///
 /// Checkpoints include:
 /// - The cursor position (byte offset in the input)
+/// - The input span at save time (`InputRef::span` / last-consumed-token span)
 /// - The lexer's extras state (for stateful lexers)
 /// - Cache state (implicitly through the cursor)
 ///

--- a/tokit/src/input/input_ref/mod.rs
+++ b/tokit/src/input/input_ref/mod.rs
@@ -133,10 +133,10 @@ where
   #[cfg_attr(not(tarpaulin), inline(always))]
   fn set_span(&mut self, new: MaybeRef<'_, L::Span>) {
     let end = self.input.len();
-    *self.span = if new.end_ref().lt(&end) {
+    *self.span = if new.end_ref().le(&end) {
       to_owned(new)
     } else {
-      L::Span::new(L::Offset::default(), end)
+      L::Span::new(new.start_ref().clone(), end)
     };
   }
 
@@ -187,12 +187,13 @@ where
     F: FnOnce(&mut Self) -> Option<R>,
   {
     let cur = self.cursor().span().clone();
+    let span = self.span.clone();
     let state = self.state.clone();
 
     match f(self) {
       Some(result) => Some(result),
       None => {
-        let ckp = Checkpoint::new(Cursor::new(cur), state);
+        let ckp = Checkpoint::new(Cursor::new(cur), span, state);
         self.restore(ckp);
         None
       }
@@ -272,7 +273,7 @@ where
   /// implementing backtracking in parsers.
   #[cfg_attr(not(tarpaulin), inline(always))]
   pub fn save(&self) -> Checkpoint<'inp, 'closure, L> {
-    Checkpoint::new(self.cursor().clone(), self.state.clone())
+    Checkpoint::new(self.cursor().clone(), self.span.clone(), self.state.clone())
   }
 
   /// Returns the current cursor position.
@@ -306,7 +307,7 @@ where
     self.cache_mut().rewind(&checkpoint);
     let cur = checkpoint.cursor();
     self.emitter().rewind(cur);
-    self.set_span(cur.span().into());
+    self.set_span((&checkpoint.span).into());
     *self.state = checkpoint.state;
   }
 

--- a/tokit/src/parser/many/mod.rs
+++ b/tokit/src/parser/many/mod.rs
@@ -6,7 +6,7 @@ use super::*;
 use handler::*;
 
 pub use delim::*;
-pub use handler::SeparatorHandler;
+pub use handler::{DelimiterHandler, SeparatorHandler};
 pub use options::*;
 pub use repeated::*;
 pub use repeated_while::*;


### PR DESCRIPTION
# Bug 1: save/restore loses tokens (checkpoint span corruption)

  Root cause: save() stored cursor() which, when the cache is non-empty, points to the cache front's span — not the actual self.span. On restore(), self.span was set to this cursor span. After cache was cleared
  during rewind, offset() returned the cursor's end (past the cached token), causing the token to be permanently lost.

  Fix (2 files):

  - checkpoint.rs: Added a span: L::Span field to Checkpoint to store the actual self.span at save time. Updated constructor to accept it.
  - input_ref/mod.rs:
    - save() — passes self.span.clone() to Checkpoint::new
    - restore() — uses checkpoint.span instead of deriving span from the cursor
    - attempt() — captures self.span.clone() and passes it to Checkpoint::new

 # Bug 2: set_span clamping corrupts span start at EOF

  Root cause: set_span used .lt(&end) (strict less-than), so when span.end == input.len() (valid for the last token), it fell into the else branch which created Span(0, input_len) — corrupting the start position to
  0.

  Fix (input_ref/mod.rs):
  - Changed .lt(&end) to .le(&end) — spans ending exactly at input length are valid
  - Else branch: changed L::Offset::default() to new.start_ref().clone() — if the end exceeds input length, clamp it but preserve the original start