### PR TITLE
fix(tokora): floor the hole wrap's scan so it cannot splice below a live mark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -306,6 +306,36 @@ with it. `ci/changelog_structure.sh` enforces every clause above and will red un
     `ci/feature_cfg_coverage_selftest.sh` plants an uncovered predicate, deletes each
     load-bearing leg in turn and staleness-flips the leg declarations, requiring a red from each.
     — *(#200)*
+16. **A recovery hole reported with a span reaching back over already-committed tokens spliced
+   its error node *below* a live checkpoint mark, silently corrupting the CST event log in
+   release builds.** The CST sink's checkpoint marks are event-buffer positions and the hole wrap
+   is an `insert`, so a wrap start below a live mark shifts every index at or above it and the
+   mark comes to name a different position. The wrap's `Start` then sits below the mark and its
+   `Finish` above it, so the rewind that follows truncates between them: the log keeps an
+   unbalanced error start where a committed token used to be. Only a `debug_assert!` stood
+   against it, so the profile users ship had no wall at all — a debug panic and a release
+   corruption from the same call.
+
+   Nothing in the crate's own recovery could reach it: `sync_balanced` spans exactly the tokens
+   its scan just settled, which postdate every capture. The reachable door is a caller running
+   its own recovery loop through `InputRef`, `EmitterView` or `ParseState::emit_skipped_region`,
+   where the span is the caller's own and no public surface stated any discipline relating it to
+   open checkpoints — the realistic trigger being a lossless grammar whose recoverer widens its
+   reported span backward over adjacent committed trivia.
+
+   The wrap start is now **bounded** rather than asserted: the backward scan is floored at the
+   youngest positional fact the sink holds — the innermost live mark-stack row, or the released
+   floor memo when a commit promoted it higher — so the splice cannot cross one by construction.
+   Fixing up the shifted rows instead is not available: every truncation point between a `Start`
+   below a mark and a `Finish` above it tears the pair, and no row arithmetic restores
+   rewind-exactness. The `debug_assert!` is gone rather than promoted, because the clamp is now
+   the contract and an assert that fires on behaviour release defines-and-accepts is the
+   profile divergence this crate has been removing.
+
+   A wider caller span still reaches the diagnostic channel verbatim; only the error node it
+   induces is narrowed, to the tokens that settled within the transaction reporting the hole.
+   That span semantics is now stated on all four public doors and on the sink's own impl.
+   — *(#177)*
 
 ## 0.8.0 (2026-08-04)
 

--- a/tokora/src/cst/sink.rs
+++ b/tokora/src/cst/sink.rs
@@ -699,16 +699,69 @@ where
   /// The hole wrap: brackets the already-buffered token events of a recovery hole in a
   /// `Start(error_kind) … Finish` pair at the recovery site.
   ///
-  /// The hole's tokens are the buffer's suffix by construction (they settled during the
-  /// scan, after every live mark was captured, and the scanner runs no user code), so the
-  /// wrap is a prefix-preserving splice: one insert at the first hole token, one appended
-  /// finish. Interleaved `Diag` slots (lexer errors crossed while skipping) ride inside
-  /// the wrap unchanged — they are invisible to materialization. If no buffered token
-  /// event lies inside the hole span (no auto-emission configured, or a direct call),
-  /// there is nothing to wrap and no node is made.
+  /// The wrap is a **prefix-preserving** splice — one insert at the first wrapped token, one
+  /// appended finish — and it stays prefix-preserving because the backward scan is *floored*
+  /// at the youngest positional fact the sink holds, not because the caller's span is trusted
+  /// to sit above it. See the floor note in the body for what the floor is and why it is a
+  /// bound rather than an assertion. Interleaved `Diag` slots (lexer errors crossed while
+  /// skipping) ride inside the wrap unchanged — they are invisible to materialization. If no
+  /// buffered token event lies inside the hole span at or above the floor (no auto-emission
+  /// configured, a direct call, or a caller span that reaches only below the floor), there is
+  /// nothing to wrap and no node is made.
+  ///
+  /// The floor bounds the wrap's **structural** authority only. A caller-chosen span wider
+  /// than the caller's own transaction still reaches the diagnostic channel verbatim and
+  /// unchanged; only the `error_kind` node it induces is narrowed, to the tokens that settled
+  /// within the transaction reporting the hole.
   fn wrap_hole(&mut self, span: &L::Span) {
+    // ── THE SCAN FLOOR — the wrap start is BOUNDED, never merely asserted ──────────────
+    //
+    // The splice below is an `insert`, so every index at or above it shifts by one, and the
+    // sink's own bookkeeping is **positional**: a checkpoint mark IS an event-buffer length,
+    // the released-floor memo freezes a `(mark, depth)` pair over a prefix, and the undo
+    // journal names indices. A splice below any of them renames it. The journal is fixed up
+    // explicitly at the end of this method; the other two are made unreachable here, by
+    // construction, and that asymmetry is forced rather than a preference: the splice would
+    // put the `Start` below a mark and its `Finish` above it, so EVERY truncation point
+    // between them tears the pair. No row arithmetic repairs that — a `+1` fixup just makes
+    // the rewind keep an orphan `Start`. The start has to be bounded before the fact.
+    //
+    // `rows` is sorted non-decreasing (rows are pushed at the then-current length and every
+    // truncation pops the rows above it), so `last()` is the youngest LIVE capture.
+    // `self.floor` is a COMMITTED row that `release` promoted, and it can sit **above**
+    // `rows.last()` — a guard opened above an older live capture and then committed leaves
+    // exactly that shape — so the floor is the max of the two, not the row stack alone.
+    // Dropping the `self.floor` term stales the depth memo instead of the row: `derived_depth`
+    // would go on adding the deltas above a mark whose prefix no longer holds the events it
+    // was frozen over, and `cst_finish`'s global-underflow check then fires on a buffer whose
+    // node really is open.
+    //
+    // In-crate this costs nothing. `sync_balanced` is the only in-crate producer of an
+    // `emit_skipped_region` call, and its span covers exactly the tokens its own scan just
+    // settled — those postdate every capture, live or released — so `at >= floor` already
+    // held for it and the floor never narrows a recovery this crate drives. The floor governs
+    // the PUBLIC door (`InputRef`/`EmitterView`/`ParseState::emit_skipped_region`), whose span
+    // is the caller's own and is under no such discipline: a recoverer that widens its
+    // reported span backward over already-committed tokens gets the wrap narrowed to its own
+    // transaction, and the report itself forwarded untouched.
+    //
+    // `EventMark`s need no term of their own here — but ONLY because `cst_mark`
+    // *materializes* a tombstone `StartNode` and this scan breaks on any structural event, so
+    // `at` is always above every tombstone and every `StartAt` target. **If a future design
+    // ever de-materialises marks — hands out an index with no event standing behind it — that
+    // immunity is gone and the floor must be extended to cover them.**
+    let floor = self
+      .rows
+      .borrow()
+      .last()
+      .map_or(0, |row| row.mark)
+      .max(self.floor.mark) as usize;
+
     let mut wrap_start: Option<usize> = None;
     for (idx, ev) in self.events.iter().enumerate().rev() {
+      if idx < floor {
+        break;
+      }
       match ev {
         Event::Diag { .. } => continue,
         Event::Token { span: s, .. }
@@ -719,21 +772,10 @@ where
         _ => break,
       }
     }
+    // `at >= floor` by construction — the loop never looks below it.
     let Some(at) = wrap_start else {
       return;
     };
-
-    // The splice preserves every prefix a live mark can name: the first hole token
-    // postdates every live capture (scan discipline), so nothing below `at` moves.
-    debug_assert!(
-      self
-        .rows
-        .borrow()
-        .last()
-        .is_none_or(|row| row.mark <= at as u64),
-      "hole wrap would splice below a live checkpoint mark; the scan discipline \
-       guarantees the hole's tokens postdate every live capture"
-    );
 
     let error_kind = self.profile.error_kind();
     self.events.insert(
@@ -746,8 +788,9 @@ where
     self.events.push(Event::FinishNode { kind: error_kind });
 
     // Keep the undo journal exact across the splice: positions at or above the insert point
-    // shift by one. (Journal entries cannot reference the spliced region — marks and their
-    // tombstones all predate the scan — but the bump is exact anyway.)
+    // shift by one. (Journal entries cannot reference the spliced region — every entry names
+    // a tombstone or a `StartAt`, both structural events the scan breaks on, so all of them
+    // sit strictly below `at` — but the bump is exact anyway.)
     for entry in &mut self.journal {
       if entry.at_len > at as u64 {
         entry.at_len += 1;
@@ -925,6 +968,15 @@ where
   /// Wraps the hole's already-buffered token events in an `error_kind` node at the
   /// recovery site (empty holes and token-less holes produce no node), then forwards the
   /// one-per-hole diagnostic to the inner emitter through the census helper.
+  ///
+  /// **Span semantics.** The wrap brackets only those hole tokens that settled *within the
+  /// transaction reporting the hole* — the buffered tokens at or above the youngest live
+  /// checkpoint. A `span` reaching back over tokens committed before that checkpoint reaches
+  /// the diagnostic channel unchanged, but exerts no structural authority over them: the
+  /// `error_kind` node stops at the transaction boundary. Checkpoint marks are event-buffer
+  /// positions, and a node spliced beneath one would rename it, so `wrap_hole`'s backward scan
+  /// is floored. This costs the crate's own recovery nothing (the scan's span never reaches
+  /// below a live capture); it bounds a caller running its own recovery loop.
   fn emit_skipped_region(&mut self, span: L::Span, skipped: usize) -> Result<(), Self::Error>
   where
     L: Lexer<'inp>,

--- a/tokora/src/cst/sink/tests.rs
+++ b/tokora/src/cst/sink/tests.rs
@@ -863,6 +863,237 @@ fn hole_wrap_rewinds_with_the_log() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
+// #177 — the wrap start is FLOORED at the youngest positional fact
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// `wrap_hole` splices with `insert`, so every index at or above the wrap start shifts by
+// one — and checkpoint marks ARE event-buffer indices. A splice below a live mark renames
+// it, and the rewind that follows tears the `Start`/`Finish` pair apart. None of these four
+// cells is gated on `debug_assertions`, in either direction: the whole point of the floor is
+// that it is a structural bound present in every build, so every one of them must hold
+// identically in debug and in release. (Before the floor, the first cell PASSED in release
+// while asserting a corrupt log and PANICKED in debug — the exact profile divergence #160
+// set out to eliminate.)
+
+/// The reported condition, inverted. A caller-chosen span reaches back over a token
+/// committed before a live checkpoint; the wrap start is floored at the mark, so the rewind
+/// restores the pre-checkpoint log **exactly** instead of leaving an orphan error start
+/// where a committed token used to be.
+#[test]
+fn hole_wrap_floors_at_the_youngest_live_row() {
+  let mut sink = verbose_sink("a j");
+  sink.record_token(&MiniTok(b'a'), &span(0, 1)); // idx 0 — committed
+  sink.record_token(&MiniTok(b' '), &span(1, 2)); // idx 1 — committed trivia
+  let before = sink.events().to_vec();
+  let ckp = Emitter::<MiniLexer<'_>>::checkpoint(&sink); // mark 2
+  sink.record_token(&MiniTok(b'j'), &span(2, 3)); // idx 2 — the junk this transaction skipped
+
+  // The span widens BACKWARD over the already-committed trivia at idx 1 — the shape an
+  // IDE-facing recoverer produces when it reports "everything from the whitespace onward".
+  Emitter::<MiniLexer<'_>>::emit_skipped_region(&mut sink, span(1, 3), 1).expect("collects");
+
+  assert_eq!(
+    sink.events(),
+    &[
+      Event::Token {
+        kind: K_TOK,
+        span: span(0, 1)
+      },
+      Event::Token {
+        kind: K_TOK,
+        span: span(1, 2)
+      },
+      Event::StartNode {
+        kind: K_ERR,
+        forward_parent: None
+      },
+      Event::Token {
+        kind: K_TOK,
+        span: span(2, 3)
+      },
+      Event::FinishNode { kind: K_ERR },
+      Event::Diag { error_span: None },
+    ],
+    "the wrap starts AT the mark, not below it: the committed trivia stays outside"
+  );
+
+  rewind(&mut sink, ckp);
+  assert_eq!(
+    sink.events(),
+    &before[..],
+    "rewind is exact — before the floor this left `[T_a, StartNode(K_ERR)]`, a committed \
+     token replaced by an unbalanced error start"
+  );
+}
+
+/// Suffix discipline is untouched: when the span covers only tokens this transaction
+/// settled, the floor is not the binding constraint and the whole hole is wrapped. This is
+/// the shape every in-crate `sync_balanced` recovery produces.
+#[test]
+fn hole_wrap_covers_a_post_checkpoint_hole_whole() {
+  let mut sink = verbose_sink("xyab");
+  sink.record_token(&MiniTok(b'x'), &span(0, 1)); // idx 0
+  let ckp = Emitter::<MiniLexer<'_>>::checkpoint(&sink); // mark 1 — the floor
+  sink.record_token(&MiniTok(b'y'), &span(1, 2)); // idx 1 — settled, outside the hole
+  sink.record_token(&MiniTok(b'a'), &span(2, 3)); // idx 2 — the hole
+  sink.record_token(&MiniTok(b'b'), &span(3, 4)); // idx 3 — the hole
+
+  Emitter::<MiniLexer<'_>>::emit_skipped_region(&mut sink, span(2, 4), 2).expect("collects");
+
+  assert_eq!(
+    sink.events(),
+    &[
+      Event::Token {
+        kind: K_TOK,
+        span: span(0, 1)
+      },
+      Event::Token {
+        kind: K_TOK,
+        span: span(1, 2)
+      },
+      Event::StartNode {
+        kind: K_ERR,
+        forward_parent: None
+      },
+      Event::Token {
+        kind: K_TOK,
+        span: span(2, 3)
+      },
+      Event::Token {
+        kind: K_TOK,
+        span: span(3, 4)
+      },
+      Event::FinishNode { kind: K_ERR },
+      Event::Diag { error_span: None },
+    ],
+    "wrap start 2 sits strictly above the floor 1 — the span's own reach binds, not the floor"
+  );
+  let _ = ckp;
+}
+
+/// No capture at all: the floor is 0 and the wrap may start at the very first event, which
+/// is what an unguarded top-level recovery has always done.
+#[test]
+fn hole_wrap_with_no_rows_floors_at_zero() {
+  let mut sink = verbose_sink("ab");
+  sink.record_token(&MiniTok(b'a'), &span(0, 1));
+  sink.record_token(&MiniTok(b'b'), &span(1, 2));
+
+  Emitter::<MiniLexer<'_>>::emit_skipped_region(&mut sink, span(0, 2), 2).expect("collects");
+
+  assert_eq!(
+    sink.events(),
+    &[
+      Event::StartNode {
+        kind: K_ERR,
+        forward_parent: None
+      },
+      Event::Token {
+        kind: K_TOK,
+        span: span(0, 1)
+      },
+      Event::Token {
+        kind: K_TOK,
+        span: span(1, 2)
+      },
+      Event::FinishNode { kind: K_ERR },
+      Event::Diag { error_span: None },
+    ],
+    "an empty mark stack floors at 0 — the whole buffer is wrappable"
+  );
+}
+
+/// The boundary itself: the wrap starts at exactly the mark index. A row with `mark == at`
+/// names the prefix `0..at`, which an insert *at* `at` leaves byte-for-byte alone — so the
+/// rewind is still exact at the tightest legal splice point.
+#[test]
+fn hole_wrap_at_the_floor_boundary_rewinds_exactly() {
+  let mut sink = verbose_sink("ab");
+  sink.record_token(&MiniTok(b'a'), &span(0, 1)); // idx 0
+  let before = sink.events().to_vec();
+  let ckp = Emitter::<MiniLexer<'_>>::checkpoint(&sink); // mark 1 == the eventual wrap start
+  sink.record_token(&MiniTok(b'b'), &span(1, 2)); // idx 1
+
+  Emitter::<MiniLexer<'_>>::emit_skipped_region(&mut sink, span(1, 2), 1).expect("collects");
+
+  assert_eq!(
+    sink.events(),
+    &[
+      Event::Token {
+        kind: K_TOK,
+        span: span(0, 1)
+      },
+      Event::StartNode {
+        kind: K_ERR,
+        forward_parent: None
+      },
+      Event::Token {
+        kind: K_TOK,
+        span: span(1, 2)
+      },
+      Event::FinishNode { kind: K_ERR },
+      Event::Diag { error_span: None },
+    ],
+    "at == floor == 1: the splice lands exactly on the mark"
+  );
+
+  rewind(&mut sink, ckp);
+  assert_eq!(
+    sink.events(),
+    &before[..],
+    "rewind to a mark the splice sat on is still exact"
+  );
+}
+
+/// The floor's second term. `release` promotes a committed row to `Sink::floor`, and that
+/// memo can sit **above** the innermost live row — so a floor read off `rows.last()` alone
+/// would still let the splice cross a frozen `(mark, depth)` prefix. Nothing tears, but the
+/// depth memo goes stale: `derived_depth` keeps summing from a prefix that no longer holds
+/// the events it was frozen over, and `cst_finish`'s global-underflow check then fires on a
+/// buffer whose node genuinely is open.
+#[test]
+fn hole_wrap_floors_at_the_released_floor_too() {
+  let mut sink = verbose_sink("abcde");
+  sink.cst_start(K_NODE); // idx 0 — depth +1, still open at the end
+  sink.record_token(&MiniTok(b'a'), &span(0, 1)); // idx 1
+  let outer = Emitter::<MiniLexer<'_>>::checkpoint(&sink); // mark 2 — stays live
+  let before = sink.events().to_vec();
+  sink.record_token(&MiniTok(b'b'), &span(1, 2)); // idx 2
+  sink.record_token(&MiniTok(b'c'), &span(2, 3)); // idx 3
+  sink.record_token(&MiniTok(b'd'), &span(3, 4)); // idx 4
+  let inner = Emitter::<MiniLexer<'_>>::checkpoint(&sink); // mark 5
+  Emitter::<MiniLexer<'_>>::release(&mut sink, inner); // committed → Sink::floor = mark 5
+  sink.record_token(&MiniTok(b'e'), &span(4, 5)); // idx 5
+
+  // Reaches down to idx 3: at or above `rows.last()` (mark 2), below the released floor (5).
+  Emitter::<MiniLexer<'_>>::emit_skipped_region(&mut sink, span(2, 5), 3).expect("collects");
+
+  assert_eq!(
+    sink.events().len(),
+    9,
+    "start, four tokens, the wrap's start, the junk token, the wrap's finish, the Diag"
+  );
+  assert_eq!(
+    sink.events()[5],
+    Event::StartNode {
+      kind: K_ERR,
+      forward_parent: None
+    },
+    "the wrap starts at the RELEASED floor (5), not at the live row (2)"
+  );
+
+  // Would panic with "global underflow" on a staled memo — K_NODE is open, depth is 1.
+  sink.cst_finish(K_NODE);
+
+  rewind(&mut sink, outer);
+  assert_eq!(
+    sink.events(),
+    &before[..],
+    "the surviving live row rewinds exactly"
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
 // The &mut threading shape — events flow through the blanket impl
 // ═══════════════════════════════════════════════════════════════════════════════
 

--- a/tokora/src/emitter/mod.rs
+++ b/tokora/src/emitter/mod.rs
@@ -283,6 +283,20 @@ pub trait Emitter<'a, L, Lang: ?Sized = ()> {
   /// `sync_balanced_hole_emission_unwinds_on_rollback` and
   /// `sync_balanced_trip_commits_prefix_without_hole_diagnostic` in
   /// `src/input/input_ref/tests.rs`.
+  ///
+  /// # Span semantics: the report is verbatim, the structure is transaction-bounded
+  ///
+  /// For a diagnostics-only emitter `span` is just the reported extent. The CST sink is the
+  /// one built-in implementation that also gives it *structural* effect — it brackets the
+  /// hole's buffered token events in an error node — and there the bracket covers only the
+  /// hole tokens that settled **within the transaction reporting the hole**, i.e. at or above
+  /// the youngest live [`checkpoint`](Self::checkpoint). A wider `span`, reaching back over
+  /// tokens committed before that checkpoint, still reaches the diagnostic channel unchanged;
+  /// it simply exerts no structural authority over them. Checkpoint marks are positions in
+  /// that emitter's event log, and a node spliced beneath one would silently rename it, so the
+  /// wrap start is *bounded* rather than trusted. The crate's own recovery never notices: a
+  /// [`sync_balanced`](crate::InputRef::sync_balanced) hole spans exactly the tokens its scan
+  /// just settled, which postdate every live capture.
   #[inline(always)]
   fn emit_skipped_region(&mut self, span: L::Span, skipped: usize) -> Result<(), Self::Error>
   where

--- a/tokora/src/emitter/view.rs
+++ b/tokora/src/emitter/view.rs
@@ -263,6 +263,13 @@ where
   }
 
   /// Emits a recovery-hole note — [`Emitter::emit_skipped_region`], forwarded.
+  ///
+  /// **Span semantics.** Under a CST sink this call also has a structural effect: the hole's
+  /// buffered tokens are bracketed in an error node, and that bracket covers only the hole
+  /// tokens that settled **within the transaction reporting the hole** — at or above the
+  /// youngest live checkpoint. A wider `span` still reaches the diagnostic channel verbatim;
+  /// it exerts no structural authority over tokens committed before that checkpoint, because
+  /// checkpoint marks are event-log positions and a node spliced beneath one would rename it.
   #[inline(always)]
   pub fn emit_skipped_region(&mut self, span: L::Span, skipped: usize) -> Result<(), E::Error> {
     self.emitter.emit_skipped_region(span, skipped)

--- a/tokora/src/input/input_ref/emit.rs
+++ b/tokora/src/input/input_ref/emit.rs
@@ -193,6 +193,15 @@ where
   ///
   /// [`sync_balanced`](InputRef::sync_balanced) raises exactly one of these per hole it skips;
   /// a caller running its own recovery loop is the reason this is reachable at all.
+  ///
+  /// **Span semantics.** Under a CST sink this call also has a structural effect: the hole's
+  /// buffered tokens are bracketed in an error node. That bracket covers only the hole tokens
+  /// that settled **within the transaction reporting the hole** — at or above the youngest
+  /// live checkpoint. A recovery loop that widens `span` backward over tokens it already
+  /// committed still gets the report forwarded verbatim, but the error node stops at the
+  /// transaction boundary: checkpoint marks are event-log positions, and a node spliced
+  /// beneath one would rename it. `sync_balanced`'s own spans postdate every live capture, so
+  /// this bound never narrows the crate's own recovery.
   #[inline(always)]
   pub fn emit_skipped_region(
     &mut self,

--- a/tokora/src/parse_state/mod.rs
+++ b/tokora/src/parse_state/mod.rs
@@ -155,6 +155,11 @@ where
 
   /// Emits a recovery-hole note —
   /// [`Emitter::emit_skipped_region`](crate::Emitter::emit_skipped_region), forwarded.
+  ///
+  /// **Span semantics.** Under a CST sink the error node this induces covers only the hole
+  /// tokens that settled **within the transaction reporting the hole** — at or above the
+  /// youngest live checkpoint. A wider `span` reaches the diagnostic channel verbatim and is
+  /// structurally inert below that boundary; see the trait method for why.
   #[inline(always)]
   pub fn emit_skipped_region(
     &mut self,


### PR DESCRIPTION
Closes #177