### PR TITLE
fix(peek): one owned window on the miss path, not two

### DIFF
--- a/tokora/src/cache/mod.rs
+++ b/tokora/src/cache/mod.rs
@@ -77,10 +77,16 @@ pub type DefaultCache<'a, L> =
 ///   [`back`](Cache::back) view those same two entries without removing them.
 /// - **Exact length.** [`len`](Cache::len) is exactly the resident count, and
 ///   [`remaining`](Cache::remaining) is exactly how many more `push_back`s will be accepted.
+///   `len` is **load-bearing and it is checked**: the peek fill reserves the window slots for
+///   the cache region from it *before* it lexes anything, so a `len` that is not the resident
+///   count mis-sizes the room [`peek`](Cache::peek) is later given. That is a panic — in every
+///   build if `len` over-reports, in debug builds if it under-reports — see the law below.
 /// - **Bounded, pure peek.** [`peek`](Cache::peek) appends exactly `min(len(), buffer capacity)`
 ///   entries to the buffer, oldest first, once each. It is logically pure: it takes `&self`,
 ///   calling it twice yields the same sequence, and it changes no observable. Borrowed and owned
-///   results denote the same tokens.
+///   results denote the same tokens. Together with exact `len` this means one thing the input
+///   layer relies on and enforces: **when the buffer has room for `len()` entries, `peek`
+///   delivers the whole resident run, `front` through `back`.**
 /// - **The restore path must not panic.** [`pop_front`](Cache::pop_front),
 ///   [`pop_back`](Cache::pop_back), [`clear`](Cache::clear), [`front`](Cache::front),
 ///   [`front_span`](Cache::front_span), [`len`](Cache::len) — **and
@@ -134,6 +140,24 @@ pub trait Cache<'a, L, Lang: ?Sized = ()>: 'a {
   /// Returns the number of tokens currently stored in the cache.
   ///
   /// This count includes all cached tokens from front to back.
+  ///
+  /// # It must be exact, and an inexact one panics
+  ///
+  /// This is not a hint. [`InputRef::peek`](crate::InputRef::peek) sizes the window before it
+  /// lexes: it reserves `len()` of the caller's slots for the cache region, spends the rest on
+  /// tokens lexed past the cache, and only then calls [`peek`](Cache::peek) into the room that
+  /// is left. On an exact `len` that room is exactly the resident run. On a `len` **below** the
+  /// resident count it is too small, so the copy is clipped mid-run and the window would come
+  /// back missing a resident while still carrying the tokens that follow it — a hole in the
+  /// stream, not a short window. On a `len` **above** it, the fill under-lexes and the window
+  /// comes back short of what was asked for. Every exit of the fill that hands a window back
+  /// checks for both, and neither hands back the window it catches: the count `peek` owes
+  /// against the room it was given, **in every build**, naming the over-report half of this
+  /// contract; and the copied region's endpoints against `front` and `back`, read *instead of*
+  /// `len` precisely so an inexact `len` cannot both cause the fault and hide it, **in debug
+  /// builds**, naming the under-report half — that comparison's cost is release-build price for
+  /// a logic bug, not a soundness one, so it runs in debug and under test rather than on every
+  /// release-mode token a grammar peeks.
   fn len(&self) -> usize;
 
   /// Returns the number of additional tokens that can be cached.
@@ -294,6 +318,29 @@ pub trait Cache<'a, L, Lang: ?Sized = ()>: 'a {
   /// observable of the cache, and calling it twice on an unchanged cache appends the same
   /// sequence both times. A borrowed entry and an owned one denote the same token, so a caller
   /// cannot tell which a cache chose to hand back.
+  ///
+  /// # The whole run, when there is room for the whole run
+  ///
+  /// The consequence the input layer depends on, and the one it enforces: **given room for
+  /// `len()` entries, this appends the resident run entire — the first entry is
+  /// [`front`](Cache::front) and the last is [`back`](Cache::back).**
+  ///
+  /// [`InputRef::peek`](crate::InputRef::peek) reserves exactly that room from
+  /// [`len`](Cache::len) before it lexes, and fills the slots it did not reserve with tokens
+  /// lexed past the cache, which sit in the buffer while this runs. So a copy that stops short
+  /// of `back` here is not a short window — it is a window whose cache region is missing an
+  /// entry the tokens after it are still present for. The fill compares the copied region's
+  /// endpoints against `front` and `back` and **panics in debug builds** rather than return
+  /// one: the comparison prices out well past what the violation is worth in release — two ring
+  /// indices, a `Maybe` discriminant, an `Option<&Span>` compare — for a fault that is a logic
+  /// bug, not a soundness one, in a caller with no `unsafe` behind it. A `len` that is not the
+  /// resident count is the way to get there; see [`len`](Cache::len).
+  ///
+  /// The one place a copy may legitimately stop short of `back` is where the window's own
+  /// capacity stopped it **and nothing is appended behind it** — the cache-hit and
+  /// latched-boundary exits, where the copy is the window's tail and a clip therefore shortens
+  /// rather than holes. Even there, stopping short with **room to spare** fails: `peek` owes
+  /// `min(len(), remaining capacity)` and the fill checks it against both.
   ///
   /// # Parameters
   ///

--- a/tokora/src/input/input_ref/census_tests.rs
+++ b/tokora/src/input/input_ref/census_tests.rs
@@ -1878,3 +1878,97 @@ fn front_census_every_probe_is_const_gated() {
     );
   }
 }
+
+/// PEEK_FOOTPRINT — the peek fill's owned token storage is the caller's window and
+/// nothing else.
+///
+/// `Token` and `State` are unconstrained in size, so every `W::CAPACITY`-slot store the
+/// fill builds costs `W::CAPACITY × (Token + State + Span)` of stack. Through 0.8.0 it
+/// built a second one — a `GenericArray<MaybeUninit<_>, W::CAPACITY>` staging the tokens
+/// lexed past the cache until the cache region had been copied into the output buffer —
+/// so a cache miss reserved two full windows and a large token or lexer state doubled a
+/// peek's frame. Those tokens are now staged in the output buffer itself and rotated into
+/// place once the cache region is in, which is what makes the second store unnecessary.
+///
+/// This census is what keeps it gone: a size assertion cannot see a new local, so the
+/// only mechanical guard against the pattern coming back is refusing to let the fill body
+/// name the things that build one. The size law itself is asserted at compile time beside
+/// the oversized fixture in `peek/tests.rs` (grep PEEK_FOOTPRINT).
+///
+/// # It is syntactic, and that is the best available
+///
+/// The needles below are a string match, so a second window behind a `type` alias the
+/// fill does not spell — `let mut spare = Staging::new();` — walks past them. That gap is
+/// known and it is not closable here, because nothing the compiler checks can see the
+/// property:
+///
+/// - a `const` assertion can read `size_of` of a **type**, never the frame of a
+///   **function**; Rust exposes no frame size at compile time, so "this body reserves one
+///   window" is not statable as a type-level fact.
+/// - a runtime stack measurement was tried and rejected on the evidence recorded beside
+///   the fixture: an unoptimized build materializes roughly seven window-sized copies
+///   around the fill, so the term under test is under a seventh of the frame and any
+///   threshold over it is a magic number a compiler release moves.
+/// - `clippy::large_stack_frames` is threshold-based on the same frame, and the frame
+///   legitimately scales with `W::CAPACITY × size_of::<Token>()` — it would fire on the
+///   *single* correct window for a large-token monomorphization.
+///
+/// So this stays a syntactic guard that is honest about being one, rather than a
+/// structural guard that is not structural. The `GenericArrayDeque::` and `.rotate_left(`
+/// counts below are the file-scoped half, and they do bite an alias: whatever it is named,
+/// a second window still has to be *constructed*, and the deque count is the shape a
+/// construction in this file takes.
+#[test]
+#[cfg_attr(
+  miri,
+  ignore = "reads crate source and string-matches: no UB surface, and miri interprets every byte"
+)]
+fn peek_footprint_census_the_fill_owns_no_store() {
+  let peek = source("peek/mod.rs");
+  let fill = method_body(peek, "peek_with_emitter_inner");
+
+  // Everything that can build a window-shaped store, plus `unsafe` — the fill needs
+  // none of them now that the staged region lives in the buffer the caller owns, and
+  // each is a way to reintroduce the second window.
+  for needle in [
+    "MaybeUninit",
+    "GenericArray<",
+    "GenericArrayDeque",
+    "uninit(",
+    "W::array",
+    "W::deque",
+    "Window::array",
+    "Window::deque",
+    "unsafe",
+  ] {
+    assert!(
+      count(&fill, needle) == 0,
+      "PEEK_FOOTPRINT drift: the peek fill names `{needle}`. The fill owns no token \
+       storage of its own — tokens past the cache are staged in the caller's window and \
+       rotated into place — so anything that reserves `W::CAPACITY` slots here is the \
+       second owned window this was removed to close, and anything `unsafe` is the \
+       partial-initialization bookkeeping that went with it (grep PEEK_FOOTPRINT)."
+    );
+  }
+
+  // One window per public entry point — the buffer each hands back — and no fourth.
+  let built = count(peek, "GenericArrayDeque::");
+  assert!(
+    built == 3,
+    "PEEK_FOOTPRINT drift: `peek/mod.rs` builds {built} deque(s), expected 3 — one per \
+     public entry point (`peek_one`, `peek_with_emitter`, `peek_with_emitter_terminal`), \
+     each the window it returns. A fourth is a store the caller never sees \
+     (grep PEEK_FOOTPRINT)."
+  );
+
+  // The staged region is put back in stream order by one rotation, and that rotation is
+  // the whole of the reordering: a second one would mean the fill is permuting something
+  // it does not own.
+  let rotations = count(peek, ".rotate_left(");
+  assert!(
+    rotations == 1,
+    "PEEK_FOOTPRINT drift: `peek/mod.rs` rotates {rotations} time(s), expected 1 — the \
+     single left-rotation that moves the staged region behind the front-of-stream region \
+     (grep PEEK_FOOTPRINT)."
+  );
+}

--- a/tokora/src/input/input_ref/peek/mod.rs
+++ b/tokora/src/input/input_ref/peek/mod.rs
@@ -1,72 +1,6 @@
-use core::mem::{ManuallyDrop, MaybeUninit};
-
-use generic_arraydeque::{ArrayLength, GenericArrayDeque, array::GenericArray};
+use generic_arraydeque::GenericArrayDeque;
 
 use super::*;
-
-/// Drop-safe staging buffer for peek tokens that overflow the cache window.
-///
-/// A peek that looks past the cache capacity must hold the overflow tokens
-/// somewhere until the cache region is copied into the output buffer. Those
-/// tokens are **owned** (`Maybe::Owned`), so a raw `MaybeUninit` array would leak
-/// them if an early return (a fatal lexer error emitted mid-scan) skipped the
-/// hand-off. `Overflow` tracks how many entries are initialized and frees exactly
-/// those in its `Drop`, so no exit path — success, `Decline`, or fatal error —
-/// can leak a staged token or its state.
-struct Overflow<T, N: ArrayLength> {
-  slots: GenericArray<MaybeUninit<T>, N>,
-  len: usize,
-}
-
-impl<T, N: ArrayLength> Overflow<T, N> {
-  #[inline(always)]
-  fn new() -> Self {
-    Self {
-      slots: GenericArray::uninit(),
-      len: 0,
-    }
-  }
-
-  // Only read by the debug-assertion accounting below; gate it to the same
-  // configuration so release builds do not see it as dead code.
-  #[cfg(debug_assertions)]
-  #[inline(always)]
-  fn len(&self) -> usize {
-    self.len
-  }
-
-  /// Stages one owned entry. Callers must not exceed `N` pushes (the overflow
-  /// region can never hold more than the window capacity).
-  #[inline(always)]
-  fn push(&mut self, value: T) {
-    self.slots[self.len].write(value);
-    self.len += 1;
-  }
-
-  /// Moves every staged entry into `buf`, in staging order, and disarms the
-  /// guard so its `Drop` will not touch the moved-out entries.
-  #[inline(always)]
-  fn drain_into(self, buf: &mut GenericArrayDeque<T, N>) {
-    // Wrap in `ManuallyDrop` up front: once entries are read out they must not be
-    // dropped again by the guard.
-    let this = ManuallyDrop::new(self);
-    for i in 0..this.len {
-      // SAFETY: `slots[0..len]` were initialized by `push`; each is read once.
-      buf.push_back(unsafe { this.slots[i].assume_init_read() });
-    }
-  }
-}
-
-impl<T, N: ArrayLength> Drop for Overflow<T, N> {
-  #[inline(always)]
-  fn drop(&mut self) {
-    for slot in self.slots.iter_mut().take(self.len) {
-      // SAFETY: `slots[0..len]` were initialized by `push` and not moved out
-      // (`drain_into` disarms via `ManuallyDrop`), so each is dropped once.
-      unsafe { slot.assume_init_drop() };
-    }
-  }
-}
 
 impl<'inp, L, Ctx, Lang: ?Sized, Cmpl> InputRef<'inp, '_, L, Ctx, Lang, Cmpl>
 where
@@ -115,6 +49,43 @@ where
   /// limit trip during the fill emits its diagnostic and latches the poison boundary before the
   /// holdback is consulted, so a peek can no more hide a tripped limit than a consume can. See
   /// [terminal beats incomplete](crate::input#terminal-beats-incomplete-and-they-never-substitute).
+  ///
+  /// # Stack footprint: one window, cache hit or miss
+  ///
+  /// The window this returns is the **only** owned token storage a peek reserves. Its worst case
+  /// is the whole array live at once:
+  ///
+  /// ```text
+  /// W::CAPACITY × size_of::<Maybe<CachedToken<&Token, &State, &Span>,
+  ///                              CachedToken<Token, State, Span>>>()
+  /// ```
+  ///
+  /// which for every realistic type is `W::CAPACITY × (size_of::<Token>() + size_of::<State>() +
+  /// size_of::<Span>())` plus per-entry padding and a discriminant. A **cache miss costs no
+  /// second window**: tokens lexed past the cache are staged in this same buffer and rotated into
+  /// place, so the miss path reserves exactly what the hit path does. (Through 0.8.0 the miss path
+  /// staged them in a separate `W::CAPACITY`-slot array, doubling the figure above.)
+  ///
+  /// Beyond the window the frame holds one clone of the lexer — `size_of::<L>()`, which contains
+  /// `State` — and a small fixed part. Nothing here is heap-allocated, and nothing scales with the
+  /// input.
+  ///
+  /// `Token` and `State` are unconstrained in size, so the bound is linear in both and in the
+  /// window width. A grammar carrying a large token payload or a large lexer state pays
+  /// `W::CAPACITY` times it for the width it asks for: prefer the narrowest window that decides
+  /// the production, and [`peek_kind`](Self::peek_kind) or
+  /// [`head_satisfies`](Self::head_satisfies) — which run at `U1` — for a head test.
+  ///
+  /// # Panics
+  ///
+  /// On a [`Cache`](crate::cache::Cache) that breaks its own contract, and only then. The fill
+  /// reserves the window's cache region from [`Cache::len`](crate::cache::Cache::len) before it
+  /// lexes, so a `len` that is not the resident count mis-sizes the room
+  /// [`Cache::peek`](crate::cache::Cache::peek) is given. **Every** exit that hands back a window
+  /// checks the copy that landed in it — against the room the fill left, and against the cache's
+  /// own `front` and `back` — and panics rather than return a window that is wrong about the
+  /// stream. Every cache this crate ships conforms, and the
+  /// cache conformance kit checks a downstream one.
   #[inline]
   pub fn peek<'p, W>(
     &'p mut self,
@@ -126,6 +97,9 @@ where
   }
 
   /// Peeks tokens to fill the provided buffer and returns the emitter.
+  ///
+  /// Reserves the same one owned window as [`peek`](Self::peek), cache hit or miss — see its
+  /// stack-footprint section.
   #[inline]
   pub fn peek_with_emitter<'p, W>(
     &'p mut self,
@@ -156,6 +130,9 @@ where
   ///
   /// Callers must consult the flag **immediately**, before any fallible or emitting call (`decide`,
   /// element handlers, close probes): an ordinary error raised in between preempts the terminal stop.
+  ///
+  /// Reserves the same one owned window as [`peek`](Self::peek), cache hit or miss — see its
+  /// stack-footprint section.
   #[inline]
   pub fn peek_with_emitter_terminal<'p, W>(
     &'p mut self,
@@ -213,7 +190,17 @@ where
           buf.push_back(Maybe::Ref(parked.as_ref()));
         }
       }
+      let at = buf.len();
       self.cache.peek::<W>(buf);
+      // CACHE_COPY, the cache-hit exit. `clip_ok` is TRUE here and this is the one shape that
+      // earns it: the fill reserved a slot per reported resident and found it had fewer slots
+      // than residents (that is what `want == 0` means), so `Cache::peek` is *expected* to
+      // stop at the window's edge rather than at `back` — and nothing is appended behind the
+      // copy, so a tail that stops at capacity is a correct short prefix and not a hole.
+      // The licence is narrow, and `assert_cache_copy` is where it is spent: a copy that
+      // stops short with room to SPARE is not a capacity clip, it is the over-report
+      // shortening the window, and it fails there.
+      Self::assert_cache_copy::<W>(self.cache, buf, at, in_cache, true);
       return Ok(self.session.emitter);
     }
 
@@ -231,12 +218,43 @@ where
           buf.push_back(Maybe::Ref(parked.as_ref()));
         }
       }
+      let at = buf.len();
       self.cache.peek::<W>(buf);
+      // CACHE_COPY, the latched-boundary exit. Nothing is appended behind this copy either, so
+      // it carries the same `clip_ok` as the hit exit — inert here, because reaching this point
+      // means `want > 0`, i.e. the room left exceeds the reported resident count and no clip
+      // should occur at all. The window is short by DESIGN on this path (a terminal stop), which
+      // is exactly why it needs the check: shortness carries no information here, so a
+      // `Cache::peek` that returned less than it owes would be invisible in the result.
+      Self::assert_cache_copy::<W>(self.cache, buf, at, in_cache, true);
       return Ok(self.session.emitter);
     }
 
-    // Drop-safe staging for tokens lexed past the cache window (see `Overflow`).
-    let mut overflowed = Overflow::<MaybeRefCachedTokenOf<'p, 'inp, L>, W::CAPACITY>::new();
+    // WHY THE OVERFLOW REGION LIVES IN `buf`.
+    //
+    // The two halves of a window are produced in the opposite order from the one it must
+    // report: the cache region is copied out in one bulk read *after* the fill, while the
+    // tokens past the cache are lexed *during* it. That ordering — not a shortage of room —
+    // is what a staging area exists to solve. It is solved here by staging those tokens at
+    // `buf`'s own tail and, once the cache region has been copied in behind them, rotating
+    // them back to the end (see after the loop).
+    //
+    // Staging in `buf` rather than in a second `W`-slot array is what holds the peek frame to
+    // ONE owned window, and it is why this function needs no `unsafe`: `buf` owns each staged
+    // entry from the moment it is pushed, so every exit path — success, a withheld frontier, a
+    // trip, or a failing return from a fatal emit — frees it exactly once through the deque's
+    // own `Drop`, with no partial-initialization bookkeeping to get wrong.
+    //
+    // The staged region always fits. With `cap = buf.capacity()`, the fill is entered only with
+    // `want = cap - buf_len - parked - in_cache` (the `saturating_sub` above returns early at
+    // zero), and every token the loop produces decrements `want` and lands in either the cache
+    // (`in_cache += 1`) or the staged region. So at every point
+    // `buf_len + staged + parked + in_cache <= cap`, and the per-push assertion below pins the
+    // same bound locally. Note what that accounting reserves: the cache region's room as much
+    // as the staged region's, sized from `Cache::len()` before a single token is staged. A
+    // `Cache` whose `len` is not its resident count therefore mis-sizes the copy that comes
+    // after the loop — see CACHE_COPY there for the check that refuses to rotate on one.
+    let mut staged = 0usize;
     // Set when a limit trip latches the input mid-scan: the staged overflow
     // tokens then become unreachable and must be truncated away (see below).
     let mut tripped = false;
@@ -271,10 +289,17 @@ where
           Verdict::Withheld(_) => break,
           Verdict::Trip(err) => {
             // A limit trip is sticky, and `classify` has already latched the durable frontier — so
-            // this (possibly fatal) emit cannot lose it: the `?` returns with the latch recorded for
-            // every later operation, and `overflowed`'s `Drop` frees any staged tokens on the way
-            // out.
-            self.emit_lexer_error_deduped(err)?;
+            // this (possibly fatal) emit cannot lose it: the failing return below carries the latch
+            // into every later operation.
+            if let Err(err) = self.emit_lexer_error_deduped(err) {
+              // Unstage before propagating. Nothing but the staged tokens has been pushed yet, so
+              // `buf` holds exactly `buf_len + staged` entries and truncating to `buf_len` drops
+              // each staged token exactly once (the deque owns them) and hands the caller's buffer
+              // back byte-for-byte as it arrived — the same observable the discarded staging
+              // buffer used to produce.
+              buf.truncate(buf_len);
+              return Err(err);
+            }
             tripped = true;
             break;
           }
@@ -282,8 +307,12 @@ where
             // Emit immediately regardless of cache fullness so an error in the
             // overflow region is never silently dropped. The dedup mark keeps a
             // later consume that re-lexes this region from reporting it twice.
-            // `overflowed`'s `Drop` frees any staged tokens on this `?`-return.
-            self.emit_lexer_error_deduped(err)?;
+            if let Err(err) = self.emit_lexer_error_deduped(err) {
+              // Unstage before propagating; see the `Trip` arm for why `buf_len` is the exact
+              // pre-fill length here.
+              buf.truncate(buf_len);
+              return Err(err);
+            }
           }
           Verdict::Token(tok) => {
             let cached = CachedToken::new(tok, lexer.state().clone());
@@ -294,8 +323,15 @@ where
                 in_cache += 1;
               }
               Err(ct) => {
-                // Cache full: stage the overflow token drop-safely.
-                overflowed.push(Maybe::Owned(ct));
+                // Cache full: stage the overflow token at the tail of the output buffer. The
+                // capacity argument above proves the push is always accepted; assert it in debug
+                // builds so a future change to the accounting cannot silently drop a token.
+                let refused = buf.push_back(Maybe::Owned(ct));
+                debug_assert!(
+                  refused.is_none(),
+                  "peek staged an overflow token past the window capacity"
+                );
+                staged += 1;
               }
             }
             want -= 1;
@@ -307,9 +343,25 @@ where
     }
     *at_slot = lex_at;
 
+    if tripped {
+      // The fill was cut short by a fresh trip: report it terminal so a decision-window
+      // combinator surfaces the stop instead of reading the short window as a decline.
+      *terminal = true;
+      // Truncate the result at the durability boundary. A limit trip latched the
+      // input mid-overflow, so a post-peek `next()` will drain the cache-resident
+      // prefix (copied in just below) and then stop — it can never re-lex the
+      // staged overflow tokens. Handing them back would expose phantom lookahead
+      // the caller can never consume, so drop them here instead. Nothing but the
+      // staged tokens has been pushed yet, so `buf_len` is the exact pre-fill
+      // length and the truncation frees each staged token exactly once. This
+      // covers a trip on the first overflow token (nothing staged) and a trip
+      // after several are staged alike.
+      buf.truncate(buf_len);
+      staged = 0;
+    }
+
     // Fill the buffer from the front of the stream (this covers a parked token, the cached ones,
     // and any this fill just added)
-    // SAFETY: Cache.peek() returns slice of initialized tokens, guaranteed by trait contract
     // The parked token is the front of the stream, so it heads the window and the cache fills in
     // behind it. Safe unguarded because every caller of this fill passes a buffer with room for at
     // least one entry.
@@ -318,50 +370,204 @@ where
         buf.push_back(Maybe::Ref(parked.as_ref()));
       }
     }
-    self.cache.peek::<W>(buf);
+    let cache_copy_at = buf.len();
     debug_assert!(
-      buf_len + parked + in_cache == buf.len(),
-      "Cache peek returned unexpected number of tokens"
+      cache_copy_at == buf_len + staged + parked,
+      "the fill pushed something it did not account for before the cache copy"
     );
+    self.cache.peek::<W>(buf);
+
+    // CACHE_COPY, the cache-miss exit — the one exit where the copy is NOT the window's tail.
+    //
+    // `clip_ok` is FALSE here, for two independent reasons and either would do:
+    //
+    //   * the staged overflow region is rotated in BEHIND this copy, so a copy that stopped
+    //     short of `back` would be closed up by tokens that belong *after* the residents the
+    //     clip dropped — a hole, not a short window;
+    //   * the fill reserved a window slot per reported resident before it lexed, and the loop
+    //     never spends more than `want`, so at this point the room left is `want_unspent +
+    //     in_cache >= in_cache` by the fill's own arithmetic. There is room for the whole run
+    //     by construction, and a clip is a defect even where nothing follows it.
+    //
+    // The second reason is why `staged > 0` is not what is passed: it would be enough, but it
+    // would make an accounting slip in the fill look like a licensed clip instead of the bug
+    // it is.
+    Self::assert_cache_copy::<W>(self.cache, buf, cache_copy_at, in_cache, false);
 
     if tripped {
-      // The fill was cut short by a fresh trip: report it terminal so a decision-window
-      // combinator surfaces the stop instead of reading the short window as a decline.
-      *terminal = true;
-      // Truncate the result at the durability boundary. A limit trip latched the
-      // input mid-overflow, so a post-peek `next()` will drain the cache-resident
-      // prefix (already copied into `buf` above) and then stop — it can never
-      // re-lex the staged overflow tokens. Handing them back would expose phantom
-      // lookahead the caller can never consume, so drop them here instead. The
-      // `Overflow` guard frees each staged token exactly once on this early
-      // return; the `drain_into` hand-off below is skipped, so there is no
-      // double-drop. This covers a trip on the first overflow token (nothing
-      // staged) and a trip after several are staged alike.
-      drop(overflowed);
       return Ok(self.session.emitter);
     }
 
-    #[cfg(debug_assertions)]
-    let yielded = overflowed.len();
-    // Move the staged overflow tokens into the output buffer; `drain_into`
-    // disarms the guard so nothing is double-dropped.
-    overflowed.drain_into(buf);
+    if staged > 0 {
+      // Restore stream order. The staged tokens were appended *before* the front-of-stream
+      // region, so the region this fill owns currently reads `[staged…][parked?][cache…]` where
+      // the window must read `[parked?][cache…][staged…]`. One left-rotation by `staged` over
+      // that region (`buf_len..`) is exactly that permutation, and it permutes values inside the
+      // deque — nothing is copied out, so no entry can be leaked or dropped twice. Entries the
+      // caller passed in (`..buf_len`) are excluded, so a prefilled buffer keeps its order too.
+      buf.make_contiguous()[buf_len..].rotate_left(staged);
+    }
 
     #[cfg(debug_assertions)]
     {
-      debug_assert!(
-        buf.len() == buf_len + parked + in_cache + yielded,
-        "buffer length mismatch after adding overflowed tokens"
-      );
       if want == 0 {
         debug_assert!(
-          exp == (in_cache - initial_in_cache) + yielded,
+          exp == (in_cache - initial_in_cache) + staged,
           "expected peeked token count mismatch"
         );
       }
     }
 
     Ok(self.session.emitter)
+  }
+
+  /// CACHE_COPY — the window invariant, stated once and checked on **every** exit that hands a
+  /// window back.
+  ///
+  /// # The invariant
+  ///
+  /// > A peek window is a **contiguous prefix of the token stream at the cursor**. The cache
+  /// > region inside it — the one region the fill does not place itself — is therefore either
+  /// > the cache's **whole resident run**, `front` through `back`, or a run the **window's own
+  /// > capacity** cut short with **nothing behind it**. There is no third case, and "short" is
+  /// > never an excuse: a copy that stops with slots to spare has lost tokens the fill was
+  /// > entitled to.
+  ///
+  /// Both halves matter and they fail differently, which is why one check cannot replace the
+  /// other:
+  ///
+  /// - a copy clipped **mid-run with something behind it** is a **HOLE** — the region after it
+  ///   belongs after the residents the clip dropped, so the window reports a token at a position
+  ///   where the next consume serves a different one;
+  /// - a copy that stops **with room to spare** is a **SHORT WINDOW** — correct as far as it
+  ///   goes, but a caller is entitled to read a window shorter than it asked for as end of
+  ///   input while the input still has more.
+  ///
+  /// # Why a caller-facing check exists at all
+  ///
+  /// `Cache::len` is load-bearing: the fill reserves the window's cache region from it *before*
+  /// it lexes, spends the rest of the window on tokens lexed past the cache, and only then calls
+  /// [`Cache::peek`](crate::cache::Cache::peek) into the room that is left. A `len` that is not
+  /// the resident count therefore mis-sizes this copy in one direction or the other, and both
+  /// directions are above.
+  ///
+  /// # Why the guards are shaped the way they are
+  ///
+  /// Every quantity a check is *gated* on here is one the **fill** computes — `at`, `room`,
+  /// `copied`, `clip_ok` — never one the cache reports. That is deliberate, and it is the
+  /// correction of a real defect: two earlier revisions of this check each gated on a
+  /// cache-supplied value, and each was blind exactly where the lie was largest.
+  ///
+  ///  1. The first was a count identity, `buf_len + staged + parked + in_cache == buf.len()`.
+  ///     An under-report is subtracted from `in_cache` and added right back as `staged`, so
+  ///     the identity held on **both sides** of the lie it was meant to catch (residents
+  ///     `[a,b,c]`, `len()` 2, a `U4` window: `0 + 2 + 0 + 2 == 4`, window `[a,b,d,e]` for a
+  ///     stream that reads `[a,b,c,d]`). Self-cancelling.
+  ///  2. The second replaced it with the endpoint witness below, but wrote the precondition as
+  ///     `in_cache > 0` — the untrusted value again. A cache under-reporting to **zero** skipped
+  ///     the witness by that precondition and passed the surviving count check trivially as
+  ///     `0 == 0`.
+  ///
+  /// A precondition is an escape hatch unless it is itself verified. So `reserved` appears here
+  /// only on the *expected* side of a comparison, where a lie shows up as a mismatch; it never
+  /// decides whether a comparison runs.
+  ///
+  /// # Parameters
+  ///
+  /// - `at` — where the copy began: `buf.len()` immediately before `Cache::peek`.
+  /// - `reserved` — the resident count the fill believes the cache has: `Cache::len()` read
+  ///   before the fill, plus every token the fill then appended. Untrusted.
+  /// - `clip_ok` — whether the window's own capacity may legitimately cut this copy short of
+  ///   `back`. **True only where the copy is the window's tail**, so a clip shortens rather
+  ///   than holes. It is *not* a licence to come back short: see `expect` below.
+  ///
+  /// # Panics
+  ///
+  /// On a `Cache` that breaks the contract above, in **every build** — the posture
+  /// [`InputRef::park`](super::InputRef) takes for a `RETAINS_FRONT` refusal and
+  /// [`Sink::cst_start`](crate::cst::Sink::cst_start) takes for a node kind. The violation is in
+  /// caller-supplied trait code, no caller can repair its own `Cache` mid-parse, and the
+  /// alternative to failing here is handing back a window that is wrong about the stream. A
+  /// recoverable error is not on offer and would not be right if it were: the peek surface
+  /// returns the *emitter's* error type, so a broken `Cache` would reach the grammar disguised
+  /// as a diagnostic about the input.
+  #[inline]
+  fn assert_cache_copy<W>(
+    cache: &Ctx::Cache,
+    buf: &Peeked<'_, 'inp, L, W>,
+    at: usize,
+    reserved: usize,
+    clip_ok: bool,
+  ) where
+    W: Window,
+  {
+    use crate::cache::PeekedTokenExt as _;
+
+    let room = buf.capacity() - at;
+    let copied = buf.len() - at;
+
+    // THE COUNT — what `Cache::peek`'s own law owes, computed from two fill-side facts and the
+    // reported length. This is the half that catches an OVER-report: a cache claiming residents
+    // it does not have makes the fill lex too few tokens to fill the window, and the copy then
+    // comes back short of the room waiting for it. Where a clip is licensed, `min` is what
+    // distinguishes the licensed clip (`copied == room`, the window full) from that short copy
+    // (`copied < room`, slots to spare) — the licence is spent here, not skipped.
+    let expect = if clip_ok {
+      reserved.min(room)
+    } else {
+      reserved
+    };
+    assert!(
+      copied == expect,
+      "`Cache` contract violation: the fill counted {reserved} resident entr(ies) from \
+       `Cache::len`, left `Cache::peek` room for {room} of them, and so is owed {expect} — \
+       and `Cache::peek` appended {copied}. `len` must be exactly the resident count and \
+       `peek` must append exactly `min(len(), the buffer's remaining capacity)`",
+    );
+
+    // THE ENDPOINTS — the resident run's own witness, read from `front`/`back` rather than from
+    // `len`, so an inexact `len` cannot both cause the fault and hide it. This is the half that
+    // catches an UNDER-report, including one all the way to zero: the count above is satisfied
+    // by `0 == 0` there, and only the cache's own front can say that a run exists which the copy
+    // did not bring back.
+    //
+    // `back` is consulted lazily, and only where it is load-bearing: a licensed clip that filled
+    // the window is *expected* to stop before `back`, so the comparison would be wrong there as
+    // well as wasted. That short-circuit is what keeps the cache-hit path — the width-1 head
+    // tests a grammar runs per token — down to one endpoint read.
+    //
+    // Compiled as `debug_assert!`, not `assert!` like THE COUNT above. What this witness guards
+    // is a LOGIC invariant, not a soundness one: this module now contains zero `unsafe`, so a
+    // `Cache` that fails it cannot corrupt memory — it can only hand back a window that
+    // misdescribes the stream — and THE COUNT still stands guard in every build for the
+    // OVER-report direction it alone can see. The UNDER-report direction, the one only this
+    // witness catches, is the expensive one to keep checking on every fill: two ring indexes, a
+    // `Maybe` discriminant, and an `Option<&Span>` compare price out at 52–55 instructions
+    // retired on the cache-hit exit — against a base fill there of roughly 52, so this one check
+    // more than doubles the one path a grammar runs per token — and 67–70 on a cache-miss fill,
+    // where the fill's own lexing already dwarfs it. A `Cache` that breaks this half of the
+    // contract still fails fast, just in debug builds and under test, rather than on every
+    // release-mode token a grammar peeks.
+    let front = cache.front_span().map(Span::start_ref);
+    let whole_run = if copied == 0 {
+      // Nothing came back. Sound only if there was nothing to bring — or, under a licensed
+      // clip, if the window had no room left to bring it into.
+      front.is_none() || (clip_ok && room == 0)
+    } else {
+      front == Some(buf[at].span().start_ref())
+        && ((clip_ok && copied == room)
+          || cache.back_span().map(Span::end_ref) == Some(buf[buf.len() - 1].span().end_ref()))
+    };
+    debug_assert!(
+      whole_run,
+      "`Cache` contract violation: `Cache::peek` did not copy the cache's whole resident \
+       run. The {copied} entr(ies) it appended into {room} slot(s) of room do not span the \
+       cache from `front` to `back`. A copy may stop short of `back` only where the \
+       window's own capacity stopped it AND nothing is appended behind it in the window; \
+       neither excuse holds here. That is what an inexact `Cache::len` does to this copy: \
+       the fill reserves the room from `len`, so a `len` below the resident count clips the \
+       copy mid-run and the window would report a token the next consume will not serve",
+    );
   }
 
   /// Width-1 head observation in grammar vocabulary, terminal-aware by construction.

--- a/tokora/src/input/input_ref/peek/tests.rs
+++ b/tokora/src/input/input_ref/peek/tests.rs
@@ -473,31 +473,100 @@ fn peek_overflow_stop_records_lexer_error() {
 // ── Fatal overflow peek must not leak staged tokens ───────────────────────────
 //
 // When a peek window exceeds the cache capacity, tokens past the cache are staged
-// in an inline overflow buffer until the cache region is copied out. If a fatal
-// lexer error is emitted while tokens are staged, the `?`-return must still drop
-// every staged token (and its state) exactly once — never leak them. A
+// at the tail of the output buffer until the cache region is copied in ahead of
+// them. If a fatal lexer error is emitted while tokens are staged, the `?`-return
+// must still drop every staged token (and its state) exactly once — never leak them
+// — and hand the buffer back holding nothing it did not arrive with. A
 // drop-counting token payload makes any leak observable.
 
-use core::sync::atomic::{AtomicUsize, Ordering};
+/// The liveness ledger the drop-safety cells below count into.
+///
+/// One per *scenario*, never a global. Rust runs tests in parallel by default, so a
+/// counter shared between cells makes every delta assertion depend on whatever else
+/// happens to be running: with these numbers held in global atomics, the ordinary
+/// `cargo test overflow_peek` invocation failed 184 runs out of 200, and a flaky
+/// leak test is the one people eventually delete. Each cell instead builds its own
+/// ledger, hands it to the lexer as state, and reads back only what its own probes
+/// wrote.
+///
+/// `Cell` rather than an atomic on purpose: a ledger never leaves the thread of the
+/// test that made it, and choosing the non-`Sync` type is what keeps that true by
+/// construction rather than by convention.
+#[derive(Debug, Default)]
+struct Ledger {
+  creates: core::cell::Cell<usize>,
+  drops: core::cell::Cell<usize>,
+}
 
-static STAGED_DROPS: AtomicUsize = AtomicUsize::new(0);
+impl Ledger {
+  /// Payloads created against this ledger and not yet freed.
+  fn live(&self) -> usize {
+    self.creates.get() - self.drops.get()
+  }
 
-/// A token payload that counts its own drops, so a leaked staged token is
-/// observable as a missing drop.
+  fn created(&self) -> usize {
+    self.creates.get()
+  }
+
+  fn dropped(&self) -> usize {
+    self.drops.get()
+  }
+
+  fn record_create(&self) {
+    self.creates.set(self.creates.get() + 1);
+  }
+
+  fn record_drop(&self) {
+    self.drops.set(self.drops.get() + 1);
+  }
+}
+
+/// A token payload that counts its own drops into its scenario's ledger, so a
+/// leaked staged token is observable as a missing drop.
 #[derive(Debug, Clone)]
-struct DropProbe;
+struct DropProbe {
+  ledger: std::rc::Rc<Ledger>,
+}
 
 impl Drop for DropProbe {
   fn drop(&mut self) {
-    STAGED_DROPS.fetch_add(1, Ordering::SeqCst);
+    self.ledger.record_drop();
+  }
+}
+
+/// The `DropTok` lexer state: nothing but the scenario's ledger, which is how the
+/// payload callback reaches it without a global.
+#[derive(Debug, Clone, Default)]
+struct DropLedger(std::rc::Rc<Ledger>);
+
+impl DropLedger {
+  fn ledger(&self) -> std::rc::Rc<Ledger> {
+    std::rc::Rc::clone(&self.0)
+  }
+
+  fn probe(&self) -> DropProbe {
+    DropProbe {
+      ledger: self.ledger(),
+    }
+  }
+}
+
+impl crate::state::State for DropLedger {
+  type Error = ();
+
+  fn check(&self) -> Result<(), Self::Error> {
+    Ok(())
   }
 }
 
 #[derive(Debug, Clone, crate::logos::Logos)]
-#[logos(crate = crate::logos, skip r"[ \t\r\n]+")]
+#[logos(crate = crate::logos, extras = DropLedger, skip r"[ \t\r\n]+")]
 enum DropTok {
-  #[regex(r"[0-9]+", |_| DropProbe)]
-  Num(DropProbe),
+  // Never *read*: the payload is observed through its destructor, which is the whole
+  // of what this cell measures. (While it was a ZST the dead-code lint exempted it
+  // as a positional field; carrying a ledger handle makes it a real value.)
+  #[regex(r"[0-9]+", |lex| lex.extras.probe())]
+  Num(#[allow(dead_code)] DropProbe),
 }
 
 impl core::fmt::Display for DropTok {
@@ -581,12 +650,16 @@ fn fatal_overflow_peek_drops_staged_tokens_no_leak() {
   // `?`-returns while 4 and 5 are still staged.
   use generic_arraydeque::typenum::U6;
 
-  let baseline = STAGED_DROPS.load(Ordering::SeqCst);
+  // Each phase gets its own ledger, threaded in as the lexer state: phase 1's input
+  // is still holding its three cache-resident tokens while phase 2 runs, and no
+  // concurrently scheduled cell can reach either counter.
+  let state = DropLedger::default();
+  let ledger = state.ledger();
 
   let cache = crate::cache::DefaultCache::<'_, DropLexer<'_>>::default();
   let mut input = crate::input::Input::<DropLexer<'_>, DropCtx<'_>, ()>::with_state_and_context(
     "1 2 3 4 5 @",
-    (),
+    state,
     crate::input::InputContext::new(FatalOnLexError, cache),
   );
   let mut inp = input.as_ref();
@@ -594,38 +667,68 @@ fn fatal_overflow_peek_drops_staged_tokens_no_leak() {
   let result = inp.peek::<U6>().map(|_| ());
   assert_eq!(result, Err(Boom), "the fatal lexer error must propagate");
 
-  let staged_dropped = STAGED_DROPS.load(Ordering::SeqCst) - baseline;
   assert_eq!(
-    staged_dropped, 2,
+    ledger.dropped(),
+    2,
     "both staged overflow tokens must be dropped exactly once on the fatal return (no leak)"
+  );
+
+  // The same scan again, taken on the fill directly so the buffer it was handed is
+  // still readable afterwards. Staging now happens *in* that buffer, so the
+  // `?`-return has to unstage before propagating: a caller that reuses its buffer
+  // must not find two tokens in it that the peek never promised.
+  let state = DropLedger::default();
+  let phase2 = state.ledger();
+
+  let cache = crate::cache::DefaultCache::<'_, DropLexer<'_>>::default();
+  let mut input = crate::input::Input::<DropLexer<'_>, DropCtx<'_>, ()>::with_state_and_context(
+    "1 2 3 4 5 @",
+    state,
+    crate::input::InputContext::new(FatalOnLexError, cache),
+  );
+  let mut inp = input.as_ref();
+
+  let mut buf = crate::cache::Peeked::<'_, '_, DropLexer<'_>, U6>::new();
+  let outcome = inp
+    .peek_with_emitter_inner::<U6>(&mut buf, &mut false)
+    .map(|_| ());
+  assert_eq!(outcome, Err(Boom), "the fatal lexer error must propagate");
+  assert!(
+    buf.is_empty(),
+    "a failing fill must hand the caller's buffer back exactly as it received it, not \
+     holding the tokens it staged in it"
+  );
+  assert_eq!(
+    phase2.dropped(),
+    2,
+    "unstaging on the fatal return frees each staged token exactly once"
   );
 }
 
 // ── A limit trip mid-overflow must truncate the peek at the durability boundary ──
 //
-// When a peek window exceeds the cache, tokens past the cache are staged in the
-// inline overflow buffer. A staged token is durable only because a later
+// When a peek window exceeds the cache, tokens past the cache are staged at the
+// tail of the output buffer. A staged token is durable only because a later
 // `next()` re-lexes and regenerates it — but a limit trip mid-overflow latches
 // the input, so `next()` will drain the cache-resident prefix and then stop,
 // never re-lexing the staged tokens. Returning them would expose PHANTOM
 // lookahead the caller can never consume. The peek must therefore truncate its
-// result to the cache-resident prefix and drop the staged overflow tokens (freed
-// exactly once by the `Overflow` guard — no double-drop with the `drain_into`
-// hand-off, which is skipped on the trip).
+// result to the cache-resident prefix, dropping the staged region before the
+// cache region is copied in — the deque owns those entries, so they are freed
+// exactly once and cannot be handed out as well.
 //
-// `LimitProbe` counts its own creations and drops so a leaked or double-dropped
-// staged token is observable as `creates != drops`.
-
-static LIMIT_CREATES: AtomicUsize = AtomicUsize::new(0);
-static LIMIT_DROPS: AtomicUsize = AtomicUsize::new(0);
+// `LimitProbe` counts its own creations and drops into its scenario's `Ledger`, so a
+// leaked or double-dropped staged token is observable as `creates != drops`.
 
 #[derive(Debug)]
-struct LimitProbe;
+struct LimitProbe {
+  ledger: std::rc::Rc<Ledger>,
+}
 
 impl LimitProbe {
-  fn new() -> Self {
-    LIMIT_CREATES.fetch_add(1, Ordering::SeqCst);
-    LimitProbe
+  fn new(ledger: std::rc::Rc<Ledger>) -> Self {
+    ledger.record_create();
+    LimitProbe { ledger }
   }
 }
 
@@ -633,23 +736,24 @@ impl Clone for LimitProbe {
   fn clone(&self) -> Self {
     // Count a clone as a creation so `creates == drops` stays exact even if the
     // framework ever clones a token payload (it does not on this path).
-    LIMIT_CREATES.fetch_add(1, Ordering::SeqCst);
-    LimitProbe
+    Self::new(std::rc::Rc::clone(&self.ledger))
   }
 }
 
 impl Drop for LimitProbe {
   fn drop(&mut self) {
-    LIMIT_DROPS.fetch_add(1, Ordering::SeqCst);
+    self.ledger.record_drop();
   }
 }
 
-/// A limiter whose scan counter is shared across every cloned lexer, so the
-/// `check()` trip point is deterministic regardless of `InputRef` rebuilding a
-/// fresh lexer per operation.
+/// A limiter whose scan counter and liveness ledger are shared across every cloned
+/// lexer, so the `check()` trip point is deterministic regardless of `InputRef`
+/// rebuilding a fresh lexer per operation, and so every payload a scenario lexes
+/// lands in that scenario's own ledger.
 #[derive(Debug, Clone, Default)]
 struct TripLimiter {
   scanned: std::rc::Rc<core::cell::Cell<usize>>,
+  ledger: std::rc::Rc<Ledger>,
   limit: usize,
 }
 
@@ -657,12 +761,22 @@ impl TripLimiter {
   fn with_limit(limit: usize) -> Self {
     Self {
       scanned: std::rc::Rc::new(core::cell::Cell::new(0)),
+      ledger: std::rc::Rc::new(Ledger::default()),
       limit,
     }
   }
 
+  /// A handle on this limiter's ledger, for the cell that built it to read back.
+  fn ledger(&self) -> std::rc::Rc<Ledger> {
+    std::rc::Rc::clone(&self.ledger)
+  }
+
   fn increase(&self) {
     self.scanned.set(self.scanned.get() + 1);
+  }
+
+  fn probe(&self) -> LimitProbe {
+    LimitProbe::new(self.ledger())
   }
 }
 
@@ -702,8 +816,9 @@ impl From<TripLimitExceeded> for TripErr {
 #[derive(Debug, Clone, crate::logos::Logos)]
 #[logos(crate = crate::logos, extras = TripLimiter, skip r"[ \t\r\n]+")]
 enum TripTok {
-  #[regex(r"[0-9]+", |lex| { lex.extras.increase(); LimitProbe::new() })]
-  Num(LimitProbe),
+  // As with `DropTok`: observed through its destructor, never read.
+  #[regex(r"[0-9]+", |lex| { lex.extras.increase(); lex.extras.probe() })]
+  Num(#[allow(dead_code)] LimitProbe),
 }
 
 impl core::fmt::Display for TripTok {
@@ -747,22 +862,27 @@ type TripCtx<'a> = (
 /// been staged. Asserts (a) the peek window equals the 3 cache-resident tokens
 /// (staged phantoms excluded); (b) exactly 3 survivors remain live after the
 /// peek (every staged token + the trip token dropped); (c) `next()` drains
-/// exactly those 3 then `None` (no rescan past the latch).
+/// exactly those 3 then `None` (no rescan past the latch); (d) once the input is
+/// gone, every payload the scenario lexed was freed exactly once.
+///
+/// The limiter carries this scenario's own ledger, so the liveness numbers below
+/// count nothing but the tokens this call produced.
 fn assert_trip_truncates<W>(src: &'static str, limit: usize, staged: usize)
 where
   W: crate::Window,
 {
-  let live = || LIMIT_CREATES.load(Ordering::SeqCst) - LIMIT_DROPS.load(Ordering::SeqCst);
+  let limiter = TripLimiter::with_limit(limit);
+  let ledger = limiter.ledger();
 
   let cache = crate::cache::DefaultCache::<'_, TripLexer<'_>>::default();
   let mut input = crate::input::Input::<TripLexer<'_>, TripCtx<'_>, ()>::with_state_and_context(
     src,
-    TripLimiter::with_limit(limit),
+    limiter,
     crate::input::InputContext::new(crate::emitter::Silent::<TripErr>::new(), cache),
   );
   let mut inp = input.as_ref();
 
-  let alive_before = live();
+  assert_eq!(ledger.live(), 0, "the scenario starts with nothing lexed");
   {
     // (a) The returned window is truncated to the cache-resident prefix — the
     // `staged` overflow phantoms are excluded.
@@ -778,7 +898,7 @@ where
   // overflow token AND the trip token have been dropped exactly once — a leak
   // would leave more alive, a double-drop fewer.
   assert_eq!(
-    live() - alive_before,
+    ledger.live(),
     3,
     "only the 3 cache-resident tokens may survive the truncating peek"
   );
@@ -789,14 +909,22 @@ where
   assert!(inp.next().unwrap().is_some(), "cache token 3");
   assert!(inp.next().unwrap().is_none(), "poisoned: no phantom 4");
   assert!(inp.next().unwrap().is_none(), "poisoned: stays None");
+
+  drop(inp);
+  drop(input);
+
+  // (d) Every token payload this scenario created was dropped exactly once:
+  // no leak (drops < creates) and no double-drop (drops > creates).
+  assert_eq!(
+    ledger.created(),
+    ledger.dropped(),
+    "every staged/cached/trip token freed exactly once (no leak, no double-drop)"
+  );
 }
 
 #[test]
 fn overflow_peek_trip_truncates_phantom_tokens() {
   use generic_arraydeque::typenum::{U4, U5, U6};
-
-  let creates_before = LIMIT_CREATES.load(Ordering::SeqCst);
-  let drops_before = LIMIT_DROPS.load(Ordering::SeqCst);
 
   // Trip mid-overflow with SEVERAL staged: 1..=3 cached, 4 & 5 staged, 6 trips.
   assert_trip_truncates::<U6>("1 2 3 4 5 6", 5, 2);
@@ -804,15 +932,6 @@ fn overflow_peek_trip_truncates_phantom_tokens() {
   assert_trip_truncates::<U5>("1 2 3 4 5", 4, 1);
   // Trip with ZERO staged: 1..=3 fill the cache, the next scan (4) trips.
   assert_trip_truncates::<U4>("1 2 3 4", 3, 0);
-
-  // Every token payload created across all scenarios was dropped exactly once:
-  // no leak (drops < creates) and no double-drop (drops > creates).
-  let creates = LIMIT_CREATES.load(Ordering::SeqCst) - creates_before;
-  let drops = LIMIT_DROPS.load(Ordering::SeqCst) - drops_before;
-  assert_eq!(
-    creates, drops,
-    "every staged/cached/trip token freed exactly once (no leak, no double-drop)"
-  );
 }
 
 // The discrimination the decision-window combinators (`peek_then`, `peek_then_choice`, the
@@ -853,4 +972,818 @@ fn peek_with_emitter_terminal_flags_a_trip_but_not_eof() {
     (3, false),
     "a full window is not terminal"
   );
+}
+
+// ── Stream order across the cache/overflow boundary ───────────────────────────
+//
+// A peek wider than the cache produces its two regions in the OPPOSITE order from
+// the one the window must report: the tokens past the cache are lexed (and staged)
+// first, while the cache region is copied out afterwards in one bulk read. The fill
+// stages the overflow region at the tail of the output buffer and rotates the
+// front-of-stream region ahead of it; these cells pin the resulting order. They are
+// new coverage, not a pin of prior behaviour: before this change nothing asserted
+// the identity of a peeked token past the cache boundary — the overflow tests
+// checked only `len()` — so removing the rotation leaves every pre-existing peek
+// test green and turns these red.
+
+/// The spans a `W`-wide peek reports, in window order.
+fn peeked_spans<W>(src: &str) -> std::vec::Vec<crate::span::SimpleSpan>
+where
+  W: crate::Window,
+{
+  use crate::cache::PeekedTokenExt as _;
+  parse_with(src, |inp| {
+    let peeked = inp.peek::<W>()?;
+    Ok(peeked.iter().map(|t| *t.span()).collect())
+  })
+  .unwrap()
+}
+
+/// Whether each slot of a `W`-wide peek came back owned (staged past the cache)
+/// rather than borrowed from the cache, in window order.
+fn peeked_arms<W>(src: &str) -> std::vec::Vec<bool>
+where
+  W: crate::Window,
+{
+  parse_with(src, |inp| {
+    let peeked = inp.peek::<W>()?;
+    Ok(peeked.iter().map(|t| t.is_owned()).collect())
+  })
+  .unwrap()
+}
+
+#[test]
+fn peek_reports_stream_order_across_the_cache_boundary() {
+  use crate::span::SimpleSpan;
+  use generic_arraydeque::typenum::U6;
+
+  // Six one-character tokens at known offsets. The default cache holds three, so
+  // the window is `[cache: a b c][staged: d e f]` — and the staged half was lexed
+  // before the cached half was read out. A window that handed the staged region
+  // back first would report 6, 8, 10, 0, 2, 4.
+  assert_eq!(
+    peeked_spans::<U6>("a b c d e f"),
+    std::vec![
+      SimpleSpan::new(0, 1),
+      SimpleSpan::new(2, 3),
+      SimpleSpan::new(4, 5),
+      SimpleSpan::new(6, 7),
+      SimpleSpan::new(8, 9),
+      SimpleSpan::new(10, 11),
+    ],
+    "the window must read in stream order across the cache/overflow boundary"
+  );
+  // And the split lands exactly at the cache capacity: three borrowed, three owned.
+  assert_eq!(
+    peeked_arms::<U6>("a b c d e f"),
+    std::vec![false, false, false, true, true, true],
+    "the borrowed cache region heads the window and the owned staged region tails it"
+  );
+}
+
+#[test]
+fn peek_reports_stream_order_with_a_single_staged_token() {
+  use crate::span::SimpleSpan;
+  use generic_arraydeque::typenum::U4;
+
+  // The smallest overflow: one staged token behind a full cache. A rotation off by
+  // one in either direction is visible here and nowhere else.
+  assert_eq!(
+    peeked_spans::<U4>("a b c d"),
+    std::vec![
+      SimpleSpan::new(0, 1),
+      SimpleSpan::new(2, 3),
+      SimpleSpan::new(4, 5),
+      SimpleSpan::new(6, 7),
+    ]
+  );
+  assert_eq!(
+    peeked_arms::<U4>("a b c d"),
+    std::vec![false, false, false, true]
+  );
+}
+
+#[test]
+fn peek_reports_stream_order_with_a_prefilled_cache() {
+  use crate::cache::PeekedTokenExt as _;
+  use crate::span::SimpleSpan;
+  use generic_arraydeque::typenum::{U2, U5};
+
+  // A narrow peek first, so the cache is already partly full when the wide peek
+  // runs: the wide fill then appends to a non-empty cache before it starts staging,
+  // which moves the boundary the rotation has to respect.
+  let spans = parse_with("a b c d e", |inp| {
+    {
+      let warm = inp.peek::<U2>()?;
+      assert_eq!(warm.len(), 2, "the warm-up peek seeds the cache");
+    }
+    let peeked = inp.peek::<U5>()?;
+    Ok(
+      peeked
+        .iter()
+        .map(|t| (*t.span(), t.is_owned()))
+        .collect::<std::vec::Vec<_>>(),
+    )
+  })
+  .unwrap();
+
+  assert_eq!(
+    spans,
+    std::vec![
+      (SimpleSpan::new(0, 1), false),
+      (SimpleSpan::new(2, 3), false),
+      (SimpleSpan::new(4, 5), false),
+      (SimpleSpan::new(6, 7), true),
+      (SimpleSpan::new(8, 9), true),
+    ]
+  );
+}
+
+// ── The same order, over a cache that retains nothing ─────────────────────────
+//
+// `()` is the zero-capacity cache: every push refuses, so the whole window is
+// staged and the parked slot — statically dead under a retaining cache — is live.
+// It is the only built-in configuration where the front of the stream is NOT a
+// cache entry, so it is the only one that exercises `[staged…][parked]` rotating
+// to `[parked][staged…]`.
+
+type UnitCacheCtx = (crate::emitter::Silent<()>, ());
+
+fn with_unit_cache<'inp, F, O>(src: &'inp str, f: F) -> O
+where
+  F: FnOnce(&mut crate::input::InputRef<'inp, '_, TestLexer<'inp>, UnitCacheCtx, ()>) -> O,
+{
+  let mut input = crate::input::Input::<TestLexer<'inp>, UnitCacheCtx, ()>::with_state_and_context(
+    src,
+    (),
+    crate::input::InputContext::new(crate::emitter::Silent::<()>::new(), ()),
+  );
+  let mut inp = input.as_ref();
+  f(&mut inp)
+}
+
+#[test]
+fn peek_over_a_non_retaining_cache_reports_stream_order() {
+  use crate::cache::PeekedTokenExt as _;
+  use crate::span::SimpleSpan;
+  use generic_arraydeque::typenum::U3;
+
+  // No cache at all: all three window slots are staged. The rotation degenerates to
+  // a full-length rotate, which must be the identity.
+  let got = with_unit_cache("a b c", |inp| {
+    let peeked = inp.peek::<U3>().unwrap();
+    peeked
+      .iter()
+      .map(|t| (*t.span(), t.is_owned()))
+      .collect::<std::vec::Vec<_>>()
+  });
+  assert_eq!(
+    got,
+    std::vec![
+      (SimpleSpan::new(0, 1), true),
+      (SimpleSpan::new(2, 3), true),
+      (SimpleSpan::new(4, 5), true),
+    ],
+    "a fully staged window is already in stream order and must not be permuted"
+  );
+}
+
+#[test]
+fn peek_over_a_parked_front_reports_the_parked_token_first() {
+  use crate::cache::PeekedTokenExt as _;
+  use crate::span::SimpleSpan;
+  use generic_arraydeque::typenum::U3;
+
+  // `sync_to` stops before the first number and, with nothing able to retain it,
+  // parks it at the front of the stream. The peek that follows must head its window
+  // with that parked token and stage `2` and `3` behind it — the window is
+  // `[parked][staged][staged]`, assembled as `[staged][staged][parked]`.
+  let got = with_unit_cache("a b 1 2 3", |inp| {
+    use crate::Token as _;
+    // One statement, so the window this returns — which borrows `inp` — dies before
+    // the peek below reborrows it.
+    assert!(
+      inp
+        .sync_to(|t| t.data.kind() == TokKind::Num, || None)
+        .unwrap()
+        .is_some(),
+      "sync_to must stop on the first number"
+    );
+    let peeked = inp.peek::<U3>().unwrap();
+    peeked
+      .iter()
+      .map(|t| (*t.span(), t.is_owned()))
+      .collect::<std::vec::Vec<_>>()
+  });
+  assert_eq!(
+    got,
+    std::vec![
+      (SimpleSpan::new(4, 5), false),
+      (SimpleSpan::new(6, 7), true),
+      (SimpleSpan::new(8, 9), true),
+    ],
+    "the parked token is the front of the stream and must head the window"
+  );
+}
+
+// ── CACHE_COPY — a `Cache` that misreports `len()` ───────────────────────────
+//
+// The fill sizes the window's cache region from `Cache::len()` BEFORE it stages
+// anything: `want = room - parked - len()`. Staging then eats the tail of the buffer,
+// so by the time `Cache::peek` runs, the room left is exactly what `len()` claimed. On
+// the documented contract that is exactly enough. On a cache whose `len` is not its
+// resident count it is not, and the two directions fail differently:
+//
+//   * UNDER-report — `Cache::peek` is clipped mid-run. The window loses the residents
+//     the clip cut off but keeps the staged tokens that belong *after* them, so what
+//     comes back is not a short window, it is a HOLE: the caller reads a token at a
+//     position where a later `next()` serves a different one.
+//   * OVER-report — the fill reserves slots for residents that are not there and lexes
+//     too few tokens to fill them. The window is a correct prefix but SHORT, which a
+//     caller is entitled to read as end of input while the input still has more.
+//
+// The hole is the one no count can see. With residents `[a,b,c]`, `len()` reporting 2
+// and a `U4` window, the fill stages `d` and `e`, `Cache::peek` appends `[a,b]` into the
+// two slots left, and `staged + parked + len() == buf.len()` holds exactly: 2 + 0 + 2 ==
+// 4. The count the fill tracks and the count it observes agree *because* the
+// under-report is subtracted from one side and added back on the other — the old debug
+// assertion passed here in DEBUG too, so promoting it to a release assert would have
+// caught nothing. The window came back `[a,b,d,e]` for a stream that reads `[a,b,c,d]`.
+//
+// What catches it is the resident run's own endpoints: a copy that is the whole run
+// starts at the cache's `front` and ends at its `back`. The count check stays on in
+// EVERY build — a corruption that only reaches a release binary is still the point of
+// it. The endpoint witness does not: it is `debug_assert!`, because what it guards is a
+// LOGIC invariant rather than a soundness one, and the comparison itself — two ring
+// indices, a `Maybe` discriminant, an `Option<&Span>` compare — prices out at 52–55
+// instructions retired on the cache-hit exit against a ~52-instruction base fill, more
+// than doubling it (see CACHE_COPY in `peek/mod.rs`). The `should_panic` cells below
+// that exercise the endpoint witness alone are `#[cfg(debug_assertions)]` accordingly.
+
+/// The three directions the one lie can take. A `bool` covered the first two; the third —
+/// under-reporting all the way to **zero** — is not "under by one" with a bigger constant,
+/// it is the case where the *magnitude* of the lie determines whether the witness can see
+/// it at all, so it gets its own mode rather than a parameter on an existing one.
+///
+/// Chosen over a `bool` plus a second `bool`, over an enum, and over three separate cache
+/// types: const generics on this crate's MSRV take integers but not enums, two `bool`s make
+/// an unrepresentable fourth combination, and three types would triple a 90-line impl to
+/// vary one `match` arm.
+mod lie {
+  /// `len()` reports one **below** the resident count. The plausible off-by-one, and the
+  /// one that HOLES the window: the copy is clipped mid-run and the staged tokens behind
+  /// it close the gap.
+  pub(super) const UNDER_BY_ONE: u8 = 0;
+  /// `len()` reports one **above**. Shortens the window instead of holing it — the fill
+  /// reserves slots for residents that are not there and lexes too few tokens for them.
+  pub(super) const OVER_BY_ONE: u8 = 1;
+  /// `len()` reports **zero**, whatever is resident. The largest under-report there is,
+  /// and — before this change — the blindest: it satisfies a count check as `0 == 0` and
+  /// skipped any witness whose precondition was written over the reported length.
+  pub(super) const UNDER_TO_ZERO: u8 = 2;
+}
+
+/// A capacity-3 ring whose `len()` misreports the resident count in one of the three
+/// [`lie`] directions, and whose every other operation, `peek` included, works on the real
+/// queue.
+///
+/// An empty cache still reports 0 under every mode, so a lie only shows once the cache is
+/// warm: the warm-up peek in each cell below is honest, and the peek under test is the one
+/// that reads a misreported length.
+///
+/// This is the plausible defect rather than a contrived one: an off-by-one — or a
+/// forgotten increment, which is the zero case — in a hand-rolled cache's length
+/// bookkeeping, in the one method the input layer sizes its window from. The crate's own
+/// conformance kit models the same class of lie (`conformance/cache_tests.rs`).
+struct MisreportingCache<'a, L, const LIE: u8>
+where
+  L: crate::Lexer<'a>,
+{
+  items: std::collections::VecDeque<crate::cache::CachedTokenOf<'a, L>>,
+}
+
+impl<'a, L, Lang: ?Sized, const LIE: u8> crate::cache::Cache<'a, L, Lang>
+  for MisreportingCache<'a, L, LIE>
+where
+  L: crate::Lexer<'a>,
+{
+  type Options = ();
+
+  // Retaining, so the parked slot is statically dead and these cells are about the cache
+  // copy alone.
+  const RETAINS_FRONT: bool = true;
+
+  fn new() -> Self {
+    Self {
+      items: std::collections::VecDeque::with_capacity(3),
+    }
+  }
+
+  fn with_options((): ()) -> Self {
+    <Self as crate::cache::Cache<'a, L, Lang>>::new()
+  }
+
+  /// THE LIE, and the only one.
+  fn len(&self) -> usize {
+    match self.items.len() {
+      0 => 0,
+      _ if LIE == lie::UNDER_TO_ZERO => 0,
+      n if LIE == lie::UNDER_BY_ONE => n - 1,
+      n => n + 1,
+    }
+  }
+
+  fn remaining(&self) -> usize {
+    3 - self.items.len()
+  }
+
+  fn push_front(
+    &mut self,
+    tok: crate::cache::CachedTokenOf<'a, L>,
+  ) -> Result<crate::cache::CachedTokenRefOf<'_, 'a, L>, crate::cache::CachedTokenOf<'a, L>> {
+    if self.items.len() == 3 {
+      return Err(tok);
+    }
+    self.items.push_front(tok);
+    Ok(self.items.front().expect("just pushed").as_ref())
+  }
+
+  fn push_back(
+    &mut self,
+    tok: crate::cache::CachedTokenOf<'a, L>,
+  ) -> Result<crate::cache::CachedTokenRefOf<'_, 'a, L>, crate::cache::CachedTokenOf<'a, L>> {
+    if self.items.len() == 3 {
+      return Err(tok);
+    }
+    self.items.push_back(tok);
+    Ok(self.items.back().expect("just pushed").as_ref())
+  }
+
+  fn pop_front(&mut self) -> Option<crate::cache::CachedTokenOf<'a, L>> {
+    self.items.pop_front()
+  }
+
+  fn pop_back(&mut self) -> Option<crate::cache::CachedTokenOf<'a, L>> {
+    self.items.pop_back()
+  }
+
+  fn clear(&mut self) {
+    self.items.clear();
+  }
+
+  fn peek<'p, W>(
+    &'p self,
+    buf: &mut generic_arraydeque::GenericArrayDeque<
+      crate::cache::MaybeRefCachedTokenOf<'p, 'a, L>,
+      W::CAPACITY,
+    >,
+  ) where
+    W: crate::Window,
+  {
+    // The real queue, oldest first, bounded by the room the buffer has left — the honest
+    // implementation of `peek`, which is what leaves the `len()` lie as the whole of the
+    // defect.
+    let fill = buf.remaining_capacity().min(self.items.len());
+    for tok in self.items.iter().take(fill) {
+      buf.push_back(mayber::Maybe::Ref(tok.as_ref()));
+    }
+  }
+
+  fn front(&self) -> Option<crate::cache::CachedTokenRefOf<'_, 'a, L>> {
+    self.items.front().map(crate::cache::CachedToken::as_ref)
+  }
+
+  fn back(&self) -> Option<crate::cache::CachedTokenRefOf<'_, 'a, L>> {
+    self.items.back().map(crate::cache::CachedToken::as_ref)
+  }
+}
+
+type MisreportingCtx<'a, const LIE: u8> = (
+  crate::emitter::Silent<()>,
+  MisreportingCache<'a, TestLexer<'a>, LIE>,
+);
+
+fn with_misreporting_cache<'inp, const LIE: u8, F, O>(src: &'inp str, f: F) -> O
+where
+  F: FnOnce(
+    &mut crate::input::InputRef<'inp, '_, TestLexer<'inp>, MisreportingCtx<'inp, LIE>, ()>,
+  ) -> O,
+{
+  let cache =
+    <MisreportingCache<'_, TestLexer<'_>, LIE> as crate::cache::Cache<'_, TestLexer<'_>, ()>>::new(
+    );
+  let mut input =
+    crate::input::Input::<TestLexer<'inp>, MisreportingCtx<'inp, LIE>, ()>::with_state_and_context(
+      src,
+      (),
+      crate::input::InputContext::new(crate::emitter::Silent::<()>::new(), cache),
+    );
+  let mut inp = input.as_ref();
+  f(&mut inp)
+}
+
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "did not copy the cache's whole resident run")]
+fn peek_over_an_under_reporting_cache_fails_fast_instead_of_holing_the_window() {
+  use generic_arraydeque::typenum::{U3, U4};
+
+  with_misreporting_cache::<{ lie::UNDER_BY_ONE }, _, _>("a b c d e", |inp| {
+    // Warm-up. The cache is empty, so `len()` tells the truth and the fill's own
+    // successful pushes carry the count: a, b and c go in and the window is right. This
+    // peek must NOT trip the check — the cell would prove nothing if the fixture failed
+    // before the call under test.
+    {
+      let warm = inp.peek::<U3>().expect("the warm-up peek must succeed");
+      assert_eq!(warm.len(), 3, "the warm-up peek seeds the cache");
+    }
+    // The call under test. `len()` now says 2 against 3 residents, so the fill reserves
+    // two slots for the cache and stages `d` and `e` into the other two; `Cache::peek` is
+    // then clipped after `[a, b]` and `c` falls out of the window. Before CACHE_COPY this
+    // returned `Ok` with the starts 0, 2, 6, 8 where the stream reads 0, 2, 4, 6 — in
+    // DEBUG AND RELEASE ALIKE, because the count identity the old debug assertion checked
+    // holds on both sides of the lie.
+    let _ = inp.peek::<U4>();
+  });
+}
+
+#[test]
+#[should_panic(expected = "and `Cache::peek` appended 3")]
+fn peek_over_an_over_reporting_cache_fails_fast_instead_of_shortening_the_window() {
+  use generic_arraydeque::typenum::{U3, U5};
+
+  with_misreporting_cache::<{ lie::OVER_BY_ONE }, _, _>("a b c d e", |inp| {
+    {
+      let warm = inp.peek::<U3>().expect("the warm-up peek must succeed");
+      assert_eq!(warm.len(), 3, "the warm-up peek seeds the cache");
+    }
+    // The other direction, and the half of CACHE_COPY a count CAN see. `len()` now says
+    // 4 against 3 residents, so the fill reserves four slots and lexes only one token
+    // past them; `Cache::peek` has room for four and appends three. Unchecked this
+    // returns a correct but four-long window from a five-slot request — a short window,
+    // which the peek contract lets a caller read as end of input.
+    let _ = inp.peek::<U5>();
+  });
+}
+
+// ── CACHE_COPY — the two holes the FIRST pair of guards left open ─────────────
+//
+// The pair of cells above went in with the guards they exercise, and both guards had the
+// same defect as the count identity they replaced: a precondition read off the untrusted
+// value. That is the class, and these two cells are its two instances.
+//
+//   * the endpoint witness was gated on `in_cache > 0`. A cache under-reporting to ZERO
+//     skips it by that precondition, and the surviving count check passes trivially as
+//     `0 == 0`. The witness was blindest exactly where the lie was largest.
+//   * the cache-hit early return ran no check at all, on the reasoning that its clip is
+//     legitimate. It is — but "legitimately clipped" and "silently shortened" are the same
+//     shape from the outside, and only `min(len(), room)` tells them apart.
+//
+// Only the second is release behaviour now. The first exercises the endpoint witness,
+// which prices out too high per fill to keep outside debug (see CACHE_COPY above), so
+// that cell is `#[cfg(debug_assertions)]` and proves debug builds only; the second
+// exercises the count check on the cache-hit exit, still `assert!` in every build, so it
+// keeps its unconditional `should_panic`.
+
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "did not copy the cache's whole resident run")]
+fn peek_over_a_cache_under_reporting_to_zero_fails_fast_instead_of_holing_the_window() {
+  use generic_arraydeque::typenum::{U2, U3};
+
+  with_misreporting_cache::<{ lie::UNDER_TO_ZERO }, _, _>("a b c d e", |inp| {
+    // Warm-up, honest: the cache is empty so 0 IS the resident count, and the fill's own
+    // three successful pushes carry `in_cache` up to 3. `a`, `b` and `c` go in.
+    {
+      let warm = inp.peek::<U3>().expect("the warm-up peek must succeed");
+      assert_eq!(warm.len(), 3, "the warm-up peek seeds the cache");
+    }
+    // The call under test. `len()` now says 0 against three residents, so the fill
+    // reserves NOTHING for the cache region and spends the whole two-slot window staging:
+    // `d` and `e` are lexed, refused by the full cache, and staged. `Cache::peek` then runs
+    // with zero room and appends zero entries.
+    //
+    // Every count in sight agrees. `copied == in_cache` is `0 == 0`; the old accounting
+    // identity `buf_len + staged + parked + in_cache == buf.len()` is `0 + 2 + 0 + 0 == 2`.
+    // And the endpoint witness — the one check that could see it — was skipped by its own
+    // `in_cache > 0` precondition, which the lie sets to false.
+    //
+    // Before this change this returned `Ok` with the starts 6, 8 — the window is `[d, e]`
+    // while the next consume serves `a` at 0, then `b`, `c`, `d`, `e`. Not a short window:
+    // three tokens of HOLE, in DEBUG AND RELEASE ALIKE.
+    let _ = inp.peek::<U2>();
+  });
+}
+
+#[test]
+#[should_panic(expected = "and `Cache::peek` appended 3")]
+fn peek_hit_over_an_over_reporting_cache_fails_fast_instead_of_shortening_the_window() {
+  use generic_arraydeque::typenum::{U3, U4};
+
+  with_misreporting_cache::<{ lie::OVER_BY_ONE }, _, _>("a b c d e", |inp| {
+    {
+      let warm = inp.peek::<U3>().expect("the warm-up peek must succeed");
+      assert_eq!(warm.len(), 3, "the warm-up peek seeds the cache");
+    }
+    // The CACHE-HIT exit, which the miss-path cells above never reach. `len()` says 4
+    // against three residents, so `want` saturates to zero at `4 - 4` and the fill returns
+    // through the early path without lexing at all: it copies the cache and hands the
+    // window back. `Cache::peek` has room for four and appends the three that exist.
+    //
+    // Unchecked, that is `Ok` with a THREE-long window from a four-slot request over an
+    // input that still holds `d` and `e` — the over-report shortening a window, on the one
+    // path the first round left unchecked because its clip "is legitimate". The clip on
+    // this path IS legitimate; what is not is stopping with a slot to spare, and
+    // `min(len(), room)` is the whole of the difference: here `min(4, 4)` is 4 and the copy
+    // brought 3.
+    let _ = inp.peek::<U4>();
+  });
+}
+
+/// The legitimate clip this path exists to serve, kept green beside the cell above so the
+/// fix cannot be "reject every short copy".
+///
+/// Same cache, same over-report, same early exit — but a `U3` request against a four-slot
+/// claim, so `min(len(), room)` is `min(4, 3)` and the three residents fill the window
+/// exactly. A copy that stops before `back` because the window ran out is correct, and it
+/// must stay `Ok`. (An honest cache reaches the same shape whenever `len()` exceeds the
+/// width asked for; this one just also proves the lie does not change the answer when the
+/// window comes back full.)
+#[test]
+fn peek_hit_clipped_by_the_window_is_not_a_violation() {
+  use crate::cache::PeekedTokenExt as _;
+  use generic_arraydeque::typenum::U3;
+
+  let starts = with_misreporting_cache::<{ lie::OVER_BY_ONE }, _, _>("a b c d e", |inp| {
+    {
+      let warm = inp.peek::<U3>().expect("the warm-up peek must succeed");
+      assert_eq!(warm.len(), 3, "the warm-up peek seeds the cache");
+    }
+    let peeked = inp
+      .peek::<U3>()
+      .expect("a copy the window's own capacity clipped is not a contract violation");
+    peeked
+      .iter()
+      .map(|t| t.span().start())
+      .collect::<std::vec::Vec<_>>()
+  });
+  assert_eq!(
+    starts,
+    std::vec![0, 2, 4],
+    "the clipped copy must still be the window's correct prefix"
+  );
+}
+
+// ── A successful overflow peek frees each staged token exactly once ────────────
+//
+// The trip and fatal-emit cells above prove the discarding exits are clean. This is
+// the *keeping* exit: the staged tokens are handed to the caller inside the window,
+// permuted into place, and freed when the window drops. A permutation that copied
+// an entry instead of moving it would show up here as `drops > creates`; one that
+// dropped an entry on the floor as `drops < creates`.
+
+#[test]
+fn successful_overflow_peek_frees_every_staged_token_exactly_once() {
+  use crate::cache::PeekedTokenExt as _;
+  use generic_arraydeque::typenum::U6;
+
+  // A limit no scan can reach: this cell is about the keeping exit, not the trip.
+  // Its ledger is this cell's own, so the counts below see only its own tokens.
+  let limiter = TripLimiter::with_limit(usize::MAX);
+  let ledger = limiter.ledger();
+
+  let cache = crate::cache::DefaultCache::<'_, TripLexer<'_>>::default();
+  let mut input = crate::input::Input::<TripLexer<'_>, TripCtx<'_>, ()>::with_state_and_context(
+    "1 2 3 4 5 6",
+    limiter,
+    crate::input::InputContext::new(crate::emitter::Silent::<TripErr>::new(), cache),
+  );
+  let mut inp = input.as_ref();
+
+  assert_eq!(ledger.live(), 0, "the cell starts with nothing lexed");
+  {
+    let peeked = inp.peek::<U6>().unwrap();
+    assert_eq!(peeked.len(), 6, "the full window must come back");
+    // Stream order, which for this fixture is also the span order.
+    let starts = peeked
+      .iter()
+      .map(|t| t.span().start())
+      .collect::<std::vec::Vec<_>>();
+    assert_eq!(starts, std::vec![0, 2, 4, 6, 8, 10]);
+    // All six the fill produced are live at once: three in the cache, three owned by
+    // the window itself.
+    assert_eq!(
+      ledger.live(),
+      6,
+      "three cache-resident and three staged tokens are live while the window is held"
+    );
+  }
+  // Dropping the window frees exactly the staged three; the cache keeps its three.
+  assert_eq!(
+    ledger.live(),
+    3,
+    "dropping the window frees the staged tokens once — no leak, no double-drop"
+  );
+
+  // The cache still holds its three and hands them back.
+  assert!(inp.next().unwrap().is_some(), "cache token 1");
+  assert!(inp.next().unwrap().is_some(), "cache token 2");
+  assert!(inp.next().unwrap().is_some(), "cache token 3");
+  drop(inp);
+  drop(input);
+
+  assert_eq!(
+    ledger.created(),
+    ledger.dropped(),
+    "every token payload the peek created was freed exactly once"
+  );
+}
+
+// ── PEEK_FOOTPRINT — one owned window, whatever the token and state cost ──────
+//
+// `Token` and `State` are unconstrained in size, so every `W`-slot store a peek
+// builds costs `W::CAPACITY × (Token + State + Span)` of stack. It must build
+// exactly one — the window it hands back. Through 0.8.0 the fill built a second one
+// on a cache miss (a `W::CAPACITY`-slot `MaybeUninit` array staging the tokens lexed
+// past the cache until the cache region had been copied out), so a large token
+// payload or a large lexer state cost twice what the caller asked for.
+//
+// The law is pinned from two sides, because neither side alone can see the whole of
+// it:
+//
+//   * the compile-time assertions below fix the *size* relation over a deliberately
+//     oversized token and lexer state — the window is one array of entries and each
+//     entry carries one token and one state, so the frame is exactly linear in both;
+//   * `peek_footprint_census_the_fill_owns_no_store` in `census_tests.rs` fixes the
+//     *structural* one — the fill body constructs no array, no deque and no
+//     `MaybeUninit` of its own. That is the live half: a size assertion cannot see a
+//     new local, and reintroducing a staging array trips the census immediately.
+//
+// A stack measurement was tried in place of the census and rejected. An unoptimized
+// build materializes roughly seven window-sized copies around the fill (every
+// `Result`, tuple and return slot on the way through `peek` gets one), so the term
+// under test is under a seventh of the frame and any threshold over it is a magic
+// number that a compiler release or an unrelated refactor moves.
+
+/// Words per oversized payload — 1 KiB at 64 bits, so the window term dominates.
+const BIG_WORDS: usize = 128;
+
+/// An oversized token payload: the `Token` half of the per-entry cost.
+#[derive(Debug, Clone)]
+struct BigPayload([u64; BIG_WORDS]);
+
+impl BigPayload {
+  /// Reads the payload back, so its bytes are load-bearing rather than dead weight.
+  fn probe(&self) -> u64 {
+    self.0[0]
+  }
+}
+
+/// An oversized lexer state: the `State` half of the per-entry cost.
+#[derive(Debug, Clone)]
+struct BigState([u64; BIG_WORDS]);
+
+impl BigState {
+  /// Reads the state back, for the same reason as [`BigPayload::probe`].
+  fn probe(&self) -> u64 {
+    self.0[0]
+  }
+}
+
+impl Default for BigState {
+  fn default() -> Self {
+    Self([0; BIG_WORDS])
+  }
+}
+
+impl crate::state::State for BigState {
+  type Error = ();
+
+  fn check(&self) -> Result<(), Self::Error> {
+    Ok(())
+  }
+}
+
+#[derive(Debug, Clone, crate::logos::Logos)]
+#[logos(crate = crate::logos, extras = BigState, skip r"[ \t\r\n]+")]
+enum BigTok {
+  #[regex(r"[0-9]+", |_| BigPayload([0; BIG_WORDS]))]
+  Num(BigPayload),
+}
+
+impl core::fmt::Display for BigTok {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    write!(f, "number")
+  }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum BigKind {
+  Num,
+}
+
+impl core::fmt::Display for BigKind {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    write!(f, "number")
+  }
+}
+
+impl crate::Token<'_> for BigTok {
+  type Kind = BigKind;
+  type Error = ();
+
+  fn kind(&self) -> BigKind {
+    BigKind::Num
+  }
+
+  fn is_trivia(&self) -> bool {
+    false
+  }
+}
+
+type BigLexer<'a> = LogosLexer<'a, BigTok>;
+type BigCtx<'a> = (
+  crate::emitter::Silent<()>,
+  crate::cache::DefaultCache<'a, BigLexer<'a>>,
+);
+
+/// One window entry: the `Maybe` of a borrowed and an owned `CachedToken`.
+type BigEntry<'r, 'a> = crate::cache::MaybeRefCachedTokenOf<'r, 'a, BigLexer<'a>>;
+/// The widest window the crate offers, over the oversized fixture.
+type BigWindow<'r, 'a> =
+  crate::cache::Peeked<'r, 'a, BigLexer<'a>, generic_arraydeque::typenum::U32>;
+
+const BIG_ENTRY: usize = core::mem::size_of::<BigEntry<'static, 'static>>();
+const BIG_WINDOW: usize = core::mem::size_of::<BigWindow<'static, 'static>>();
+
+// The size law, stated relationally so it survives a change of word size or of
+// `CachedToken`'s layout.
+const _: () = {
+  // An entry owns one whole token and one whole lexer state: that is why the peek
+  // footprint is linear in both, and why a second store of this shape doubles it.
+  assert!(
+    BIG_ENTRY >= core::mem::size_of::<BigTok>() + core::mem::size_of::<BigState>(),
+    "a window entry must be able to own a token together with its lexer state"
+  );
+  // And the window is exactly 32 of them plus the deque's own indices — one array,
+  // with no room for a shadow copy hiding inside it.
+  assert!(
+    32 * BIG_ENTRY <= BIG_WINDOW
+      && BIG_WINDOW <= 32 * BIG_ENTRY + 4 * core::mem::size_of::<usize>(),
+    "a U32 peek window must be one array of 32 entries plus the deque's own bookkeeping"
+  );
+};
+
+/// Forty single-digit tokens: more than the widest window, so the fill stops at the
+/// window bound rather than at end of input.
+const BIG_SRC: &str = "1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 \
+                       1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0";
+
+#[test]
+fn widest_peek_over_oversized_token_and_state_stays_in_stream_order() {
+  use crate::cache::PeekedTokenExt as _;
+  use generic_arraydeque::typenum::U32;
+
+  // The widest window the crate allows, over a 1 KiB token payload and a 1 KiB lexer
+  // state, against the three-slot default cache: 3 cache-resident entries and 29
+  // staged ones, the largest staged region any peek can produce. Running the
+  // monomorphization is the point — it is where an accounting slip in the staged
+  // region would trip a debug assertion, and where a second window would be paid for.
+  let cache = crate::cache::DefaultCache::<'_, BigLexer<'_>>::default();
+  let mut input = crate::input::Input::<BigLexer<'_>, BigCtx<'_>, ()>::with_state_and_context(
+    BIG_SRC,
+    BigState::default(),
+    crate::input::InputContext::new(crate::emitter::Silent::<()>::new(), cache),
+  );
+  let mut inp = input.as_ref();
+
+  let peeked = inp.peek::<U32>().unwrap();
+  assert_eq!(peeked.len(), 32, "the widest window must come back full");
+  // Token `i` of the fixture starts at offset `2 * i`; stream order is therefore
+  // visible as a strictly increasing run of even starts, across the boundary at 3.
+  let starts = peeked
+    .iter()
+    .map(|t| t.span().start())
+    .collect::<std::vec::Vec<_>>();
+  assert_eq!(
+    starts,
+    (0..32).map(|i| i * 2).collect::<std::vec::Vec<_>>(),
+    "the oversized window must read in stream order across the cache boundary"
+  );
+  let owned = peeked.iter().filter(|t| t.is_owned()).count();
+  assert_eq!(
+    owned, 29,
+    "3 cache-resident entries, 29 staged past the cache"
+  );
+
+  // Both oversized halves really are carried per entry — the premise the size
+  // assertions above rest on.
+  match peeked[0].token() {
+    BigTok::Num(payload) => assert_eq!(payload.probe(), 0),
+  }
+  let head_state = match &peeked[0] {
+    mayber::Maybe::Ref(cached) => cached.state.probe(),
+    mayber::Maybe::Owned(cached) => cached.state.probe(),
+  };
+  assert_eq!(head_state, 0, "every entry carries a whole lexer state");
 }


### PR DESCRIPTION
Closes R4 of #139. A peek that overflowed the cache window reserved **two** full owned-capable windows; it now reserves one.

## The defect, and why the fix removes rather than relocates

`peek` allocated the public `Peeked<W>` deque, and on a cache miss also built an `Overflow` holding a second `W`-slot `GenericArray<MaybeUninit<T>, N>`. The type-level window limit bounds the slot count, but `Token` and lexer `State` sizes are unconstrained, so a large token type produced an unexpectedly large stack frame.

`Overflow` existed for **ordering**, not storage: tokens past the cache are lexed *during* the fill, while the cache region is copied out in one bulk append *afterwards*, and `Cache::peek` only appends — so anything already in `buf` would precede the cache region.

The obvious restructuring — copy the cache first, then lex straight into `buf` — is blocked by the borrow checker: `Cache::peek` takes `&'p self` at the window's element lifetime, freezing the cache field while the loop still needs `&mut self`. The third option works: **stage in `buf`'s own tail, then one `rotate_left`** turns `[staged][parked?][cache]` into `[parked?][cache][staged]`. Capacity holds by the same accounting that already bounds `want`.

**Four `unsafe` blocks deleted, none added.** The staged write, the `ManuallyDrop` + `assume_init_read` drain, the `assume_init_drop`, and the uninitialised array construction are all gone. `tokora/src/input/input_ref/` now contains **zero** `unsafe`. Drop safety is the deque's: `buf` owns each entry from the push, and `rotate_left` permutes in place without copying anything out.

Owned storage, measured:

| entry size | window | before | after |
|---|---|---|---|
| 2072 B (1 KiB token + 1 KiB state) | U32 | 132,632 | **66,320** (−50.0%) |
| same | U8 | 33,176 | **16,592** (−50.0%) |
| 32 B (crate fixture) | U32 | 2,072 | **1,040** (−49.8%) |

## What review found: a lying `Cache` could corrupt the window silently

The reordering has one behavioural consequence — `Cache::peek` now sees less remaining capacity, because the staged entries are already present. Its law is "append exactly `min(len(), remaining)`", so a custom `Cache` whose `len()` under-reports gets clipped mid-run, and the rotation boundary lands wrong. The result is a **hole**, not a short window:

```
returned: [(0,false), (2,false), (6,true), (8,true)]   ← offset 4 skipped
stream:   [(0,false), (2,false), (4,false), (6,true)]
```

The pre-existing accounting assertion could not catch it **in either profile**: the under-report is subtracted from the cached count and added straight back as the staged count, so the identity holds on both sides of the lie — `0 + 2 + 0 + 2 == 4`.

Two checks now run on **every window-returning exit, in every build**:

- **count** — `copied == min(reserved, room)` where a clip is licensed, `copied == reserved` where it is not. That `min` is the entire difference between a legitimate window-capacity clip (fills the window) and an over-report (leaves slots to spare).
- **endpoints** — read from `Cache::front`/`back`, never `len`, so an inexact length cannot both cause a fault and hide it.

The governing rule: **every quantity a check is gated on is one the fill computes.** The cache-reported value appears only on the *expected* side of a comparison. Two earlier revisions violated that — first the self-cancelling identity, then an `in_cache > 0` guard that skipped exactly when a cache under-reported to zero.

Failure mode is a panic, matching `InputRef::park` and `Sink::cst_start`, which both assert caller-contract violations in every build. A recoverable error was rejected: the peek surface returns the *emitter's* error type, so a broken `Cache` would reach the grammar disguised as a diagnostic about the input.

`Cache::len` and `Cache::peek` gain the contract text this enforces; `InputRef::peek` gains a `# Panics` section.

## A test flake that CI could not have caught

The drop-safety cells used global atomic counters. The whole `peek::tests` module was stable — **0 failures in 180 runs** across three thread counts — but `cargo test overflow_peek`, the filter a developer editing those cells actually types, failed **184 of 200 times**, and three cells at `--test-threads=3` failed **382 of 400**.

Each scenario now owns a `Ledger` threaded in as lexer state, using `Cell` rather than an atomic *because* a ledger never leaves its test's thread — making that structural rather than conventional. **Zero failures in 4,312 test-process invocations** across both profiles and eight thread counts, including the configurations that had failed 382/400.

## Two residuals, disclosed and accepted in review

The endpoint witness pins the run's **ends, not its middle** — a cache that reorders interior entries while starting at `front`, ending at `back`, and returning the expected count would pass. That is `Cache::peek`'s ordering law, which the conformance kit tests directly.

The clip licence is a hand-supplied constant per call site. A fourth window exit passing it with a tail behind it would not be caught mechanically; an existing census pins the cache copy at three sites, but counts the copy rather than the argument.

## Verification

`cargo test --all-features` — **1,548 lib** (debug) / **1,535** (release), 2 ignored. `cargo doc --all-features`, `clippy -D warnings`, `fmt --check`, both no-std tiers, both no-std test runs (205 and 697 passed), and three `thumbv6m-none-eabi` checks — all exit 0.

**Codex adversarial review: APPROVE**, round 4, no findings.

**Perf gate: queued.** Unlike R3, this change sits on a path `input_scan` already exercises, so it is measurable with the existing suite. Results will be posted here before merge.
