### PR TITLE
fix(peek): one owned lookahead window, cache hit or miss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1209,6 +1209,92 @@ concrete public struct with no bound to reject anybody.
    placement drops. Two new regressions pin the behaviour itself, one per gate, each watched failing
    first and each with a widened-limit control that differs in nothing but the scan budget.
 
+13. **A peek that reached the lexer reserved two token windows, not one.** The fill allocated the
+   public `Peeked<W>` deque the caller gets back, and then — on the cache-miss path — a second
+   `W::CAPACITY`-slot store of the same entry type, a `GenericArray<MaybeUninit<_>, W::CAPACITY>`
+   holding the tokens lexed past the cache until the cache region had been copied out. The window
+   bound caps the slot *count*, but `Token`, `State` and `Span` are unconstrained in size, so a
+   grammar with a large token payload or a large lexer state paid **twice** the window it asked
+   for on every peek that reached the lexer. For the crate's own oversized fixture — a 1 KiB token
+   beside a 1 KiB lexer state, 2,072 bytes an entry — that is 132,632 bytes at `U32` and 33,176 at
+   `U8`; those are now **66,320** and **16,592**. Nothing about the peek's result changes; this is
+   stack the caller was paying for and could not see. It matters most where the stack is smallest,
+   which is the `no_std` target the crate advertises.
+
+   The second store existed to solve an **ordering** problem, not a storage one. A window's two
+   halves are produced in the opposite order from the one it must report: the tokens past the
+   cache are lexed *during* the fill, while the cache region is copied out in one bulk read
+   *after* it, and `Cache::peek` only appends. That needs the staged region to end up *behind* the
+   cache region — not a second array. So it is staged at the tail of the window the caller already
+   owns and rotated back once the cache region is in. The rotation permutes values inside the
+   deque and copies none out, and the deque owns each staged entry from the moment it is pushed,
+   so every exit — success, a withheld frontier, a limit trip, a fatal emit — frees it exactly
+   once. `input/input_ref/` now contains no `unsafe` block at all; the two it had were the removed
+   array's partial-initialization bookkeeping.
+
+   Reordering the copy *ahead* of the loop would need no rotation and no check, and it is not
+   available: `Cache::peek` takes `&'p self` and the entries it appends borrow the cache for the
+   whole of the fill, while the loop's every step — `lex_within_boundary`, `classify`,
+   `emit_lexer_error_deduped`, `cache_append` — takes `&mut self`, and `cache_append` mutates the
+   very cache those entries borrow.
+
+   **The reordering creates one hazard, and it is checked.** `Cache::len` is now load-bearing: the
+   fill reserves the window's cache region from it *before* it stages anything, so a `len` that is
+   not the resident count mis-sizes the copy that follows. An under-report clips the copy mid-run
+   and the rotation then closes the gap with staged tokens that belong *after* the residents the
+   clip dropped — not a short window, a **hole**, at a position the next consume will not serve.
+   `Cache::len` and `Cache::peek` now say so where an implementor reads them, and the fill exit
+   that rotates checks the copy it got, in **every build**: a count identity, and — because an
+   inexact `len` can satisfy any count derived from it — the resident run's own `front`/`back`
+   endpoints, gated on the staged count, which is a number the fill computes rather than one the
+   cache reports. The endpoint witness is the release-critical half, not the optional one: it is
+   the only check that sees a clip landing exactly on the window's edge, or a `len` under-reporting
+   all the way to **zero**, which passes the count trivially as `0 == 0`. Both of those are the
+   hole. `InputRef::peek` grows a `# Panics` section. The two exits that answer from tokens already
+   at the front of the stream append nothing behind their copy, so they cannot hole, and they are
+   unchanged and unchecked.
+
+   **The hot read pays nothing for it, and that took measuring.** The half of the fill that
+   reaches the lexer is now `#[inline(never)]`: staging in the window puts a deque push, a
+   truncate, a rotation and a `Cache::peek` whose room is a runtime value into the same body as
+   the resident-head arm, and the register allocation and block layout that follow are shared.
+   Left in one function, six peek-shaped bench ids paid **1.11×–1.31×** for code they never run —
+   and the checks are not what they were paying: with both removed entirely the same six ids
+   still read 1.11×–1.31×. Split out, with the overflow-free fill taking its own exit and the
+   panic message built out of line, the same six read **0.80×–1.15×**: the two `heavy` ids — a
+   large lexer state, exactly the shape the second window cost the most — come back **20%
+   faster**, and the worst reading is `input/scan/peek1_then_next` at 1.15×, a drain that defeats
+   its own cache by construction so that every read is a fill. Geometric mean across the six,
+   0.98×. Nothing outside the peek family moves.
+
+   The same law decided where the release-active endpoint witness lives, and it cost one more
+   measurement to find out. Inlined into the fill it sits past the overflow-free `return`,
+   unreachable from the arm that takes it — and moved `peek1_then_next` by **1.025×** anyway,
+   consistently and outside the noise, for exactly the reason the split above exists. So
+   `assert_cache_copy` is `#[inline(never)]` too, and its second message joins the first in a
+   `#[cold]` free function. Out of line, the six ids read **0.9987** geometric mean against the
+   window fix alone, every one of them inside 0.974×–1.009×, over ten interleaved criterion
+   rounds. The 67–70-instruction figure that once argued for keeping the witness in debug builds
+   is withdrawn: it was the cost of running the check, and what a hot path actually pays is the
+   cost of *stepping over* it.
+
+   Coverage, since the previous overflow tests asserted only `len()`: seven cells pinning window
+   order across the cache/overflow boundary — the smallest overflow, a prefilled cache, a cache
+   that retains nothing, a parked front token, and the widest window over an oversized token and
+   state — which removing the rotation turns red along with the pre-existing
+   `token_accessor_reads_owned_arm`; a drop-counted cell for the *keeping* exit; a second phase on
+   the fatal-emit cell that reads the buffer back after the failing return; compile-time size
+   assertions over the oversized fixture; and a source census that refuses to let the fill body
+   name an array, a deque, a `MaybeUninit` or `unsafe` again. The two `should_panic` cells that
+   exercise the endpoint witness alone — the under-report by one, and the under-report to zero —
+   are ungated and run under `cargo test --release` as well, which is the build the witness was
+   promoted for; a `should_panic` whose panic compiles out passes by never running the code it
+   names. The drop-safety cells now count into a per-scenario `Rc<Ledger>` instead of `static
+   AtomicUsize`: they assert *live* deltas while their own window is still held, so under Rust's
+   default parallel test runner they were counting whatever else happened to be running —
+   `cargo test overflow_peek` failed 184 runs out of 200. —
+   *(#156)*
+
 ### Added
 
 17. **`cast::token_any` and `cast::tokens` close the two gaps in the cast module's token

--- a/tokora/src/cache/mod.rs
+++ b/tokora/src/cache/mod.rs
@@ -168,6 +168,19 @@ pub trait Cache<'a, L, Lang: ?Sized = ()>: 'a {
   /// Returns the number of tokens currently stored in the cache.
   ///
   /// This count includes all cached tokens from front to back.
+  ///
+  /// # It must be **exact**, and the peek fill is why
+  ///
+  /// [`InputRef::peek`](crate::input::InputRef::peek) sizes the window's cache region from
+  /// this number *before* it lexes: it reserves one window slot per reported resident, spends
+  /// the rest of the window on tokens lexed past the cache, and only then calls
+  /// [`peek`](Cache::peek) into the room that is left. A `len` that is not the resident count
+  /// therefore mis-sizes that copy — under-report and it is clipped mid-run with the
+  /// later-lexed tokens closing the gap behind it, over-report and the window comes back short
+  /// while the input still has more. The fill checks the copy it gets and **panics** rather
+  /// than hand back a window that is wrong about the stream; see that method's `# Panics`.
+  ///
+  /// An upper bound, a capacity, or a count that lags a push is not a `len`.
   fn len(&self) -> usize;
 
   /// Returns the number of additional tokens that can be cached.
@@ -328,6 +341,12 @@ pub trait Cache<'a, L, Lang: ?Sized = ()>: 'a {
   /// observable of the cache, and calling it twice on an unchanged cache appends the same
   /// sequence both times. A borrowed entry and an owned one denote the same token, so a caller
   /// cannot tell which a cache chose to hand back.
+  ///
+  /// Given room for `len()` entries this must therefore deliver the resident run **entire**,
+  /// [`front`](Cache::front) through [`back`](Cache::back). The one place a copy may stop short
+  /// of `back` is where the buffer's own capacity stopped it. The peek fill leaves exactly the
+  /// room [`len`](Cache::len) claimed and checks what comes back — see that method for the
+  /// consequences of the two directions a wrong `len` can take.
   ///
   /// # Parameters
   ///

--- a/tokora/src/guide/arch_source_slice.md
+++ b/tokora/src/guide/arch_source_slice.md
@@ -229,6 +229,34 @@ The feature graph layers up from there:
 - **no feature** → `core` only. Core `str` / `[u8]` sources, the parser itself, and its
   stack-buffered lookahead machinery (peek windows of 1-32 tokens over a small inline
   cache) — no allocator in sight.
+
+  Stack-buffered means the lookahead is on **your** stack, so the bound is worth stating.
+  A `peek::<W>()` reserves **one** window and its worst case is the whole array live at
+  once:
+
+  ```text
+  W::CAPACITY × size_of::<Maybe<CachedToken<&Token, &State, &Span>,
+                                CachedToken<Token, State, Span>>>()
+  ```
+
+  which for every realistic type is `W::CAPACITY × (size_of::<Token>() + size_of::<State>() +
+  size_of::<Span>())` plus per-entry padding and a discriminant. `W::CAPACITY` is at most
+  **32** — `U32` is the widest window the crate offers — so that expression, evaluated at
+  32, is the maximum a single peek can cost. Everything else on the frame is O(1) in the
+  window width: single-entry temporaries, one clone of the lexer (`size_of::<L>()`, which
+  contains `State`), and a small fixed part.
+
+  The coefficient is **one**, not two, and that is recent: through 0.8.0 a peek that looked
+  past the cache staged the extra tokens in a *second* `W::CAPACITY`-slot array, so a cache
+  miss cost twice the figure above. At `U32` over a 1 KiB token beside a 1 KiB lexer state —
+  2,072 bytes an entry — that second array was 66,312 bytes of stack nobody asked for, and the
+  peek's owned storage was 132,632 bytes rather than 66,320. Those tokens are now staged in
+  the window the caller already owns.
+
+  `Token`, `State` and `Span` are yours and unconstrained in size, so this is the one place
+  an embedded target has to do the arithmetic itself: pick the narrowest window that decides
+  the production, and use `peek_kind` / `head_satisfies` — which run at `U1` — for a head
+  test. Nothing here is heap-allocated and nothing scales with the length of the input.
 - **`alloc`** → adds the allocator-backed pieces (growable containers, the session stack) while
   staying `no_std`.
 - **`std`** (default) → everything, plus it turns on the upstream backends' own default features.

--- a/tokora/src/input/input_ref/census_tests.rs
+++ b/tokora/src/input/input_ref/census_tests.rs
@@ -1870,7 +1870,7 @@ fn front_census_one_front_surface() {
     }
   }
 
-  // The peek fill is the one back push, and it is not a put-back; all three of its window exits
+  // The peek fill is the one back push, and it is not a put-back; every one of its window exits
   // must put the parked token in front of the cached run, or a window comes back missing the
   // token at the front of the stream.
   let peek = source("peek/mod.rs");
@@ -1880,11 +1880,32 @@ fn front_census_one_front_surface() {
   );
   let exits = count(peek, "self.cache.peek::<W>(");
   let prepends = count(peek, "Maybe::Ref(parked.as_ref())");
+  // FOUR exits, THREE prepends, and that is not a hole. Two of the exits — the overflow-free
+  // fill and the one that rotates a staged region into place — are two tails of the *same*
+  // block in `peek_lex_fill`, and the one prepend there precedes the branch between them, so it
+  // heads the window on both. The other two exits (the resident-head arm and the latched
+  // boundary) carry one each. What a count cannot say is "precedes", so the ordering is checked
+  // below rather than assumed: a prepend that drifted *after* a copy would keep this count
+  // exactly and produce the window this census exists to refuse.
   assert!(
-    exits == 3 && prepends == exits,
+    exits == 4 && prepends == 3,
     "FRONT_CENSUS drift: the peek fill has {exits} window exit(s) and {prepends} parked \
-     prepend(s) — every exit must head its window with the parked token, or a window at a \
-     latched boundary comes back empty over a live, consumable token (grep FRONT_CENSUS)."
+     prepend(s), expected 4 and 3 — every exit must head its window with the parked token, or a \
+     window at a latched boundary comes back empty over a live, consumable token \
+     (grep FRONT_CENSUS)."
+  );
+  let fill = method_body(peek, "peek_lex_fill");
+  let prepend_at = fill
+    .find("Maybe::Ref(parked.as_ref())")
+    .expect("FRONT_CENSUS: the peek fill's lexing half must prepend the parked token");
+  let first_copy = fill
+    .find("self.cache.peek::<W>(")
+    .expect("FRONT_CENSUS: the peek fill's lexing half must copy the cache into the window");
+  assert!(
+    prepend_at < first_copy && count(&fill, "Maybe::Ref(parked.as_ref())") == 1,
+    "FRONT_CENSUS drift: the peek fill's lexing half prepends the parked token at or after its \
+     first cache copy. Its two exits share one prepend precisely because that prepend runs \
+     before the branch between them (grep FRONT_CENSUS)."
   );
 }
 
@@ -1950,4 +1971,110 @@ fn front_census_every_probe_is_const_gated() {
        through the five front primitives (grep FRONT_CENSUS)."
     );
   }
+}
+
+/// PEEK_FOOTPRINT — the peek fill's owned token storage is the caller's window and
+/// nothing else.
+///
+/// `Token`, `State` and `Span` are unconstrained in size, so every `W::CAPACITY`-slot
+/// store the fill builds costs `W::CAPACITY × (Token + State + Span)` of stack. Through
+/// 0.8.0 it built a second one — a `GenericArray<MaybeUninit<_>, W::CAPACITY>` staging the
+/// tokens lexed past the cache until the cache region had been copied into the output
+/// buffer — so a cache miss reserved two full windows and a large token or lexer state
+/// doubled a peek's frame. Those tokens are now staged in the output buffer itself and
+/// rotated into place once the cache region is in, which is what makes the second store
+/// unnecessary.
+///
+/// This census is what keeps it gone: a size assertion cannot see a new local, so the
+/// only mechanical guard against the pattern coming back is refusing to let the fill body
+/// name the things that build one. The size law itself is asserted at compile time beside
+/// the oversized fixture in `peek/tests.rs` (grep PEEK_FOOTPRINT).
+///
+/// # It is syntactic, and that is the best available
+///
+/// The needles below are a string match, so a second window behind a `type` alias the
+/// fill does not spell — `let mut spare = Staging::new();` — walks past them. That gap is
+/// known and it is not closable here, because nothing the compiler checks can see the
+/// property:
+///
+/// - a `const` assertion can read `size_of` of a **type**, never the frame of a
+///   **function**; Rust exposes no frame size at compile time, so "this body reserves one
+///   window" is not statable as a type-level fact.
+/// - a runtime stack measurement was tried and rejected on the evidence recorded beside
+///   the fixture: an unoptimized build materializes roughly seven window-sized copies
+///   around the fill, so the term under test is under a seventh of the frame and any
+///   threshold over it is a magic number a compiler release moves.
+/// - `clippy::large_stack_frames` is threshold-based on the same frame, and the frame
+///   legitimately scales with `W::CAPACITY × size_of::<Token>()` — it would fire on the
+///   *single* correct window for a large-token monomorphization.
+///
+/// So this stays a syntactic guard that is honest about being one, rather than a
+/// structural guard that is not structural. The `GenericArrayDeque::` and `.rotate_left(`
+/// counts below are the file-scoped half, and they do bite an alias: whatever it is named,
+/// a second window still has to be *constructed*, and the deque count is the shape a
+/// construction in this file takes.
+#[test]
+#[cfg_attr(
+  miri,
+  ignore = "reads crate source and string-matches: no UB surface, and miri interprets every byte"
+)]
+fn peek_footprint_census_the_fill_owns_no_store() {
+  let peek = source("peek/mod.rs");
+  let fill = method_body(peek, "peek_with_emitter_inner");
+
+  // Everything that can build a window-shaped store, plus `unsafe` — the fill needs
+  // none of them now that the staged region lives in the buffer the caller owns, and
+  // each is a way to reintroduce the second window.
+  for needle in [
+    "MaybeUninit",
+    "GenericArray<",
+    "GenericArrayDeque",
+    "uninit(",
+    "W::array",
+    "W::deque",
+    "Window::array",
+    "Window::deque",
+    "unsafe",
+  ] {
+    assert!(
+      count(&fill, needle) == 0,
+      "PEEK_FOOTPRINT drift: the peek fill names `{needle}`. The fill owns no token \
+       storage of its own — tokens past the cache are staged in the caller's window and \
+       rotated into place — so anything that reserves `W::CAPACITY` slots here is the \
+       second owned window this was removed to close, and anything `unsafe` is the \
+       partial-initialization bookkeeping that went with it (grep PEEK_FOOTPRINT)."
+    );
+  }
+
+  // And the whole module, not just the fill: the staging array's `unsafe` was in a
+  // helper beside the fill rather than in it, so a body-scoped count alone would not
+  // have seen it go.
+  let unsafes = count(peek, "unsafe");
+  assert!(
+    unsafes == 0,
+    "PEEK_FOOTPRINT drift: `peek/mod.rs` names `unsafe` {unsafes} time(s), expected 0. \
+     The only `unsafe` this module ever had was the staging array's partial-initialization \
+     bookkeeping, which the single-window fill does not need (grep PEEK_FOOTPRINT)."
+  );
+
+  // One window per public entry point — the buffer each hands back — and no fourth.
+  let built = count(peek, "GenericArrayDeque::");
+  assert!(
+    built == 3,
+    "PEEK_FOOTPRINT drift: `peek/mod.rs` builds {built} deque(s), expected 3 — one per \
+     public entry point (`peek_one`, `peek_with_emitter`, `peek_with_emitter_terminal`), \
+     each the window it returns. A fourth is a store the caller never sees \
+     (grep PEEK_FOOTPRINT)."
+  );
+
+  // The staged region is put back in stream order by one rotation, and that rotation is
+  // the whole of the reordering: a second one would mean the fill is permuting something
+  // it does not own.
+  let rotations = count(peek, ".rotate_left(");
+  assert!(
+    rotations == 1,
+    "PEEK_FOOTPRINT drift: `peek/mod.rs` rotates {rotations} time(s), expected 1 — the \
+     single left-rotation that moves the staged region behind the front-of-stream region \
+     (grep PEEK_FOOTPRINT)."
+  );
 }

--- a/tokora/src/input/input_ref/peek/mod.rs
+++ b/tokora/src/input/input_ref/peek/mod.rs
@@ -1,71 +1,73 @@
-use core::mem::{ManuallyDrop, MaybeUninit};
-
-use generic_arraydeque::{ArrayLength, GenericArrayDeque, array::GenericArray};
+use generic_arraydeque::GenericArrayDeque;
 
 use super::*;
 
-/// Drop-safe staging buffer for peek tokens that overflow the cache window.
+/// CACHE_COPY's release half, raised **out of line**.
 ///
-/// A peek that looks past the cache capacity must hold the overflow tokens
-/// somewhere until the cache region is copied into the output buffer. Those
-/// tokens are **owned** (`Maybe::Owned`), so a raw `MaybeUninit` array would leak
-/// them if an early return (a fatal lexer error emitted mid-scan) skipped the
-/// hand-off. `Overflow` tracks how many entries are initialized and frees exactly
-/// those in its `Drop`, so no exit path — success, `Decline`, or fatal error —
-/// can leak a staged token or its state.
-struct Overflow<T, N: ArrayLength> {
-  slots: GenericArray<MaybeUninit<T>, N>,
-  len: usize,
+/// `#[cold]` and `#[inline(never)]` are load-bearing rather than decorative, and for a
+/// reason that is this module's whole subject: a formatted `panic!` needs a
+/// `core::fmt::Arguments` and its argument array built somewhere, and inlined into the fill
+/// that somewhere is the *fill's* frame — 96 bytes on aarch64, reserved on every call for a
+/// path that never runs. PEEK_FOOTPRINT is a frame-size law, so the panic's own storage
+/// belongs in the panic's own function. Measured: with this message inlined, a `U1` peek's
+/// release frame *grew* by those 96 bytes and swallowed the window this change was made to
+/// save.
+///
+/// Free-standing rather than an associated function for the same accounting: it names none
+/// of `InputRef`'s eight parameters, so the crate carries one copy of it instead of one per
+/// monomorphization.
+#[cold]
+#[inline(never)]
+fn cache_copy_count_violation(reserved: usize, copied: usize) -> ! {
+  panic!(
+    "`Cache` contract violation: the peek fill counted {reserved} resident entr(ies) from \
+     `Cache::len` and left `Cache::peek` room for all of them — and `Cache::peek` appended \
+     {copied}. `len` must be exactly the resident count and `peek` must append exactly \
+     `min(len(), the buffer's remaining capacity)`"
+  )
 }
 
-impl<T, N: ArrayLength> Overflow<T, N> {
-  #[inline(always)]
-  fn new() -> Self {
-    Self {
-      slots: GenericArray::uninit(),
-      len: 0,
-    }
-  }
-
-  // Only read by the debug-assertion accounting below; gate it to the same
-  // configuration so release builds do not see it as dead code.
-  #[cfg(debug_assertions)]
-  #[inline(always)]
-  fn len(&self) -> usize {
-    self.len
-  }
-
-  /// Stages one owned entry. Callers must not exceed `N` pushes (the overflow
-  /// region can never hold more than the window capacity).
-  #[inline(always)]
-  fn push(&mut self, value: T) {
-    self.slots[self.len].write(value);
-    self.len += 1;
-  }
-
-  /// Moves every staged entry into `buf`, in staging order, and disarms the
-  /// guard so its `Drop` will not touch the moved-out entries.
-  #[inline(always)]
-  fn drain_into(self, buf: &mut GenericArrayDeque<T, N>) {
-    // Wrap in `ManuallyDrop` up front: once entries are read out they must not be
-    // dropped again by the guard.
-    let this = ManuallyDrop::new(self);
-    for i in 0..this.len {
-      // SAFETY: `slots[0..len]` were initialized by `push`; each is read once.
-      buf.push_back(unsafe { this.slots[i].assume_init_read() });
-    }
-  }
+/// CACHE_COPY's endpoint half, raised **out of line**, for exactly the reason
+/// [`cache_copy_count_violation`] is.
+///
+/// This message is the longer of the two and takes two runtime arguments, so inlined it
+/// reserves its `core::fmt::Arguments` and argument array in the *fill's* frame — the 96-byte
+/// aarch64 cost measured on the count message, on a path that never runs. Free-standing and
+/// non-generic for the same accounting: one copy in the crate rather than one per
+/// monomorphization. It is also what keeps the release-active witness at its call site down to
+/// the compares themselves plus a never-taken branch to here.
+#[cold]
+#[inline(never)]
+fn cache_copy_endpoint_violation(copied: usize, staged: usize) -> ! {
+  panic!(
+    "`Cache` contract violation: `Cache::peek` did not copy the cache's whole resident run. \
+     The {copied} entr(ies) it appended do not span the cache from `front` to `back`, and \
+     {staged} staged token(s) are about to be rotated in behind them — so the window would \
+     report a token at a position the next consume will not serve. That is what an inexact \
+     `Cache::len` does to this copy: the fill reserves the room from `len` before it stages \
+     anything, so a `len` below the resident count clips the copy mid-run"
+  )
 }
 
-impl<T, N: ArrayLength> Drop for Overflow<T, N> {
-  #[inline(always)]
-  fn drop(&mut self) {
-    for slot in self.slots.iter_mut().take(self.len) {
-      // SAFETY: `slots[0..len]` were initialized by `push` and not moved out
-      // (`drain_into` disarms via `ManuallyDrop`), so each is dropped once.
-      unsafe { slot.assume_init_drop() };
-    }
-  }
+/// Stages one overflow token at the tail of the window, out of line.
+///
+/// `#[inline(never)]` for the same reason [`cache_copy_count_violation`] is: this arm runs
+/// only where the cache has refused a token, and a ring push's head/len arithmetic and
+/// capacity branch inlined into the fill loop shape the register allocation of the arm that
+/// runs on every ordinary fill.
+#[inline(never)]
+fn stage_overflow<T, N: generic_arraydeque::ArrayLength>(
+  buf: &mut GenericArrayDeque<T, N>,
+  value: T,
+) {
+  // The fill's accounting proves the push is always accepted (see PEEK_FOOTPRINT); assert the
+  // room in debug builds so a future change to it cannot silently drop a token. The predicate
+  // is the window's own two numbers, not the cache's.
+  debug_assert!(
+    buf.len() < buf.capacity(),
+    "peek staged an overflow token past the window capacity"
+  );
+  buf.push_back(value);
 }
 
 impl<'inp, L, Ctx, Lang: ?Sized, Cmpl> InputRef<'inp, '_, L, Ctx, Lang, Cmpl>
@@ -115,6 +117,47 @@ where
   /// limit trip during the fill emits its diagnostic and latches the poison boundary before the
   /// holdback is consulted, so a peek can no more hide a tripped limit than a consume can. See
   /// [terminal beats incomplete](crate::input#terminal-beats-incomplete-and-they-never-substitute).
+  ///
+  /// # Stack footprint: one window, cache hit or miss
+  ///
+  /// The window this returns is the **only** `W::CAPACITY`-sized owned token storage a peek
+  /// reserves, and its worst case is the whole array live at once:
+  ///
+  /// ```text
+  /// W::CAPACITY × size_of::<Maybe<CachedToken<&Token, &State, &Span>,
+  ///                              CachedToken<Token, State, Span>>>()
+  /// ```
+  ///
+  /// which for every realistic type is `W::CAPACITY × (size_of::<Token>() + size_of::<State>() +
+  /// size_of::<Span>())` plus per-entry padding and a discriminant. A **cache miss costs no
+  /// second window**: tokens lexed past the cache are staged in this same buffer and rotated
+  /// into place, so the miss path reserves exactly what the hit path does. (Through 0.8.0 the
+  /// miss path staged them in a separate `W::CAPACITY`-slot array, doubling the figure above.)
+  ///
+  /// Everything else in the frame is **O(1) in the window width**: single-entry temporaries (one
+  /// [`CachedToken`](crate::cache::CachedToken) in flight to the cache, the deque's own push and
+  /// rotate temporaries), one clone of the lexer — `size_of::<L>()`, which contains `State` — and
+  /// a small fixed part. Nothing here is heap-allocated, and nothing scales with the input.
+  ///
+  /// `Token` and `State` are unconstrained in size, so the bound is linear in both and in the
+  /// window width — with a coefficient of **one**, not two. A grammar carrying a large token
+  /// payload or a large lexer state pays `W::CAPACITY` times it for the width it asks for:
+  /// prefer the narrowest window that decides the production, and
+  /// [`peek_kind`](Self::peek_kind) or [`head_satisfies`](Self::head_satisfies) — which run at
+  /// `U1` — for a head test.
+  ///
+  /// # Panics
+  ///
+  /// On a [`Cache`](crate::cache::Cache) that breaks its own contract, and only then, on the
+  /// fill path that reaches the lexer. The fill reserves the window's cache region from
+  /// [`Cache::len`](crate::cache::Cache::len) *before* it stages anything past it, so a `len`
+  /// that is not the resident count mis-sizes the room
+  /// [`Cache::peek`](crate::cache::Cache::peek) is then given. The exit that hands such a window
+  /// back checks the copy that landed in it — against the room the fill left, and against the
+  /// cache's own `front` and `back`, which an inexact `len` cannot move — and panics rather than
+  /// return a window that is wrong about the stream. **Both checks run in release**, because the
+  /// window a broken `len` produces there is not a short one but a hole. Every cache this crate
+  /// ships conforms, and the cache conformance kit checks a downstream one.
   #[inline]
   pub fn peek<'p, W>(
     &'p mut self,
@@ -126,6 +169,9 @@ where
   }
 
   /// Peeks tokens to fill the provided buffer and returns the emitter.
+  ///
+  /// Reserves the same one owned window as [`peek`](Self::peek), cache hit or miss, and panics
+  /// on the same broken-`Cache` condition — see its stack-footprint and panics sections.
   #[inline]
   pub fn peek_with_emitter<'p, W>(
     &'p mut self,
@@ -156,6 +202,10 @@ where
   ///
   /// Callers must consult the flag **immediately**, before any fallible or emitting call (`decide`,
   /// element handlers, close probes): an ordinary error raised in between preempts the terminal stop.
+  ///
+  /// Rides the same fill as [`peek`](Self::peek) — the terminal flag is an extra out-parameter on
+  /// it, not a second code path — so it reserves the same one owned window, cache hit or miss, and
+  /// panics on the same broken-`Cache` condition. See its stack-footprint and panics sections.
   #[inline]
   pub fn peek_with_emitter_terminal<'p, W>(
     &'p mut self,
@@ -180,7 +230,6 @@ where
   /// end of input or a partial-input frontier — see
   /// [`peek_with_emitter_terminal`](Self::peek_with_emitter_terminal).
   #[inline]
-  #[allow(unused_assignments)]
   fn peek_with_emitter_inner<'p, W>(
     &'p mut self,
     buf: &mut Peeked<'p, 'inp, L, W>,
@@ -196,12 +245,8 @@ where
     // The parked front token is not a cache entry, but it IS the front of the stream, so it takes
     // a window slot and the fill must not re-lex it.
     let parked = usize::from(Self::can_park() && self.pending.is_some());
-    let mut in_cache = self.cache().len();
-    #[cfg(debug_assertions)]
-    let initial_in_cache = in_cache;
-    let mut want = remaining_cap.saturating_sub(parked + in_cache);
-    #[cfg(debug_assertions)]
-    let exp = want;
+    let in_cache = self.cache().len();
+    let want = remaining_cap.saturating_sub(parked + in_cache);
 
     // If enough tokens are already retained, just serve them
     if want == 0 {
@@ -235,8 +280,99 @@ where
       return Ok(self.session.emitter);
     }
 
-    // Drop-safe staging for tokens lexed past the cache window (see `Overflow`).
-    let mut overflowed = Overflow::<MaybeRefCachedTokenOf<'p, 'inp, L>, W::CAPACITY>::new();
+    // The flag comes back as a value rather than through the `&mut bool`: `peek_one` passes a
+    // `&mut false` it never reads, and with the fill out of line an out-parameter would force
+    // that temporary into memory and a pointer into the call. Returned, both writes to it are
+    // dead stores the inliner drops.
+    self
+      .peek_lex_fill::<W>(buf, buf_len, parked, in_cache, want)
+      .map(|(emitter, term)| {
+        *terminal = term;
+        emitter
+      })
+  }
+
+  /// PEEK_HOT_SPLIT — the half of the fill that reaches the lexer, kept **out of line**.
+  ///
+  /// The two arms above answer from tokens already at the front of the stream, and on a
+  /// grammar's decision points that is nearly always the answer: measured on a GraphQL parse,
+  /// 17,028 width-1 reads out of 17,029. This half is the other one.
+  ///
+  /// `#[inline(never)]` is a measurement, not a preference. Staging the overflow region in
+  /// `buf` puts the deque's push, truncate and rotate — and a `Cache::peek` whose room is now a
+  /// runtime value rather than a constant — into the same body as those two arms, and the
+  /// register allocation and block layout that follow are shared. Left in one function the
+  /// resident-head arm picked up about seven instructions on a thirty-instruction path it does
+  /// not use, and six peek-shaped bench ids paid **1.11×–1.31×** for a change that never
+  /// touched their code. Split out — with the overflow-free exit below taking its own tail and
+  /// the panic message built in [`cache_copy_count_violation`] — the same six read 0.80×–1.15×,
+  /// geometric mean 0.98×, and the two `heavy` ids come back 20% faster than the two-window
+  /// version they replace. The extra call is paid only where a lexer call is about to dwarf it.
+  /// (The cost is *not* the CACHE_COPY checks: with them removed entirely the same six ids
+  /// still read 1.11×–1.31×.)
+  ///
+  /// The receiver is `&'p mut self` — the *caller's own* borrow, not a fresh reborrow — because
+  /// the entries [`Cache::peek`](crate::cache::Cache::peek) appends borrow the cache for `'p`,
+  /// the window's element lifetime. The return type names `'p`, which is what forces the
+  /// reborrow to be that long.
+  ///
+  /// # Parameters
+  ///
+  /// The four quantities the caller already computed, so this body does not recompute them:
+  /// `buf_len` (the caller's own prefix, excluded from everything here), `parked`, `in_cache`
+  /// (the cache's reported resident count) and `want` (window slots left to fill, `> 0`).
+  #[inline(never)]
+  fn peek_lex_fill<'p, W>(
+    &'p mut self,
+    buf: &mut Peeked<'p, 'inp, L, W>,
+    buf_len: usize,
+    parked: usize,
+    in_cache: usize,
+    want: usize,
+  ) -> Result<(&'p mut Ctx::Emitter, bool), <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error>
+  where
+    W: Window,
+  {
+    let mut terminal = false;
+    let mut in_cache = in_cache;
+    let mut want = want;
+    #[cfg(debug_assertions)]
+    let initial_in_cache = in_cache;
+    #[cfg(debug_assertions)]
+    let exp = want;
+
+    // PEEK_FOOTPRINT — WHY THE OVERFLOW REGION LIVES IN `buf`.
+    //
+    // The two halves of a window are produced in the opposite order from the one it must
+    // report: the cache region is copied out in one bulk read *after* the fill, while the
+    // tokens past the cache are lexed *during* it. That ordering — not a shortage of room —
+    // is what a staging area exists to solve. It is solved here by staging those tokens at
+    // `buf`'s own tail and, once the cache region has been copied in behind them, rotating
+    // them back to the end (see after the loop).
+    //
+    // Staging in `buf` rather than in a second `W::CAPACITY`-slot array is what holds the peek
+    // frame to ONE window-sized store: `Token` and `State` are unconstrained in size, so a
+    // second one doubles a peek's stack for a grammar that carries a large payload. It is also
+    // why this function needs no partial-initialization bookkeeping: `buf` owns each staged
+    // entry from the moment it is pushed, so every exit path — success, a withheld frontier, a
+    // trip, or a failing return from a fatal emit — frees it exactly once through the deque's
+    // own `Drop`.
+    //
+    // The copy is NOT reorderable ahead of the loop. `Cache::peek` takes `&'p self` and the
+    // entries it appends borrow the cache for `'p`, the whole of the fill; the loop's every
+    // step (`lex_within_boundary`, `classify`, `emit_lexer_error_deduped`, `cache_append`)
+    // takes `&mut self`, and `cache_append` genuinely mutates the cache it would be aliasing.
+    //
+    // The staged region always fits. With `cap = buf.capacity()`, the fill is entered only with
+    // `want = cap - buf_len - parked - in_cache` (the `saturating_sub` above returns early at
+    // zero), and every token the loop produces decrements `want` and lands in either the cache
+    // (`in_cache += 1`) or the staged region. So at every point
+    // `buf_len + staged + parked + in_cache <= cap`, and the per-push assertion below pins the
+    // same bound locally. Note what that accounting reserves: the cache region's room as much
+    // as the staged region's, sized from `Cache::len()` before a single token is staged. A
+    // `Cache` whose `len` is not its resident count therefore mis-sizes the copy that comes
+    // after the loop — see CACHE_COPY there for the checks that refuse to rotate on one.
+    let mut staged = 0usize;
     // Set when a limit trip latches the input mid-scan: the staged overflow
     // tokens then become unreachable and must be truncated away (see below).
     let mut tripped = false;
@@ -271,10 +407,17 @@ where
           Verdict::Withheld(_) => break,
           Verdict::Trip(err) => {
             // A limit trip is sticky, and `classify` has already latched the durable frontier — so
-            // this (possibly fatal) emit cannot lose it: the `?` returns with the latch recorded for
-            // every later operation, and `overflowed`'s `Drop` frees any staged tokens on the way
-            // out.
-            self.emit_lexer_error_deduped(err)?;
+            // this (possibly fatal) emit cannot lose it: the failing return below carries the latch
+            // into every later operation.
+            if let Err(err) = self.emit_lexer_error_deduped(err) {
+              // Unstage before propagating. Nothing but the staged tokens has been pushed yet, so
+              // `buf` holds exactly `buf_len + staged` entries and truncating to `buf_len` drops
+              // each staged token exactly once (the deque owns them) and hands the caller's buffer
+              // back byte-for-byte as it arrived — the same observable the discarded staging
+              // buffer used to produce.
+              buf.truncate(buf_len);
+              return Err(err);
+            }
             tripped = true;
             break;
           }
@@ -282,8 +425,12 @@ where
             // Emit immediately regardless of cache fullness so an error in the
             // overflow region is never silently dropped. The dedup mark keeps a
             // later consume that re-lexes this region from reporting it twice.
-            // `overflowed`'s `Drop` frees any staged tokens on this `?`-return.
-            self.emit_lexer_error_deduped(err)?;
+            if let Err(err) = self.emit_lexer_error_deduped(err) {
+              // Unstage before propagating; see the `Trip` arm for why `buf_len` is the exact
+              // pre-fill length here.
+              buf.truncate(buf_len);
+              return Err(err);
+            }
           }
           Verdict::Token(tok) => {
             let cached = CachedToken::new(tok, lexer.state().clone());
@@ -294,8 +441,9 @@ where
                 in_cache += 1;
               }
               Err(ct) => {
-                // Cache full: stage the overflow token drop-safely.
-                overflowed.push(Maybe::Owned(ct));
+                // Cache full: stage the overflow token at the tail of the output buffer.
+                stage_overflow::<_, W::CAPACITY>(buf, Maybe::Owned(ct));
+                staged += 1;
               }
             }
             want -= 1;
@@ -307,9 +455,25 @@ where
     }
     *at_slot = lex_at;
 
+    if tripped {
+      // The fill was cut short by a fresh trip: report it terminal so a decision-window
+      // combinator surfaces the stop instead of reading the short window as a decline.
+      terminal = true;
+      // Truncate the result at the durability boundary. A limit trip latched the
+      // input mid-overflow, so a post-peek `next()` will drain the cache-resident
+      // prefix (copied in just below) and then stop — it can never re-lex the
+      // staged overflow tokens. Handing them back would expose phantom lookahead
+      // the caller can never consume, so drop them here instead. Nothing but the
+      // staged tokens has been pushed yet, so `buf_len` is the exact pre-fill
+      // length and the truncation frees each staged token exactly once. This
+      // covers a trip on the first overflow token (nothing staged) and a trip
+      // after several are staged alike.
+      buf.truncate(buf_len);
+      staged = 0;
+    }
+
     // Fill the buffer from the front of the stream (this covers a parked token, the cached ones,
     // and any this fill just added)
-    // SAFETY: Cache.peek() returns slice of initialized tokens, guaranteed by trait contract
     // The parked token is the front of the stream, so it heads the window and the cache fills in
     // behind it. Safe unguarded because every caller of this fill passes a buffer with room for at
     // least one entry.
@@ -318,50 +482,209 @@ where
         buf.push_back(Maybe::Ref(parked.as_ref()));
       }
     }
-    self.cache.peek::<W>(buf);
     debug_assert!(
-      buf_len + parked + in_cache == buf.len(),
-      "Cache peek returned unexpected number of tokens"
+      buf.len() == buf_len + staged + parked,
+      "the fill pushed something it did not account for before the cache copy"
     );
 
-    if tripped {
-      // The fill was cut short by a fresh trip: report it terminal so a decision-window
-      // combinator surfaces the stop instead of reading the short window as a decline.
-      *terminal = true;
-      // Truncate the result at the durability boundary. A limit trip latched the
-      // input mid-overflow, so a post-peek `next()` will drain the cache-resident
-      // prefix (already copied into `buf` above) and then stop — it can never
-      // re-lex the staged overflow tokens. Handing them back would expose phantom
-      // lookahead the caller can never consume, so drop them here instead. The
-      // `Overflow` guard frees each staged token exactly once on this early
-      // return; the `drain_into` hand-off below is skipped, so there is no
-      // double-drop. This covers a trip on the first overflow token (nothing
-      // staged) and a trip after several are staged alike.
-      drop(overflowed);
-      return Ok(self.session.emitter);
+    if staged == 0 {
+      // PEEK_HOT_SPLIT — NOTHING OVERFLOWED, which is what a fill that fits the cache always
+      // looks like, and what a trip leaves behind after the truncation above. `buf` holds
+      // exactly what it held here before the reordering — the caller's prefix and the parked
+      // token — so this exit *is* the one 0.8.0 shipped: nothing to rotate, and no CACHE_COPY
+      // hazard, because a copy with nothing behind it can shorten the window but cannot hole
+      // it (the same reason the two arms above are unchecked).
+      //
+      // Its own arm rather than a fold into the general one, and the difference is not
+      // cosmetic: with `staged` a runtime value the room this copy is given stops being a
+      // constant, which is enough to cost the copy its specialization. Six peek-shaped bench
+      // ids — the dispatch family, which drains as it goes and so reaches this fill on every
+      // token — paid 1.11×–1.31× for exactly that, with the checks removed entirely.
+      self.cache.peek::<W>(buf);
+      #[cfg(debug_assertions)]
+      {
+        debug_assert!(
+          buf.len() == buf_len + parked + in_cache,
+          "buffer length mismatch after the cache copy"
+        );
+        if want == 0 {
+          debug_assert!(
+            exp == in_cache - initial_in_cache,
+            "expected peeked token count mismatch"
+          );
+        }
+      }
+      return Ok((self.session.emitter, terminal));
     }
 
-    #[cfg(debug_assertions)]
-    let yielded = overflowed.len();
-    // Move the staged overflow tokens into the output buffer; `drain_into`
-    // disarms the guard so nothing is double-dropped.
-    overflowed.drain_into(buf);
+    let cache_copy_at = buf.len();
+    self.cache.peek::<W>(buf);
+    Self::assert_cache_copy::<W>(self.cache, buf, cache_copy_at, in_cache, staged);
+
+    // Restore stream order. The staged tokens were appended *before* the front-of-stream
+    // region, so the region this fill owns currently reads `[staged…][parked?][cache…]` where
+    // the window must read `[parked?][cache…][staged…]`. One left-rotation by `staged` over
+    // that region (`buf_len..`) is exactly that permutation, and it permutes values inside the
+    // deque — nothing is copied out, so no entry can be leaked or dropped twice. Entries the
+    // caller passed in (`..buf_len`) are excluded, so a prefilled buffer keeps its order too.
+    buf.make_contiguous()[buf_len..].rotate_left(staged);
 
     #[cfg(debug_assertions)]
     {
       debug_assert!(
-        buf.len() == buf_len + parked + in_cache + yielded,
-        "buffer length mismatch after adding overflowed tokens"
+        buf.len() == buf_len + parked + in_cache + staged,
+        "buffer length mismatch after the cache copy and the staged region"
       );
       if want == 0 {
         debug_assert!(
-          exp == (in_cache - initial_in_cache) + yielded,
+          exp == (in_cache - initial_in_cache) + staged,
           "expected peeked token count mismatch"
         );
       }
     }
 
-    Ok(self.session.emitter)
+    Ok((self.session.emitter, terminal))
+  }
+
+  /// CACHE_COPY — the window invariant on the one exit that reorders, checked there and
+  /// nowhere else.
+  ///
+  /// # The invariant
+  ///
+  /// > A peek window is a **contiguous prefix of the token stream at the cursor**. On the fill
+  /// > exit the cache region is not the window's tail — the staged region is rotated in behind
+  /// > it — so that region must be the cache's **whole resident run**, `front` through `back`.
+  /// > A capacity clip is not licensed here and cannot happen on a conforming cache: by the
+  /// > fill's own arithmetic the room left for the copy is `in_cache + want_unspent`, which is
+  /// > never below `in_cache`.
+  ///
+  /// # Why a caller-facing check exists at all, and only here
+  ///
+  /// [`Cache::len`](crate::cache::Cache::len) is load-bearing on this path: the fill reserves the
+  /// window's cache region from it *before* it stages anything, spends the rest of the window on
+  /// tokens lexed past the cache, and only then calls [`Cache::peek`](crate::cache::Cache::peek)
+  /// into the room that is left. A `len` that is not the resident count mis-sizes that copy, and
+  /// the two directions fail differently:
+  ///
+  /// - an **under-report** clips the copy mid-run, and the rotation then closes the gap with
+  ///   staged tokens that belong *after* the residents the clip dropped — not a short window, a
+  ///   **HOLE**: the window reports a token at a position where the next consume serves a
+  ///   different one. This failure is **created by the reordering** and is the reason this
+  ///   function exists;
+  /// - an **over-report** makes the fill reserve slots for residents that are not there and lex
+  ///   too few tokens for them, so the window comes back **SHORT** while the input still has
+  ///   more. That one is not new — it is what an over-reporting cache did before the reordering
+  ///   too — but the count below sees it for free.
+  ///
+  /// The two early exits of the fill (the cache hit and the latched boundary) append nothing
+  /// behind the copy, so neither can hole and neither is checked: they behave exactly as they
+  /// did before the reordering, and adding a check there would put its cost on the width-1 head
+  /// read a grammar runs per token.
+  ///
+  /// # Why the guards are shaped the way they are
+  ///
+  /// Every quantity a check is *gated* on is one the **fill** computes — `at`, `copied`,
+  /// `staged` — never one the cache reports. `reserved` is a cache-derived value and appears
+  /// only on the *expected* side of a comparison, where a lie shows up as a mismatch; it never
+  /// decides whether a comparison runs. That is not a style preference, it is the correction of
+  /// a real defect: an earlier revision of this check gated the endpoint witness on
+  /// `reserved > 0`, and a cache under-reporting all the way to **zero** skipped the witness by
+  /// that precondition while passing the count trivially as `0 == 0` — blindest exactly where
+  /// the lie was largest. A precondition is an escape hatch unless it is itself verified.
+  ///
+  /// # The two halves, both in every build
+  ///
+  /// **THE COUNT** is a compare in every build. It catches the over-report direction outright,
+  /// and it catches every under-report except the one that lands exactly on the window's edge.
+  ///
+  /// **THE ENDPOINTS** — the resident run's own witness, read from `front`/`back` rather than
+  /// from `len`, so an inexact `len` cannot both cause the fault and hide it — is in every build
+  /// too. It has to be, because it is the ONLY check that can see the two cases the count cannot:
+  /// a clip whose `copied` happens to equal the reserved count, and an under-report all the way
+  /// to zero, which satisfies the count trivially as `0 == 0`. Both of those are the **hole**, and
+  /// a release build is where a downstream `Cache` runs.
+  ///
+  /// It was a `debug_assert!` for one release, on an instruction count that read the comparison —
+  /// two ring indexes, a `Maybe` discriminant, an `Option<&Span>` compare — at 67–70 instructions
+  /// retired per cache-miss fill. **That reasoning is retracted, and the retraction is measured.**
+  /// The instruction count was never the price: the six peek-shaped bench ids read **0.9987**
+  /// geometric mean with this witness release-active, every id inside 0.974×–1.009×, over ten
+  /// interleaved criterion rounds on aarch64-apple-darwin.
+  ///
+  /// What the promotion *did* cost, before `#[inline(never)]` below, was the same thing
+  /// PEEK_HOT_SPLIT found: the witness's code sitting in
+  /// [`peek_lex_fill`](Self::peek_lex_fill)'s body — past the
+  /// overflow-free `return`, never executed by it — moved `input/scan/peek1_then_next` by
+  /// **1.025×**, consistently and outside the noise. Out of line it reads **1.003×**. An
+  /// instruction count answers "what does this code cost where it runs"; the question that
+  /// decides a hot path is "what does its presence cost the arm that skips it", and only a
+  /// measurement answers that one.
+  ///
+  /// # Parameters
+  ///
+  /// - `at` — where the copy began: `buf.len()` immediately before `Cache::peek`.
+  /// - `reserved` — the resident count the fill believes the cache has: `Cache::len()` read
+  ///   before the fill, plus every token the fill then appended. Untrusted.
+  /// - `staged` — how many tokens are waiting to be rotated in behind the copy, and the whole
+  ///   reason this function is called: the fill reaches it only where `staged > 0`, because
+  ///   that is exactly where a clipped copy becomes a hole rather than a short tail. Reported
+  ///   in the message; not read as a gate, since the gate is the call site.
+  ///
+  /// # Panics
+  ///
+  /// On a `Cache` that breaks the contract above, in **every build**, on either half — the
+  /// posture [`InputRef::park`](super::InputRef) takes for a `RETAINS_FRONT` refusal and
+  /// [`Sink::cst_start`](crate::cst::Sink::cst_start) takes for a node kind. The violation is in
+  /// caller-supplied trait code, no caller can repair its own `Cache` mid-parse, and the
+  /// alternative to failing here is handing back a window that is wrong about the stream. A
+  /// recoverable error is not on offer and would not be right if it were: the peek surface
+  /// returns the *emitter's* error type, so a broken `Cache` would reach the grammar disguised
+  /// as a diagnostic about the input.
+  ///
+  /// `#[inline(never)]` is the measurement above, and both messages stay in their own `#[cold]`
+  /// free functions on top of it: this body is generic, so it is one copy per monomorphization,
+  /// while [`cache_copy_count_violation`] and [`cache_copy_endpoint_violation`] are one copy
+  /// crate-wide — and PEEK_FOOTPRINT is a frame-size law that a callee's frame counts against as
+  /// surely as the fill's own.
+  #[inline(never)]
+  fn assert_cache_copy<W>(
+    cache: &Ctx::Cache,
+    buf: &Peeked<'_, 'inp, L, W>,
+    at: usize,
+    reserved: usize,
+    staged: usize,
+  ) where
+    W: Window,
+  {
+    use crate::cache::PeekedTokenExt as _;
+
+    let copied = buf.len() - at;
+
+    // THE COUNT. The fill left the copy `reserved + want_unspent` slots of room and
+    // `Cache::peek`'s own law owes it `min(len(), room)` entries; with `len() == reserved` and
+    // `room >= reserved` that is `reserved` exactly, so anything else is the cache disagreeing
+    // with the count the fill sized the window from. One compare and a never-taken branch
+    // here; the message is built in [`cache_copy_count_violation`], which is where its frame
+    // belongs.
+    if copied != reserved {
+      cache_copy_count_violation(reserved, copied);
+    }
+
+    // THE ENDPOINTS. This function is reached only from the exit that rotates, which the fill
+    // takes only with `staged > 0` — the one configuration where a clipped copy holes the window
+    // rather than shortening it. An overflow-free fill (and a trip, which truncates the staged
+    // region away) returns before it, unchecked, exactly as the two resident-head arms do.
+    let front = cache.front_span().map(Span::start_ref);
+    let whole_run = if copied == 0 {
+      // Nothing came back. Sound only if there was nothing to bring.
+      front.is_none()
+    } else {
+      front == Some(buf[at].span().start_ref())
+        && cache.back_span().map(Span::end_ref) == Some(buf[buf.len() - 1].span().end_ref())
+    };
+    if !whole_run {
+      cache_copy_endpoint_violation(copied, staged);
+    }
   }
 
   /// Width-1 head observation in grammar vocabulary, terminal-aware by construction.

--- a/tokora/src/input/input_ref/peek/tests.rs
+++ b/tokora/src/input/input_ref/peek/tests.rs
@@ -474,31 +474,100 @@ fn peek_overflow_stop_records_lexer_error() {
 // ── Fatal overflow peek must not leak staged tokens ───────────────────────────
 //
 // When a peek window exceeds the cache capacity, tokens past the cache are staged
-// in an inline overflow buffer until the cache region is copied out. If a fatal
-// lexer error is emitted while tokens are staged, the `?`-return must still drop
-// every staged token (and its state) exactly once — never leak them. A
+// at the tail of the output buffer until the cache region is copied in ahead of
+// them. If a fatal lexer error is emitted while tokens are staged, the `?`-return
+// must still drop every staged token (and its state) exactly once — never leak them
+// — and hand the buffer back holding nothing it did not arrive with. A
 // drop-counting token payload makes any leak observable.
 
-use core::sync::atomic::{AtomicUsize, Ordering};
+/// The liveness ledger the drop-safety cells below count into.
+///
+/// One per *scenario*, never a global. Rust runs tests in parallel by default, so a
+/// counter shared between cells makes every delta assertion depend on whatever else
+/// happens to be running: with these numbers held in global atomics, the ordinary
+/// `cargo test overflow_peek` invocation failed 184 runs out of 200, and a flaky
+/// leak test is the one people eventually delete. Each cell instead builds its own
+/// ledger, hands it to the lexer as state, and reads back only what its own probes
+/// wrote.
+///
+/// `Cell` rather than an atomic on purpose: a ledger never leaves the thread of the
+/// test that made it, and choosing the non-`Sync` type is what keeps that true by
+/// construction rather than by convention.
+#[derive(Debug, Default)]
+struct Ledger {
+  creates: core::cell::Cell<usize>,
+  drops: core::cell::Cell<usize>,
+}
 
-static STAGED_DROPS: AtomicUsize = AtomicUsize::new(0);
+impl Ledger {
+  /// Payloads created against this ledger and not yet freed.
+  fn live(&self) -> usize {
+    self.creates.get() - self.drops.get()
+  }
 
-/// A token payload that counts its own drops, so a leaked staged token is
-/// observable as a missing drop.
+  fn created(&self) -> usize {
+    self.creates.get()
+  }
+
+  fn dropped(&self) -> usize {
+    self.drops.get()
+  }
+
+  fn record_create(&self) {
+    self.creates.set(self.creates.get() + 1);
+  }
+
+  fn record_drop(&self) {
+    self.drops.set(self.drops.get() + 1);
+  }
+}
+
+/// A token payload that counts its own drops into its scenario's ledger, so a
+/// leaked staged token is observable as a missing drop.
 #[derive(Debug, Clone)]
-struct DropProbe;
+struct DropProbe {
+  ledger: std::rc::Rc<Ledger>,
+}
 
 impl Drop for DropProbe {
   fn drop(&mut self) {
-    STAGED_DROPS.fetch_add(1, Ordering::SeqCst);
+    self.ledger.record_drop();
+  }
+}
+
+/// The `DropTok` lexer state: nothing but the scenario's ledger, which is how the
+/// payload callback reaches it without a global.
+#[derive(Debug, Clone, Default)]
+struct DropLedger(std::rc::Rc<Ledger>);
+
+impl DropLedger {
+  fn ledger(&self) -> std::rc::Rc<Ledger> {
+    std::rc::Rc::clone(&self.0)
+  }
+
+  fn probe(&self) -> DropProbe {
+    DropProbe {
+      ledger: self.ledger(),
+    }
+  }
+}
+
+impl crate::state::State for DropLedger {
+  type Error = ();
+
+  fn check(&self) -> Result<(), Self::Error> {
+    Ok(())
   }
 }
 
 #[derive(Debug, Clone, crate::logos::Logos)]
-#[logos(crate = crate::logos, skip r"[ \t\r\n]+")]
+#[logos(crate = crate::logos, extras = DropLedger, skip r"[ \t\r\n]+")]
 enum DropTok {
-  #[regex(r"[0-9]+", |_| DropProbe)]
-  Num(DropProbe),
+  // Never *read*: the payload is observed through its destructor, which is the whole
+  // of what this cell measures. (While it was a ZST the dead-code lint exempted it
+  // as a positional field; carrying a ledger handle makes it a real value.)
+  #[regex(r"[0-9]+", |lex| lex.extras.probe())]
+  Num(#[allow(dead_code)] DropProbe),
 }
 
 impl core::fmt::Display for DropTok {
@@ -582,12 +651,16 @@ fn fatal_overflow_peek_drops_staged_tokens_no_leak() {
   // `?`-returns while 4 and 5 are still staged.
   use generic_arraydeque::typenum::U6;
 
-  let baseline = STAGED_DROPS.load(Ordering::SeqCst);
+  // Each phase gets its own ledger, threaded in as the lexer state: phase 1's input
+  // is still holding its three cache-resident tokens while phase 2 runs, and no
+  // concurrently scheduled cell can reach either counter.
+  let state = DropLedger::default();
+  let ledger = state.ledger();
 
   let cache = crate::cache::DefaultCache::<'_, DropLexer<'_>>::default();
   let mut input = crate::input::Input::<DropLexer<'_>, DropCtx<'_>, ()>::with_state_and_context(
     "1 2 3 4 5 @",
-    (),
+    state,
     crate::input::InputContext::new(FatalOnLexError, cache),
   );
   let mut inp = input.as_ref();
@@ -595,38 +668,68 @@ fn fatal_overflow_peek_drops_staged_tokens_no_leak() {
   let result = inp.peek::<U6>().map(|_| ());
   assert_eq!(result, Err(Boom), "the fatal lexer error must propagate");
 
-  let staged_dropped = STAGED_DROPS.load(Ordering::SeqCst) - baseline;
   assert_eq!(
-    staged_dropped, 2,
+    ledger.dropped(),
+    2,
     "both staged overflow tokens must be dropped exactly once on the fatal return (no leak)"
+  );
+
+  // The same scan again, taken on the fill directly so the buffer it was handed is
+  // still readable afterwards. Staging now happens *in* that buffer, so the
+  // `?`-return has to unstage before propagating: a caller that reuses its buffer
+  // must not find two tokens in it that the peek never promised.
+  let state = DropLedger::default();
+  let phase2 = state.ledger();
+
+  let cache = crate::cache::DefaultCache::<'_, DropLexer<'_>>::default();
+  let mut input = crate::input::Input::<DropLexer<'_>, DropCtx<'_>, ()>::with_state_and_context(
+    "1 2 3 4 5 @",
+    state,
+    crate::input::InputContext::new(FatalOnLexError, cache),
+  );
+  let mut inp = input.as_ref();
+
+  let mut buf = crate::cache::Peeked::<'_, '_, DropLexer<'_>, U6>::new();
+  let outcome = inp
+    .peek_with_emitter_inner::<U6>(&mut buf, &mut false)
+    .map(|_| ());
+  assert_eq!(outcome, Err(Boom), "the fatal lexer error must propagate");
+  assert!(
+    buf.is_empty(),
+    "a failing fill must hand the caller's buffer back exactly as it received it, not \
+     holding the tokens it staged in it"
+  );
+  assert_eq!(
+    phase2.dropped(),
+    2,
+    "unstaging on the fatal return frees each staged token exactly once"
   );
 }
 
 // ── A limit trip mid-overflow must truncate the peek at the durability boundary ──
 //
-// When a peek window exceeds the cache, tokens past the cache are staged in the
-// inline overflow buffer. A staged token is durable only because a later
+// When a peek window exceeds the cache, tokens past the cache are staged at the
+// tail of the output buffer. A staged token is durable only because a later
 // `next()` re-lexes and regenerates it — but a limit trip mid-overflow latches
 // the input, so `next()` will drain the cache-resident prefix and then stop,
 // never re-lexing the staged tokens. Returning them would expose PHANTOM
 // lookahead the caller can never consume. The peek must therefore truncate its
-// result to the cache-resident prefix and drop the staged overflow tokens (freed
-// exactly once by the `Overflow` guard — no double-drop with the `drain_into`
-// hand-off, which is skipped on the trip).
+// result to the cache-resident prefix, dropping the staged region before the
+// cache region is copied in — the deque owns those entries, so they are freed
+// exactly once and cannot be handed out as well.
 //
-// `LimitProbe` counts its own creations and drops so a leaked or double-dropped
-// staged token is observable as `creates != drops`.
-
-static LIMIT_CREATES: AtomicUsize = AtomicUsize::new(0);
-static LIMIT_DROPS: AtomicUsize = AtomicUsize::new(0);
+// `LimitProbe` counts its own creations and drops into its scenario's `Ledger`, so a
+// leaked or double-dropped staged token is observable as `creates != drops`.
 
 #[derive(Debug)]
-struct LimitProbe;
+struct LimitProbe {
+  ledger: std::rc::Rc<Ledger>,
+}
 
 impl LimitProbe {
-  fn new() -> Self {
-    LIMIT_CREATES.fetch_add(1, Ordering::SeqCst);
-    LimitProbe
+  fn new(ledger: std::rc::Rc<Ledger>) -> Self {
+    ledger.record_create();
+    LimitProbe { ledger }
   }
 }
 
@@ -634,23 +737,24 @@ impl Clone for LimitProbe {
   fn clone(&self) -> Self {
     // Count a clone as a creation so `creates == drops` stays exact even if the
     // framework ever clones a token payload (it does not on this path).
-    LIMIT_CREATES.fetch_add(1, Ordering::SeqCst);
-    LimitProbe
+    Self::new(std::rc::Rc::clone(&self.ledger))
   }
 }
 
 impl Drop for LimitProbe {
   fn drop(&mut self) {
-    LIMIT_DROPS.fetch_add(1, Ordering::SeqCst);
+    self.ledger.record_drop();
   }
 }
 
-/// A limiter whose scan counter is shared across every cloned lexer, so the
-/// `check()` trip point is deterministic regardless of `InputRef` rebuilding a
-/// fresh lexer per operation.
+/// A limiter whose scan counter and liveness ledger are shared across every cloned
+/// lexer, so the `check()` trip point is deterministic regardless of `InputRef`
+/// rebuilding a fresh lexer per operation, and so every payload a scenario lexes
+/// lands in that scenario's own ledger.
 #[derive(Debug, Clone, Default)]
 struct TripLimiter {
   scanned: std::rc::Rc<core::cell::Cell<usize>>,
+  ledger: std::rc::Rc<Ledger>,
   limit: usize,
 }
 
@@ -658,12 +762,22 @@ impl TripLimiter {
   fn with_limit(limit: usize) -> Self {
     Self {
       scanned: std::rc::Rc::new(core::cell::Cell::new(0)),
+      ledger: std::rc::Rc::new(Ledger::default()),
       limit,
     }
   }
 
+  /// A handle on this limiter's ledger, for the cell that built it to read back.
+  fn ledger(&self) -> std::rc::Rc<Ledger> {
+    std::rc::Rc::clone(&self.ledger)
+  }
+
   fn increase(&self) {
     self.scanned.set(self.scanned.get() + 1);
+  }
+
+  fn probe(&self) -> LimitProbe {
+    LimitProbe::new(self.ledger())
   }
 }
 
@@ -703,8 +817,9 @@ impl From<TripLimitExceeded> for TripErr {
 #[derive(Debug, Clone, crate::logos::Logos)]
 #[logos(crate = crate::logos, extras = TripLimiter, skip r"[ \t\r\n]+")]
 enum TripTok {
-  #[regex(r"[0-9]+", |lex| { lex.extras.increase(); LimitProbe::new() })]
-  Num(LimitProbe),
+  // As with `DropTok`: observed through its destructor, never read.
+  #[regex(r"[0-9]+", |lex| { lex.extras.increase(); lex.extras.probe() })]
+  Num(#[allow(dead_code)] LimitProbe),
 }
 
 impl core::fmt::Display for TripTok {
@@ -748,22 +863,27 @@ type TripCtx<'a> = (
 /// been staged. Asserts (a) the peek window equals the 3 cache-resident tokens
 /// (staged phantoms excluded); (b) exactly 3 survivors remain live after the
 /// peek (every staged token + the trip token dropped); (c) `next()` drains
-/// exactly those 3 then `None` (no rescan past the latch).
+/// exactly those 3 then `None` (no rescan past the latch); (d) once the input is
+/// gone, every payload the scenario lexed was freed exactly once.
+///
+/// The limiter carries this scenario's own ledger, so the liveness numbers below
+/// count nothing but the tokens this call produced.
 fn assert_trip_truncates<W>(src: &'static str, limit: usize, staged: usize)
 where
   W: crate::Window,
 {
-  let live = || LIMIT_CREATES.load(Ordering::SeqCst) - LIMIT_DROPS.load(Ordering::SeqCst);
+  let limiter = TripLimiter::with_limit(limit);
+  let ledger = limiter.ledger();
 
   let cache = crate::cache::DefaultCache::<'_, TripLexer<'_>>::default();
   let mut input = crate::input::Input::<TripLexer<'_>, TripCtx<'_>, ()>::with_state_and_context(
     src,
-    TripLimiter::with_limit(limit),
+    limiter,
     crate::input::InputContext::new(crate::emitter::Silent::<TripErr>::new(), cache),
   );
   let mut inp = input.as_ref();
 
-  let alive_before = live();
+  assert_eq!(ledger.live(), 0, "the scenario starts with nothing lexed");
   {
     // (a) The returned window is truncated to the cache-resident prefix — the
     // `staged` overflow phantoms are excluded.
@@ -779,7 +899,7 @@ where
   // overflow token AND the trip token have been dropped exactly once — a leak
   // would leave more alive, a double-drop fewer.
   assert_eq!(
-    live() - alive_before,
+    ledger.live(),
     3,
     "only the 3 cache-resident tokens may survive the truncating peek"
   );
@@ -790,14 +910,22 @@ where
   assert!(inp.next().unwrap().is_some(), "cache token 3");
   assert!(inp.next().unwrap().is_none(), "poisoned: no phantom 4");
   assert!(inp.next().unwrap().is_none(), "poisoned: stays None");
+
+  drop(inp);
+  drop(input);
+
+  // (d) Every token payload this scenario created was dropped exactly once:
+  // no leak (drops < creates) and no double-drop (drops > creates).
+  assert_eq!(
+    ledger.created(),
+    ledger.dropped(),
+    "every staged/cached/trip token freed exactly once (no leak, no double-drop)"
+  );
 }
 
 #[test]
 fn overflow_peek_trip_truncates_phantom_tokens() {
   use generic_arraydeque::typenum::{U4, U5, U6};
-
-  let creates_before = LIMIT_CREATES.load(Ordering::SeqCst);
-  let drops_before = LIMIT_DROPS.load(Ordering::SeqCst);
 
   // Trip mid-overflow with SEVERAL staged: 1..=3 cached, 4 & 5 staged, 6 trips.
   assert_trip_truncates::<U6>("1 2 3 4 5 6", 5, 2);
@@ -805,15 +933,6 @@ fn overflow_peek_trip_truncates_phantom_tokens() {
   assert_trip_truncates::<U5>("1 2 3 4 5", 4, 1);
   // Trip with ZERO staged: 1..=3 fill the cache, the next scan (4) trips.
   assert_trip_truncates::<U4>("1 2 3 4", 3, 0);
-
-  // Every token payload created across all scenarios was dropped exactly once:
-  // no leak (drops < creates) and no double-drop (drops > creates).
-  let creates = LIMIT_CREATES.load(Ordering::SeqCst) - creates_before;
-  let drops = LIMIT_DROPS.load(Ordering::SeqCst) - drops_before;
-  assert_eq!(
-    creates, drops,
-    "every staged/cached/trip token freed exactly once (no leak, no double-drop)"
-  );
 }
 
 // The discrimination the decision-window combinators (`peek_then`, `peek_then_choice`, the
@@ -854,4 +973,825 @@ fn peek_with_emitter_terminal_flags_a_trip_but_not_eof() {
     (3, false),
     "a full window is not terminal"
   );
+}
+
+// ── Stream order across the cache/overflow boundary ───────────────────────────
+//
+// A peek wider than the cache produces its two regions in the OPPOSITE order from
+// the one the window must report: the tokens past the cache are lexed (and staged)
+// first, while the cache region is copied out afterwards in one bulk read. The fill
+// stages the overflow region at the tail of the output buffer and rotates the
+// front-of-stream region ahead of it; these cells pin the resulting order. They are
+// new coverage, not a pin of prior behaviour: before this change nothing asserted
+// the identity of a peeked token past the cache boundary — the overflow tests
+// checked only `len()` — so removing the rotation leaves every pre-existing peek
+// test green and turns these red.
+
+/// The spans a `W`-wide peek reports, in window order.
+fn peeked_spans<W>(src: &str) -> std::vec::Vec<crate::span::SimpleSpan>
+where
+  W: crate::Window,
+{
+  use crate::cache::PeekedTokenExt as _;
+  parse_with(src, |inp| {
+    let peeked = inp.peek::<W>()?;
+    Ok(peeked.iter().map(|t| *t.span()).collect())
+  })
+  .unwrap()
+}
+
+/// Whether each slot of a `W`-wide peek came back owned (staged past the cache)
+/// rather than borrowed from the cache, in window order.
+fn peeked_arms<W>(src: &str) -> std::vec::Vec<bool>
+where
+  W: crate::Window,
+{
+  parse_with(src, |inp| {
+    let peeked = inp.peek::<W>()?;
+    Ok(peeked.iter().map(|t| t.is_owned()).collect())
+  })
+  .unwrap()
+}
+
+#[test]
+fn peek_reports_stream_order_across_the_cache_boundary() {
+  use crate::span::SimpleSpan;
+  use generic_arraydeque::typenum::U6;
+
+  // Six one-character tokens at known offsets. The default cache holds three, so
+  // the window is `[cache: a b c][staged: d e f]` — and the staged half was lexed
+  // before the cached half was read out. A window that handed the staged region
+  // back first would report 6, 8, 10, 0, 2, 4.
+  assert_eq!(
+    peeked_spans::<U6>("a b c d e f"),
+    std::vec![
+      SimpleSpan::new(0, 1),
+      SimpleSpan::new(2, 3),
+      SimpleSpan::new(4, 5),
+      SimpleSpan::new(6, 7),
+      SimpleSpan::new(8, 9),
+      SimpleSpan::new(10, 11),
+    ],
+    "the window must read in stream order across the cache/overflow boundary"
+  );
+  // And the split lands exactly at the cache capacity: three borrowed, three owned.
+  assert_eq!(
+    peeked_arms::<U6>("a b c d e f"),
+    std::vec![false, false, false, true, true, true],
+    "the borrowed cache region heads the window and the owned staged region tails it"
+  );
+}
+
+#[test]
+fn peek_reports_stream_order_with_a_single_staged_token() {
+  use crate::span::SimpleSpan;
+  use generic_arraydeque::typenum::U4;
+
+  // The smallest overflow: one staged token behind a full cache. A rotation off by
+  // one in either direction is visible here and nowhere else.
+  assert_eq!(
+    peeked_spans::<U4>("a b c d"),
+    std::vec![
+      SimpleSpan::new(0, 1),
+      SimpleSpan::new(2, 3),
+      SimpleSpan::new(4, 5),
+      SimpleSpan::new(6, 7),
+    ]
+  );
+  assert_eq!(
+    peeked_arms::<U4>("a b c d"),
+    std::vec![false, false, false, true]
+  );
+}
+
+#[test]
+fn peek_reports_stream_order_with_a_prefilled_cache() {
+  use crate::cache::PeekedTokenExt as _;
+  use crate::span::SimpleSpan;
+  use generic_arraydeque::typenum::{U2, U5};
+
+  // A narrow peek first, so the cache is already partly full when the wide peek
+  // runs: the wide fill then appends to a non-empty cache before it starts staging,
+  // which moves the boundary the rotation has to respect.
+  let spans = parse_with("a b c d e", |inp| {
+    {
+      let warm = inp.peek::<U2>()?;
+      assert_eq!(warm.len(), 2, "the warm-up peek seeds the cache");
+    }
+    let peeked = inp.peek::<U5>()?;
+    Ok(
+      peeked
+        .iter()
+        .map(|t| (*t.span(), t.is_owned()))
+        .collect::<std::vec::Vec<_>>(),
+    )
+  })
+  .unwrap();
+
+  assert_eq!(
+    spans,
+    std::vec![
+      (SimpleSpan::new(0, 1), false),
+      (SimpleSpan::new(2, 3), false),
+      (SimpleSpan::new(4, 5), false),
+      (SimpleSpan::new(6, 7), true),
+      (SimpleSpan::new(8, 9), true),
+    ]
+  );
+}
+
+// ── The same order, over a cache that retains nothing ─────────────────────────
+//
+// `()` is the zero-capacity cache: every push refuses, so the whole window is
+// staged and the parked slot — statically dead under a retaining cache — is live.
+// It is the only built-in configuration where the front of the stream is NOT a
+// cache entry, so it is the only one that exercises `[staged…][parked]` rotating
+// to `[parked][staged…]`.
+
+type UnitCacheCtx = (crate::emitter::Silent<()>, ());
+
+fn with_unit_cache<'inp, F, O>(src: &'inp str, f: F) -> O
+where
+  F: FnOnce(&mut crate::input::InputRef<'inp, '_, TestLexer<'inp>, UnitCacheCtx, ()>) -> O,
+{
+  let mut input = crate::input::Input::<TestLexer<'inp>, UnitCacheCtx, ()>::with_state_and_context(
+    src,
+    (),
+    crate::input::InputContext::new(crate::emitter::Silent::<()>::new(), ()),
+  );
+  let mut inp = input.as_ref();
+  f(&mut inp)
+}
+
+#[test]
+fn peek_over_a_non_retaining_cache_reports_stream_order() {
+  use crate::cache::PeekedTokenExt as _;
+  use crate::span::SimpleSpan;
+  use generic_arraydeque::typenum::U3;
+
+  // No cache at all: all three window slots are staged. The rotation degenerates to
+  // a full-length rotate, which must be the identity.
+  let got = with_unit_cache("a b c", |inp| {
+    let peeked = inp.peek::<U3>().unwrap();
+    peeked
+      .iter()
+      .map(|t| (*t.span(), t.is_owned()))
+      .collect::<std::vec::Vec<_>>()
+  });
+  assert_eq!(
+    got,
+    std::vec![
+      (SimpleSpan::new(0, 1), true),
+      (SimpleSpan::new(2, 3), true),
+      (SimpleSpan::new(4, 5), true),
+    ],
+    "a fully staged window is already in stream order and must not be permuted"
+  );
+}
+
+#[test]
+fn peek_over_a_parked_front_reports_the_parked_token_first() {
+  use crate::cache::PeekedTokenExt as _;
+  use crate::span::SimpleSpan;
+  use generic_arraydeque::typenum::U3;
+
+  // `sync_to` stops before the first number and, with nothing able to retain it,
+  // parks it at the front of the stream. The peek that follows must head its window
+  // with that parked token and stage `2` and `3` behind it — the window is
+  // `[parked][staged][staged]`, assembled as `[staged][staged][parked]`.
+  let got = with_unit_cache("a b 1 2 3", |inp| {
+    use crate::Token as _;
+    // One statement, so the window this returns — which borrows `inp` — dies before
+    // the peek below reborrows it.
+    assert!(
+      inp
+        .sync_to(|t| t.data.kind() == TokKind::Num, || None)
+        .unwrap()
+        .is_some(),
+      "sync_to must stop on the first number"
+    );
+    let peeked = inp.peek::<U3>().unwrap();
+    peeked
+      .iter()
+      .map(|t| (*t.span(), t.is_owned()))
+      .collect::<std::vec::Vec<_>>()
+  });
+  assert_eq!(
+    got,
+    std::vec![
+      (SimpleSpan::new(4, 5), false),
+      (SimpleSpan::new(6, 7), true),
+      (SimpleSpan::new(8, 9), true),
+    ],
+    "the parked token is the front of the stream and must head the window"
+  );
+}
+
+// ── CACHE_COPY — a `Cache` that misreports `len()` ───────────────────────────
+//
+// The fill sizes the window's cache region from `Cache::len()` BEFORE it stages
+// anything: `want = room - parked - len()`. Staging then eats the tail of the buffer,
+// so by the time `Cache::peek` runs, the room left is exactly what `len()` claimed. On
+// the documented contract that is exactly enough. On a cache whose `len` is not its
+// resident count it is not, and the two directions fail differently:
+//
+//   * UNDER-report — `Cache::peek` is clipped mid-run. The window loses the residents
+//     the clip cut off but keeps the staged tokens that belong *after* them, so what
+//     comes back is not a short window, it is a HOLE: the caller reads a token at a
+//     position where a later `next()` serves a different one. THIS ONE IS CREATED BY
+//     THE REORDERING, and closing it is why `assert_cache_copy` exists.
+//   * OVER-report — the fill reserves slots for residents that are not there and lexes
+//     too few tokens to fill them. The window is a correct prefix but SHORT, which a
+//     caller is entitled to read as end of input while the input still has more. Not
+//     new — that is what an over-reporting cache did before the reordering too — but
+//     the count check sees it for free.
+//
+// The hole is the one no count can see. With residents `[a,b,c]`, `len()` reporting 2
+// and a `U4` window, the fill stages `d` and `e`, `Cache::peek` appends `[a,b]` into the
+// two slots left, and `copied == in_cache` holds exactly: 2 == 2. The count the fill
+// tracks and the count it observes agree *because* the under-report is subtracted from
+// one side and added back on the other. The window came back `[a,b,d,e]` for a stream
+// that reads `[a,b,c,d]`.
+//
+// What catches it is the resident run's own endpoints: a copy that is the whole run
+// starts at the cache's `front` and ends at its `back`. BOTH halves stay on in EVERY
+// build — the count and the endpoints alike — so the cells below are ungated and the
+// hole is refused in release, which is the only build where a downstream `Cache` runs
+// at speed. The endpoint witness was `debug_assert!` for one release; what changed is
+// the measurement, not the reasoning (see CACHE_COPY in `peek/mod.rs`).
+//
+// A release build is where these cells earn their keep, and it is also where a
+// `should_panic` can rot silently: a cell whose panic compiles out passes by never
+// running the code it names. `cargo test --release --all-features` runs them, and the
+// count cell below is the control — it was already ungated and already release-active,
+// so a red there is the harness rather than this change.
+
+/// The three directions the one lie can take. A `bool` covered the first two; the third —
+/// under-reporting all the way to **zero** — is not "under by one" with a bigger constant,
+/// it is the case where the *magnitude* of the lie determines whether the witness can see
+/// it at all, so it gets its own mode rather than a parameter on an existing one.
+///
+/// Chosen over a `bool` plus a second `bool`, over an enum, and over three separate cache
+/// types: const generics on this crate's MSRV take integers but not enums, two `bool`s make
+/// an unrepresentable fourth combination, and three types would triple a 90-line impl to
+/// vary one `match` arm.
+mod lie {
+  /// `len()` reports one **below** the resident count. The plausible off-by-one, and the
+  /// one that HOLES the window: the copy is clipped mid-run and the staged tokens behind
+  /// it close the gap.
+  pub(super) const UNDER_BY_ONE: u8 = 0;
+  /// `len()` reports one **above**. Shortens the window instead of holing it — the fill
+  /// reserves slots for residents that are not there and lexes too few tokens for them.
+  pub(super) const OVER_BY_ONE: u8 = 1;
+  /// `len()` reports **zero**, whatever is resident. The largest under-report there is,
+  /// and the blindest: it satisfies a count check as `0 == 0` and would skip any witness
+  /// whose precondition was written over the reported length.
+  pub(super) const UNDER_TO_ZERO: u8 = 2;
+}
+
+/// A capacity-3 ring whose `len()` misreports the resident count in one of the three
+/// [`lie`] directions, and whose every other operation, `peek` included, works on the real
+/// queue.
+///
+/// An empty cache still reports 0 under every mode, so a lie only shows once the cache is
+/// warm: the warm-up peek in each cell below is honest, and the peek under test is the one
+/// that reads a misreported length.
+///
+/// This is the plausible defect rather than a contrived one: an off-by-one — or a
+/// forgotten increment, which is the zero case — in a hand-rolled cache's length
+/// bookkeeping, in the one method the input layer sizes its window from. The crate's own
+/// conformance kit models the same class of lie (`conformance/cache_tests.rs`).
+struct MisreportingCache<'a, L, const LIE: u8>
+where
+  L: crate::Lexer<'a>,
+{
+  items: std::collections::VecDeque<crate::cache::CachedTokenOf<'a, L>>,
+}
+
+impl<'a, L, Lang: ?Sized, const LIE: u8> crate::cache::Cache<'a, L, Lang>
+  for MisreportingCache<'a, L, LIE>
+where
+  L: crate::Lexer<'a>,
+{
+  type Options = ();
+
+  // Retaining, so the parked slot is statically dead and these cells are about the cache
+  // copy alone.
+  const RETAINS_FRONT: bool = true;
+
+  fn new() -> Self {
+    Self {
+      items: std::collections::VecDeque::with_capacity(3),
+    }
+  }
+
+  fn with_options((): ()) -> Self {
+    <Self as crate::cache::Cache<'a, L, Lang>>::new()
+  }
+
+  /// THE LIE, and the only one.
+  fn len(&self) -> usize {
+    match self.items.len() {
+      0 => 0,
+      _ if LIE == lie::UNDER_TO_ZERO => 0,
+      n if LIE == lie::UNDER_BY_ONE => n - 1,
+      n => n + 1,
+    }
+  }
+
+  fn remaining(&self) -> usize {
+    3 - self.items.len()
+  }
+
+  fn push_front(
+    &mut self,
+    tok: crate::cache::CachedTokenOf<'a, L>,
+  ) -> Result<crate::cache::CachedTokenRefOf<'_, 'a, L>, crate::cache::CachedTokenOf<'a, L>> {
+    if self.items.len() == 3 {
+      return Err(tok);
+    }
+    self.items.push_front(tok);
+    Ok(self.items.front().expect("just pushed").as_ref())
+  }
+
+  fn push_back(
+    &mut self,
+    tok: crate::cache::CachedTokenOf<'a, L>,
+  ) -> Result<crate::cache::CachedTokenRefOf<'_, 'a, L>, crate::cache::CachedTokenOf<'a, L>> {
+    if self.items.len() == 3 {
+      return Err(tok);
+    }
+    self.items.push_back(tok);
+    Ok(self.items.back().expect("just pushed").as_ref())
+  }
+
+  fn pop_front(&mut self) -> Option<crate::cache::CachedTokenOf<'a, L>> {
+    self.items.pop_front()
+  }
+
+  fn pop_back(&mut self) -> Option<crate::cache::CachedTokenOf<'a, L>> {
+    self.items.pop_back()
+  }
+
+  fn clear(&mut self) {
+    self.items.clear();
+  }
+
+  fn peek<'p, W>(
+    &'p self,
+    buf: &mut generic_arraydeque::GenericArrayDeque<
+      crate::cache::MaybeRefCachedTokenOf<'p, 'a, L>,
+      W::CAPACITY,
+    >,
+  ) where
+    W: crate::Window,
+  {
+    // The real queue, oldest first, bounded by the room the buffer has left — the honest
+    // implementation of `peek`, which is what leaves the `len()` lie as the whole of the
+    // defect.
+    let fill = buf.remaining_capacity().min(self.items.len());
+    for tok in self.items.iter().take(fill) {
+      buf.push_back(mayber::Maybe::Ref(tok.as_ref()));
+    }
+  }
+
+  fn front(&self) -> Option<crate::cache::CachedTokenRefOf<'_, 'a, L>> {
+    self.items.front().map(crate::cache::CachedToken::as_ref)
+  }
+
+  fn back(&self) -> Option<crate::cache::CachedTokenRefOf<'_, 'a, L>> {
+    self.items.back().map(crate::cache::CachedToken::as_ref)
+  }
+}
+
+type MisreportingCtx<'a, const LIE: u8> = (
+  crate::emitter::Silent<()>,
+  MisreportingCache<'a, TestLexer<'a>, LIE>,
+);
+
+fn with_misreporting_cache<'inp, const LIE: u8, F, O>(src: &'inp str, f: F) -> O
+where
+  F: FnOnce(
+    &mut crate::input::InputRef<'inp, '_, TestLexer<'inp>, MisreportingCtx<'inp, LIE>, ()>,
+  ) -> O,
+{
+  let cache =
+    <MisreportingCache<'_, TestLexer<'_>, LIE> as crate::cache::Cache<'_, TestLexer<'_>, ()>>::new(
+    );
+  let mut input =
+    crate::input::Input::<TestLexer<'inp>, MisreportingCtx<'inp, LIE>, ()>::with_state_and_context(
+      src,
+      (),
+      crate::input::InputContext::new(crate::emitter::Silent::<()>::new(), cache),
+    );
+  let mut inp = input.as_ref();
+  f(&mut inp)
+}
+
+/// Release-active: the endpoint witness runs on the rotation path in every build, so this
+/// cell is ungated. The window it refuses is a HOLE, and a hole is exactly what a release
+/// build must not hand back.
+#[test]
+#[should_panic(expected = "did not copy the cache's whole resident run")]
+fn peek_over_an_under_reporting_cache_fails_fast_instead_of_holing_the_window() {
+  use generic_arraydeque::typenum::{U3, U4};
+
+  with_misreporting_cache::<{ lie::UNDER_BY_ONE }, _, _>("a b c d e", |inp| {
+    // Warm-up. The cache is empty, so `len()` tells the truth and the fill's own
+    // successful pushes carry the count: a, b and c go in and the window is right. This
+    // peek must NOT trip the check — the cell would prove nothing if the fixture failed
+    // before the call under test.
+    {
+      let warm = inp.peek::<U3>().expect("the warm-up peek must succeed");
+      assert_eq!(warm.len(), 3, "the warm-up peek seeds the cache");
+    }
+    // The call under test. `len()` now says 2 against 3 residents, so the fill reserves
+    // two slots for the cache and stages `d` and `e` into the other two; `Cache::peek` is
+    // then clipped after `[a, b]` and `c` falls out of the window. Without CACHE_COPY this
+    // returns `Ok` with the starts 0, 2, 6, 8 where the stream reads 0, 2, 4, 6 — and the
+    // count check cannot see it: the under-report is subtracted from `in_cache` and added
+    // straight back as `staged`, so `copied == in_cache` holds on both sides of the lie.
+    let _ = inp.peek::<U4>();
+  });
+}
+
+#[test]
+#[should_panic(expected = "and `Cache::peek` appended 3")]
+fn peek_over_an_over_reporting_cache_fails_fast_instead_of_shortening_the_window() {
+  use generic_arraydeque::typenum::{U3, U5};
+
+  with_misreporting_cache::<{ lie::OVER_BY_ONE }, _, _>("a b c d e", |inp| {
+    {
+      let warm = inp.peek::<U3>().expect("the warm-up peek must succeed");
+      assert_eq!(warm.len(), 3, "the warm-up peek seeds the cache");
+    }
+    // The other direction, and the half of CACHE_COPY a count CAN see — in every build.
+    // `len()` now says 4 against 3 residents, so the fill reserves four slots and lexes
+    // only one token past them; `Cache::peek` has room for four and appends three.
+    // Unchecked this returns a correct but four-long window from a five-slot request — a
+    // short window, which the peek contract lets a caller read as end of input.
+    let _ = inp.peek::<U5>();
+  });
+}
+
+/// Release-active for the same reason as the cell above, and this is the one that most
+/// needs to be: a count check reads `0 == 0` here and sees nothing at all, so before the
+/// promotion a release build had NO witness on the largest under-report there is.
+#[test]
+#[should_panic(expected = "did not copy the cache's whole resident run")]
+fn peek_over_a_cache_under_reporting_to_zero_fails_fast_instead_of_holing_the_window() {
+  use generic_arraydeque::typenum::{U2, U3};
+
+  with_misreporting_cache::<{ lie::UNDER_TO_ZERO }, _, _>("a b c d e", |inp| {
+    // Warm-up, honest: the cache is empty so 0 IS the resident count, and the fill's own
+    // three successful pushes carry `in_cache` up to 3. `a`, `b` and `c` go in.
+    {
+      let warm = inp.peek::<U3>().expect("the warm-up peek must succeed");
+      assert_eq!(warm.len(), 3, "the warm-up peek seeds the cache");
+    }
+    // The call under test. `len()` now says 0 against three residents, so the fill
+    // reserves NOTHING for the cache region and spends the whole two-slot window staging:
+    // `d` and `e` are lexed, refused by the full cache, and staged. `Cache::peek` then runs
+    // with zero room and appends zero entries.
+    //
+    // Every count in sight agrees: `copied == in_cache` is `0 == 0`. This is the case that
+    // decides the SHAPE of the endpoint witness — gate it on the reported length, as an
+    // earlier revision did, and the largest lie there is walks straight past it. It is
+    // gated on `staged`, which the fill counted, so it runs here.
+    //
+    // Unchecked this returns `Ok` with the starts 6, 8 — the window is `[d, e]` while the
+    // next consume serves `a` at 0, then `b`, `c`, `d`, `e`. Not a short window: three
+    // tokens of HOLE.
+    let _ = inp.peek::<U2>();
+  });
+}
+
+/// The cache-hit exit runs no CACHE_COPY check, and this cell is where that decision is
+/// written down.
+///
+/// The reordering this fix makes is confined to the fill path: the hit exit appends
+/// nothing behind its cache copy, so a copy the window's own capacity clipped is a correct
+/// short prefix there and cannot hole. Its one weakness — an over-reporting `len()`
+/// shortening the window, because `want` saturates to zero before the copy is sized — is
+/// **pre-existing and unchanged**, and checking it would put the check's cost on the
+/// width-1 head read a grammar runs per token. Both shapes below therefore return `Ok`,
+/// as they did before this change; the cell exists so that a future decision to check
+/// them is a deliberate one.
+#[test]
+fn peek_hit_exit_is_unchecked_and_unchanged_by_the_reordering() {
+  use crate::cache::PeekedTokenExt as _;
+  use generic_arraydeque::typenum::{U3, U4};
+
+  let starts = |peeked: &crate::cache::Peeked<'_, '_, TestLexer<'_>, U3>| {
+    peeked
+      .iter()
+      .map(|t| t.span().start())
+      .collect::<std::vec::Vec<_>>()
+  };
+
+  // (1) The LEGITIMATE clip: a `U3` request against a four-slot claim, so
+  // `min(len(), room)` is `min(4, 3)` and the three residents fill the window exactly. A
+  // copy that stops before `back` because the window ran out is correct.
+  let clipped = with_misreporting_cache::<{ lie::OVER_BY_ONE }, _, _>("a b c d e", |inp| {
+    {
+      let warm = inp.peek::<U3>().expect("the warm-up peek must succeed");
+      assert_eq!(warm.len(), 3, "the warm-up peek seeds the cache");
+    }
+    let peeked = inp
+      .peek::<U3>()
+      .expect("a copy the window's own capacity clipped is not a contract violation");
+    starts(&peeked)
+  });
+  assert_eq!(
+    clipped,
+    std::vec![0, 2, 4],
+    "the clipped copy must still be the window's correct prefix"
+  );
+
+  // (2) The over-report SHORTENING the window, unchecked here by design. `len()` says 4
+  // against three residents, so `want` saturates to zero at `4 - 4` and the fill returns
+  // through the hit exit without lexing at all; `Cache::peek` has room for four and
+  // appends the three that exist. A three-long window comes back from a four-slot request
+  // over an input that still holds `d` and `e`.
+  let shortened = with_misreporting_cache::<{ lie::OVER_BY_ONE }, _, _>("a b c d e", |inp| {
+    {
+      let warm = inp.peek::<U3>().expect("the warm-up peek must succeed");
+      assert_eq!(warm.len(), 3, "the warm-up peek seeds the cache");
+    }
+    let peeked = inp
+      .peek::<U4>()
+      .expect("the hit exit is not CACHE_COPY-checked");
+    peeked
+      .iter()
+      .map(|t| t.span().start())
+      .collect::<std::vec::Vec<_>>()
+  });
+  assert_eq!(
+    shortened,
+    std::vec![0, 2, 4],
+    "unchanged pre-existing behaviour: the hit exit hands back what the copy brought"
+  );
+}
+
+// ── A successful overflow peek frees each staged token exactly once ────────────
+//
+// The trip and fatal-emit cells above prove the discarding exits are clean. This is
+// the *keeping* exit: the staged tokens are handed to the caller inside the window,
+// permuted into place, and freed when the window drops. A permutation that copied
+// an entry instead of moving it would show up here as `drops > creates`; one that
+// dropped an entry on the floor as `drops < creates`.
+
+#[test]
+fn successful_overflow_peek_frees_every_staged_token_exactly_once() {
+  use crate::cache::PeekedTokenExt as _;
+  use generic_arraydeque::typenum::U6;
+
+  // A limit no scan can reach: this cell is about the keeping exit, not the trip.
+  // Its ledger is this cell's own, so the counts below see only its own tokens.
+  let limiter = TripLimiter::with_limit(usize::MAX);
+  let ledger = limiter.ledger();
+
+  let cache = crate::cache::DefaultCache::<'_, TripLexer<'_>>::default();
+  let mut input = crate::input::Input::<TripLexer<'_>, TripCtx<'_>, ()>::with_state_and_context(
+    "1 2 3 4 5 6",
+    limiter,
+    crate::input::InputContext::new(crate::emitter::Silent::<TripErr>::new(), cache),
+  );
+  let mut inp = input.as_ref();
+
+  assert_eq!(ledger.live(), 0, "the cell starts with nothing lexed");
+  {
+    let peeked = inp.peek::<U6>().unwrap();
+    assert_eq!(peeked.len(), 6, "the full window must come back");
+    // Stream order, which for this fixture is also the span order.
+    let starts = peeked
+      .iter()
+      .map(|t| t.span().start())
+      .collect::<std::vec::Vec<_>>();
+    assert_eq!(starts, std::vec![0, 2, 4, 6, 8, 10]);
+    // All six the fill produced are live at once: three in the cache, three owned by
+    // the window itself.
+    assert_eq!(
+      ledger.live(),
+      6,
+      "three cache-resident and three staged tokens are live while the window is held"
+    );
+  }
+  // Dropping the window frees exactly the staged three; the cache keeps its three.
+  assert_eq!(
+    ledger.live(),
+    3,
+    "dropping the window frees the staged tokens once — no leak, no double-drop"
+  );
+
+  // The cache still holds its three and hands them back.
+  assert!(inp.next().unwrap().is_some(), "cache token 1");
+  assert!(inp.next().unwrap().is_some(), "cache token 2");
+  assert!(inp.next().unwrap().is_some(), "cache token 3");
+  drop(inp);
+  drop(input);
+
+  assert_eq!(
+    ledger.created(),
+    ledger.dropped(),
+    "every token payload the peek created was freed exactly once"
+  );
+}
+
+// ── PEEK_FOOTPRINT — one owned window, whatever the token and state cost ──────
+//
+// `Token`, `State` and `Span` are unconstrained in size, so every `W`-slot store a
+// peek builds costs `W::CAPACITY × (Token + State + Span)` of stack. It must build
+// exactly one — the window it hands back. Through 0.8.0 the fill built a second one
+// on a cache miss (a `W::CAPACITY`-slot `MaybeUninit` array staging the tokens lexed
+// past the cache until the cache region had been copied out), so a large token
+// payload or a large lexer state cost twice what the caller asked for. On the widest
+// window the crate offers, over the fixture below, that second store was 66,304 bytes
+// of stack nobody asked for.
+//
+// The law is pinned from two sides, because neither side alone can see the whole of
+// it:
+//
+//   * the compile-time assertions below fix the *size* relation over a deliberately
+//     oversized token and lexer state — the window is one array of entries and each
+//     entry carries one token, one state and one span, so the frame is exactly linear
+//     in all three;
+//   * `peek_footprint_census_the_fill_owns_no_store` in `census_tests.rs` fixes the
+//     *structural* one — the fill body constructs no array, no deque and no
+//     `MaybeUninit` of its own. That is the live half: a size assertion cannot see a
+//     new local, and reintroducing a staging array trips the census immediately.
+//
+// A stack measurement was tried in place of the census and rejected. An unoptimized
+// build materializes roughly seven window-sized copies around the fill (every
+// `Result`, tuple and return slot on the way through `peek` gets one), so the term
+// under test is under a seventh of the frame and any threshold over it is a magic
+// number that a compiler release or an unrelated refactor moves.
+
+/// Words per oversized payload — 1 KiB at 64 bits, so the window term dominates.
+const BIG_WORDS: usize = 128;
+
+/// An oversized token payload: the `Token` half of the per-entry cost.
+#[derive(Debug, Clone)]
+struct BigPayload([u64; BIG_WORDS]);
+
+impl BigPayload {
+  /// Reads the payload back, so its bytes are load-bearing rather than dead weight.
+  fn probe(&self) -> u64 {
+    self.0[0]
+  }
+}
+
+/// An oversized lexer state: the `State` half of the per-entry cost.
+#[derive(Debug, Clone)]
+struct BigState([u64; BIG_WORDS]);
+
+impl BigState {
+  /// Reads the state back, for the same reason as [`BigPayload::probe`].
+  fn probe(&self) -> u64 {
+    self.0[0]
+  }
+}
+
+impl Default for BigState {
+  fn default() -> Self {
+    Self([0; BIG_WORDS])
+  }
+}
+
+impl crate::state::State for BigState {
+  type Error = ();
+
+  fn check(&self) -> Result<(), Self::Error> {
+    Ok(())
+  }
+}
+
+#[derive(Debug, Clone, crate::logos::Logos)]
+#[logos(crate = crate::logos, extras = BigState, skip r"[ \t\r\n]+")]
+enum BigTok {
+  #[regex(r"[0-9]+", |_| BigPayload([0; BIG_WORDS]))]
+  Num(BigPayload),
+}
+
+impl core::fmt::Display for BigTok {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    write!(f, "number")
+  }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum BigKind {
+  Num,
+}
+
+impl core::fmt::Display for BigKind {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    write!(f, "number")
+  }
+}
+
+impl crate::Token<'_> for BigTok {
+  type Kind = BigKind;
+  type Error = ();
+
+  fn kind(&self) -> BigKind {
+    BigKind::Num
+  }
+
+  fn is_trivia(&self) -> bool {
+    false
+  }
+}
+
+type BigLexer<'a> = LogosLexer<'a, BigTok>;
+type BigCtx<'a> = (
+  crate::emitter::Silent<()>,
+  crate::cache::DefaultCache<'a, BigLexer<'a>>,
+);
+
+/// One window entry: the `Maybe` of a borrowed and an owned `CachedToken`.
+type BigEntry<'r, 'a> = crate::cache::MaybeRefCachedTokenOf<'r, 'a, BigLexer<'a>>;
+/// The widest window the crate offers, over the oversized fixture.
+type BigWindow<'r, 'a> =
+  crate::cache::Peeked<'r, 'a, BigLexer<'a>, generic_arraydeque::typenum::U32>;
+/// The span this fixture's lexer carries, per entry.
+type BigSpan = <BigLexer<'static> as crate::Lexer<'static>>::Span;
+
+const BIG_ENTRY: usize = core::mem::size_of::<BigEntry<'static, 'static>>();
+const BIG_WINDOW: usize = core::mem::size_of::<BigWindow<'static, 'static>>();
+
+// The size law, stated relationally so it survives a change of word size or of
+// `CachedToken`'s layout.
+const _: () = {
+  // An entry owns one whole token, one whole lexer state and one whole span: that is
+  // why the peek footprint is linear in all three, and why a second store of this
+  // shape doubles it.
+  assert!(
+    BIG_ENTRY
+      >= core::mem::size_of::<BigTok>()
+        + core::mem::size_of::<BigState>()
+        + core::mem::size_of::<BigSpan>(),
+    "a window entry must be able to own a token together with its lexer state and span"
+  );
+  // And the window is exactly 32 of them plus the deque's own indices — one array,
+  // with no room for a shadow copy hiding inside it.
+  assert!(
+    32 * BIG_ENTRY <= BIG_WINDOW
+      && BIG_WINDOW <= 32 * BIG_ENTRY + 4 * core::mem::size_of::<usize>(),
+    "a U32 peek window must be one array of 32 entries plus the deque's own bookkeeping"
+  );
+};
+
+/// Forty single-digit tokens: more than the widest window, so the fill stops at the
+/// window bound rather than at end of input.
+const BIG_SRC: &str = "1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 \
+                       1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0";
+
+#[test]
+fn widest_peek_over_oversized_token_and_state_stays_in_stream_order() {
+  use crate::cache::PeekedTokenExt as _;
+  use generic_arraydeque::typenum::U32;
+
+  // The widest window the crate allows, over a 1 KiB token payload and a 1 KiB lexer
+  // state, against the three-slot default cache: 3 cache-resident entries and 29
+  // staged ones, the largest staged region any peek can produce. Running the
+  // monomorphization is the point — it is where an accounting slip in the staged
+  // region would trip a debug assertion, and where a second window would be paid for.
+  let cache = crate::cache::DefaultCache::<'_, BigLexer<'_>>::default();
+  let mut input = crate::input::Input::<BigLexer<'_>, BigCtx<'_>, ()>::with_state_and_context(
+    BIG_SRC,
+    BigState::default(),
+    crate::input::InputContext::new(crate::emitter::Silent::<()>::new(), cache),
+  );
+  let mut inp = input.as_ref();
+
+  let peeked = inp.peek::<U32>().unwrap();
+  assert_eq!(peeked.len(), 32, "the widest window must come back full");
+  // Token `i` of the fixture starts at offset `2 * i`; stream order is therefore
+  // visible as a strictly increasing run of even starts, across the boundary at 3.
+  let starts = peeked
+    .iter()
+    .map(|t| t.span().start())
+    .collect::<std::vec::Vec<_>>();
+  assert_eq!(
+    starts,
+    (0..32).map(|i| i * 2).collect::<std::vec::Vec<_>>(),
+    "the oversized window must read in stream order across the cache boundary"
+  );
+  let owned = peeked.iter().filter(|t| t.is_owned()).count();
+  assert_eq!(
+    owned, 29,
+    "3 cache-resident entries, 29 staged past the cache"
+  );
+
+  // Both oversized halves really are carried per entry — the premise the size
+  // assertions above rest on.
+  match peeked[0].token() {
+    BigTok::Num(payload) => assert_eq!(payload.probe(), 0),
+  }
+  let head_state = match &peeked[0] {
+    mayber::Maybe::Ref(cached) => cached.state.probe(),
+    mayber::Maybe::Owned(cached) => cached.state.probe(),
+  };
+  assert_eq!(head_state, 0, "every entry carries a whole lexer state");
 }


### PR DESCRIPTION
Closes #156. 