### PR TITLE
fix(tokora)!: the cache conformance kit certifies entries, not spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,83 @@ with it. `ci/changelog_structure.sh` enforces every clause above and will red un
   write is for the sites where the gate and the item are apart — the re-exports of a gated
   module's contents above all, where the label has to name the gate on the `pub use`.
 
+- **The cache conformance kit now certifies whole cached *entries*, not spans — so a cache that
+  certified under 0.8.0 can go red under 0.9.0, and that red is the kit seeing more, not a kit
+  regression.** Every oracle in `tokora::conformance::cache` used to compare `L::Span` and
+  nothing else: `front`, `back`, `pop_front`, `pop_back`, `peek`, `peek_one`, the token a refused
+  push hands back, `push_many`'s overflow and the entry a `pop_front_if` predicate is given were
+  all read through a projection that discarded the token and the `L::State`. A cache that
+  returned the right spans while permuting or corrupting what sat beside them passed every check,
+  in full — and 0.8.0 said so, in the kit's own *what it deliberately does not check* section.
+
+  That was not a cosmetic hole. `L::State` is the half the input layer restores a lexer **from**:
+  `InputRef::resume` reads the newest retained entry, clones its state and rebuilds the lexer with
+  `Lexer::with_state` + `bump`, and the rollback path reads the same field off the entries
+  `pop_back` hands out. A third-party cache with right spans and wrong states did not merely fail
+  to be certified — it was certified, and then corrupted every restore that resumed from it.
+
+  The kit's observable is now the triple `(L::Span, L::Token, L::State)`, compared componentwise
+  wherever an entry, an entry reference or a peeked entry is read back, with a separate message
+  per component so a failure says which of the three diverged. `Cache::span` stays span-valued,
+  because a combined span is synthesized from two endpoints and has no entry behind it.
+
+  Some values were read as *presence* rather than read at all, and that turned out to be the same
+  hole one level down. Two of them mattered. The peek-mutate-peek driver — the only one in the kit
+  that pops an instance it has already peeked — bound each popped entry, asserted it was `Some`
+  and threw it away, which left the whole defect class alive on the peek-then-consume path the
+  severity argument above rests on. And **every** push in the kit reduced its result to
+  `is_ok()`, discarding the reference `push_back`/`push_front` promise on success: a cache can
+  store the offered entry perfectly and hand back a reference assembled from a different resident,
+  and nothing downstream can tell, because everything downstream reads storage.
+
+  Enumerating the *shapes* a value arrives in — `Some`, `None`, `Ok`, `Err`-expected,
+  `Err`-unexpected — turned out not to be enough, because a single call site can be two shapes at
+  once: checks 3 and 5 each have one push whose refusal is sometimes legitimate and sometimes not,
+  so an enumeration organised by shape classified them once and never saw the other branch. That
+  is the same hole four review rounds in a row, each closed by hand and each followed by another.
+  All five sites are closed here, and every read of a `Cache` return value in the kit now goes
+  through one of a handful of comparing helpers, so the sites are few and each one's disposition
+  is visible at the call. What is **not** here is a mechanical guard that fails when a call turns
+  up at a site the kit has not accounted for — the enumeration is still one made by hand, and the
+  scanner that would make it not be is #221.
+
+  The last of those sites was a **classification** error rather than a missed call, and it is
+  worth stating because it is the shape the rest of this entry keeps circling. Check 9's
+  false-predicate arm — `pop_front_if` driven with a predicate that declines — was filed among
+  the kit's *absence is the law* exceptions and threw its predicate's argument away. For the
+  arm's **return** that filing is right: `None` is the whole answer. But `pop_front_if` and
+  `try_pop_front_if` are the only two `Cache` methods that run **caller code**, and they hand an
+  entry over *before* they learn what to return, so a `None` says nothing about what the
+  predicate was shown. A cache could keep storage conforming, decline correctly, leave residency
+  untouched, and still run the caller's validation predicate against a token or an `L::State`
+  from a position that entry never occupied — certified. Every arm that runs a predicate against
+  a non-empty cache now records its argument and compares it. The two empty-cache probes stay
+  absence-only on a different footing, stated where they live: their law is that the predicate
+  must never run, asserted directly beside them, so on a conforming path nothing is handed to
+  anyone.
+
+  **Two compile-time breaks, for kit users only.** `CacheHarness` now requires
+  `L::Token: PartialEq` and `L::State: PartialEq`. They sit on the harness and not on the `Token`
+  or `State` traits, so no production implementor — and no logos `Extras` — is taxed to serve a
+  test kit; the cost falls where the kit is used. Migration is to derive `PartialEq`, or to
+  certify against a discriminating toy lexer, which is sound because a cache is generic over the
+  entries it stores. Neither break can be silent: both surface as compile errors.
+
+  **What the kit can and cannot discriminate is now stated exactly.** A substitution — an entry
+  that differs from the one stored at that position — is always caught. A permutation of values
+  that were already equal is not, so the discrimination is the pairwise distinctness of the tokens
+  and the states *your corpus carries*. Spans are pairwise distinct from any source, so the
+  ordering laws are unaffected; a single token variant with no payload, or a lexer whose
+  `L::State` is `()`, makes that half of the comparison vacuous. A constant state is not a gap for
+  that lexer — a single-valued state cannot be re-associated — but it is a gap for a cache
+  intended for stateful lexers and certified under a stateless one, and `CacheHarness::new`'s docs
+  now say so.
+
+  Nothing outside the kit moves: `Cache`, `Lexer`, `State`, `Token`, `CachedToken`,
+  `PeekedTokenExt` and the whole input layer are untouched, no public API is added, and
+  `CachedToken` gains no `PartialEq` impl (the kit compares componentwise for the message quality
+  that buys).
+
 ### Changed
 
 - **MSRV raised to 1.95.** The previous floor, 1.87, was not a forced minimum — the crate

--- a/tokora/src/conformance/cache.rs
+++ b/tokora/src/conformance/cache.rs
@@ -18,6 +18,21 @@
 //!
 //! # What it checks
 //!
+//! The kit's fundamental observable is the **cached entry** — the triple
+//! (`L::Span`, `L::Token`, `L::State`) that a [`CachedToken`] carries. Wherever a check reads an
+//! entry back out of a cache — through `front`, `back`, `pop_front`, `pop_back`, `peek`,
+//! `peek_one`, the token a refused push hands back, `push_many`'s overflow, or the entry a
+//! `pop_front_if` predicate is given — all three components are compared, componentwise, against
+//! what the kit stored at that position, each with its own message.
+//!
+//! The `L::State` half is the one with teeth. It is what the input layer restores a lexer
+//! **from**: `InputRef::lexer` rebuilds the lexer at the lookahead frontier out of the state the
+//! newest retained entry carries ([`crate::Lexer::with_state`] + [`crate::Lexer::bump`]), and
+//! the rollback path reads the same field off the entries
+//! `pop_back` hands out. A cache that returns the right spans beside the wrong states does not
+//! merely fail to be certified: until #183 it **passed**, in full, and then corrupted every
+//! restore that resumed from it.
+//!
 //! Each check is one law from the [`Cache`] trait contract:
 //!
 //! 1. **Empty invariants** — a fresh cache is empty on every observable at once: `len` 0,
@@ -86,7 +101,11 @@
 //!    every residency down to empty — because a sweep that builds a fresh cache per residency
 //!    only ever asks a cache its FIRST question, and a `peek` that memoises its first answer and
 //!    serves it after later pops is pure, is correct at the residency it latched, and is
-//!    otherwise invisible. And the bound and order are read through **three window types**, not
+//!    otherwise invisible. Those pops are the only ones in the kit that run on an already-peeked
+//!    instance, so the **entry** each of them returns is compared there too: a `peek` that leaves
+//!    a cached lookahead frontier behind and lets a later pop report its `L::State` out of that
+//!    instead of out of the entry it removed keeps every span and every residency correct, and
+//!    hands the caller a lexer position no entry ever had. And the bound and order are read through **three window types**, not
 //!    one: `peek` is generic over `W` and may read `W::CAPACITY` off it, so a single fixed window
 //!    leaves a branch on that parameter unreachable — the single-slot fast path the trait invites
 //!    (`peek_one`'s default body is `peek::<U1>`), and the truncating path a cache takes when the
@@ -126,14 +145,18 @@
 //!    `true` (or `Ok(())`) answer removes exactly the front entry, matching what a bare
 //!    `pop_front` would return from an identically filled cache. Against an empty cache, both
 //!    answer `None` and the predicate never runs at all — there is no front to hand it. The
-//!    predicate's **argument** is recorded and compared on **both** methods, not only on
-//!    `pop_front_if`: the two `try_pop_front_if` closures used to throw it away, so everything the
-//!    check asserted about that method was its return value and its residency — and an override
-//!    that ran the caller's validation predicate against `back()` and then produced the conforming
-//!    return and the conforming residency satisfied all of it. That is a cache whose
-//!    caller-supplied predicate decides whether to remove or retain the front on the strength of
-//!    unrelated lookahead, certified by a check whose own prose named the property it was not
-//!    testing.
+//!    predicate's **argument** is recorded and compared at **every arm that runs it** — both
+//!    methods, and the DECLINING answer as well as the accepting one. It took two findings to get
+//!    there. The two `try_pop_front_if` closures used to throw the argument away, so everything
+//!    the check asserted about that method was its return value and its residency. Then the
+//!    `pop_front_if` arm driven with a `false` predicate turned out to do the same, because a
+//!    site that answers `None` had been filed under "absence is the law" — a classification made
+//!    on what the call RETURNS, when what makes these two methods different is that they hand an
+//!    entry to caller code BEFORE they know what to return. Either way an override that ran the
+//!    caller's validation predicate against `back()` and then produced the conforming return and
+//!    the conforming residency satisfied all of it. That is a cache whose caller-supplied
+//!    predicate decides whether to remove or retain the front on the strength of unrelated
+//!    lookahead, certified by a check whose own prose named the property it was not testing.
 //! 10. **`push_many`** — accepts tokens in order until the cache is full, then hands the
 //!     remainder back through the returned iterator, unchanged and in the order they arrived.
 //!
@@ -190,30 +213,43 @@
 //! catches, and one silent total-capacity fixture that the kit is asserted to **accept**, so
 //! this paragraph stops being true the moment that assertion starts failing.
 //!
+//! **What an empty cache's `pop_front_if`/`try_pop_front_if` predicate is SHOWN, if it wrongly
+//! runs at all.** These two methods are the only ones on `Cache` that hand an entry to caller
+//! code, and they do it before they know what to return — so for them a `None` return is not
+//! evidence that nothing was handed over. Every arm the kit drives against a *non-empty* cache
+//! therefore records the predicate's argument and compares it, the declining arm included. The
+//! two empty-cache probes do not: their law is that the predicate must **never run**, which is
+//! asserted directly, and a cache that runs one has already failed on the louder violation. What
+//! the kit does not then say is which entry it conjured to run it with. No cache is certified
+//! because of this — reaching the case requires failing the check — and it is written down here
+//! rather than left implied, because the round that closed the declining arm found it by
+//! noticing that exactly this sentence had never been written for it.
+//!
 //! **The non-panicking restore path** cannot be checked by running code: the input layer calls
 //! `pop_front`, `pop_back`, `clear`, `front`, `front_span` and `len` from guard drops that may
 //! run mid-unwind, where a panic aborts the process. A test cannot survive its own witness. The
 //! law is on the trait; this kit exercises those six operations so a panicking one fails *here*,
 //! in a test, rather than in a consumer's rollback.
 //!
-//! **Every oracle in this file compares spans, never tokens or state.** `span_of` takes a
-//! `CachedToken` and returns only its `L::Span`, discarding the token and the `L::State` half —
-//! and every check built on `front`, `back`, `pop_front`, `pop_back` or `peek` compares exactly
-//! that: the span it gets back against the spans the corpus lexed, never the token or the state
-//! sitting beside it in the same value. So a cache that returns the right spans while permuting
-//! or corrupting the tokens or the states behind them passes every check in this kit, in full.
+//! **A permutation of entries that are equal to begin with.** Every oracle compares the whole
+//! entry — span, token and state — so a *substitution*, an entry that differs from the one the
+//! kit stored at that position, is always caught. What no comparison can see is a permutation of
+//! values that were already indistinguishable. The kit's discrimination is therefore exactly the
+//! **pairwise distinctness of the tokens and the states your corpus carries**.
 //!
-//! That matters because `L::State` is not incidental payload: it is the half the input layer
-//! restores the lexer *from*. `InputRef::lexer` rebuilds the lexer at the lookahead frontier from
-//! exactly the state the newest retained token carries. A third-party cache with the right spans
-//! and the wrong states does not merely fail to be certified by this kit — it passes, and then
-//! corrupts every restore that resumes from the state it handed back.
+//! Spans are pairwise distinct from every source, because `corpus` lexes successive items and
+//! successive items occupy successive positions — so the ordering laws never lose discrimination,
+//! whatever the kit is pointed at. Tokens and states are not free that way. A corpus of one
+//! fieldless token variant has one inhabitant, so a token comparison over it is vacuous; a lexer
+//! whose `L::State` is `()` — which is every logos `Extras` that was not given one — makes the
+//! state comparison vacuous in the same way.
 //!
-//! It is not closed here. Closing it needs a **heterogeneous** corpus — the in-tree corpus
-//! (`cache_tests.rs`'s `CTok`) is a single token kind, so even a token-identity comparison could
-//! not discriminate a permuted or substituted token today — **and** every oracle in this file
-//! changed to compare more than spans. That is a change to the kit's fundamental observable,
-//! deliberately deferred rather than rushed before a release.
+//! A constant state is not a gap for **that** lexer: a single-valued state has nothing to be
+//! re-associated with, so a cache cannot corrupt it. It is a gap for a cache **intended for
+//! stateful lexers** and certified under a stateless one, which is the one combination this
+//! paragraph exists to warn about. Certify such a cache under a corpus whose tokens and states
+//! are pairwise distinct — see [`new`](CacheHarness::new) — and the entry comparison discriminates
+//! every re-association a cache can make.
 //!
 //! # Violation posture
 //!
@@ -232,9 +268,25 @@ use mayber::Maybe;
 
 use crate::{
   Lexer, Span, Window,
-  cache::{Cache, CachedToken, CachedTokenOf, MaybeRefCachedTokenOf, PeekedTokenExt},
+  cache::{
+    Cache, CachedToken, CachedTokenOf, CachedTokenRefOf, MaybeRefCachedTokenOf, PeekedTokenExt,
+  },
   span::Spanned,
 };
+
+/// One peeked entry, flattened out of [`Maybe`]'s two arms into the triple the kit compares.
+///
+/// `peek` may hand back a borrow of a resident entry or an owned clone — [`Cache::peek`]'s own
+/// contract allows either — and the kit reads both arms the same way: the span and the token
+/// through [`PeekedTokenExt`], the state through [`peeked_state`]. Cloning the three components
+/// out is also what makes the purity law expressible, since [`CachedToken`] has no `PartialEq`
+/// (the kit compares componentwise, for the message quality that buys) and a `Maybe` holding a
+/// borrow cannot outlive the `peek` call that produced it.
+type PeekedTriple<'inp, L> = (
+  <L as Lexer<'inp>>::Span,
+  <L as Lexer<'inp>>::Token,
+  <L as Lexer<'inp>>::State,
+);
 
 /// The peek window the kit peeks through. Four is enough to distinguish "bounded by the buffer"
 /// from "bounded by the residency" on both sides of the default cache capacity, and to give the
@@ -298,12 +350,51 @@ impl Prefill {
 
 /// The span of a cached token, owned. `token()` hands back a `Spanned<&T, &Span>`, so the span
 /// arrives double-borrowed and has to be dereferenced once before it can be cloned.
+///
+/// Since #183 the kit's observable is the whole entry, not the span — see
+/// [`assert_entry_eq`](CacheHarness::assert_entry_eq). This projection stays for the two jobs that
+/// are genuinely span-valued: building the expectation lists the span-level laws read
+/// ([`assert_span_at`](CacheHarness::assert_span_at)'s combined span, the `front_span`/`back_span`
+/// accessors), and putting spans in failure messages, where they are the vocabulary a reader
+/// locates an entry by.
 fn span_of<'inp, L>(tok: &CachedTokenOf<'inp, L>) -> L::Span
 where
   L: Lexer<'inp>,
 {
   (*tok.token().span_ref()).clone()
 }
+
+/// The `L::State` a peeked entry carries, whichever arm of [`Maybe`] it arrived on.
+///
+/// [`PeekedTokenExt`] reaches the token and the span arm-blind and deliberately does not reach the
+/// state: giving it a third accessor would need a third type parameter on that trait, a breaking
+/// change to a released public surface for a convenience nothing on the restore path needs. So
+/// the kit matches the arm itself. Third parties can read the same fact through public API — match
+/// the [`Maybe`] and call [`CachedToken::state`] — so this checks a publicly observable value, not
+/// a crate-private one.
+fn peeked_state<'s, 'r, 'inp, L>(entry: &'s MaybeRefCachedTokenOf<'r, 'inp, L>) -> &'s L::State
+where
+  L: Lexer<'inp>,
+  'r: 's,
+{
+  match entry {
+    Maybe::Ref(borrowed) => borrowed.state,
+    Maybe::Owned(owned) => &owned.state,
+  }
+}
+
+/// The consequence sentence the `back()` and `pop_back` state comparisons carry, and nothing else
+/// does.
+///
+/// Those are the two reads the input layer's **restore** path makes: `InputRef::resume` takes
+/// `cache().back()`, clones its `L::State` and rebuilds the lexer with `Lexer::with_state` +
+/// `bump`, and the rollback drops an abandoned continuation with a run of `pop_back` calls. A
+/// wrong state at either of them is not a cosmetic divergence — it is a lexer rebuilt from a state
+/// no position in the source ever had.
+const RESTORE_NOTE: &str = " This entry's `L::State` is what `InputRef::lexer` restores the lexer from (`with_state` + `bump`), so a right span with a wrong state beside it passes nothing here: it corrupts every restore that resumes from it.";
+
+/// No consequence sentence — every state comparison that is not on the restore path.
+const NO_NOTE: &str = "";
 
 /// A conformance harness that drives a [`Cache`] implementation `C` against the cache contract.
 ///
@@ -382,6 +473,14 @@ impl<'inp, L, C, Lang> CacheHarness<'inp, L, C, Lang>
 where
   L: Lexer<'inp>,
   L::State: Clone,
+  // The kit's observable is the whole cached entry, so the token and the state have to be
+  // comparable (#183). Both bounds sit HERE, on the harness, and not on `Lexer::Token` or on
+  // `State`: a supertrait would tax every production implementor — including every logos
+  // `Extras` — to serve a test kit. A kit user that hits them derives `PartialEq`, or certifies
+  // against a discriminating toy lexer, which is sound because a cache is generic over the
+  // entries it stores.
+  L::Token: PartialEq,
+  L::State: PartialEq,
   Lang: ?Sized,
   C: Cache<'inp, L, Lang>,
 {
@@ -391,6 +490,16 @@ where
   /// the checks build, plus the tokens past it that check 6 prefills the peek buffer with — and
   /// at least two in any case, since a queue law about ordering is not observable on one element.
   /// `run` says so, with the number, if it does not.
+  ///
+  /// **Variety matters as much as length.** The kit compares whole entries — span, token and
+  /// state — so what it can discriminate is bounded by how distinguishable the corpus is. A
+  /// source whose tokens are all one fieldless variant has one token value in it, and a lexer
+  /// whose `L::State` never changes has one state value in it; against either, that half of the
+  /// comparison cannot fail. Spans are pairwise distinct from any source, so the ordering laws
+  /// hold up regardless. Point the kit at a source whose tokens carry distinct payloads, under a
+  /// lexer whose state advances as it lexes, and every re-association a cache can make is
+  /// visible. The module docs' *what it deliberately does not check* section states the bound
+  /// exactly.
   #[must_use]
   pub fn new(source: &'inp L::Source) -> Self {
     Self {
@@ -544,18 +653,575 @@ where
 
   /// A fresh cache holding the first `n` corpus tokens, pushed back to front-order.
   ///
-  /// Returns the cache and the spans it should be holding, so every later assertion compares
-  /// against a list the kit built rather than against the cache's own answer.
-  fn filled(&self, n: usize) -> (C, Vec<L::Span>) {
+  /// Returns the cache and the **entries** it should be holding, so every later assertion
+  /// compares against a list the kit built rather than against the cache's own answer. Each entry
+  /// is cloned before the push and the clone is what is kept: the cache takes the original by
+  /// value, and what the kit needs afterwards is the whole triple — span, token and state — not
+  /// the span projection it kept before #183.
+  fn filled(&self, n: usize) -> (C, Vec<CachedTokenOf<'inp, L>>) {
     let mut cache = self.make();
     let mut want = Vec::new();
-    for tok in self.corpus(n) {
-      let span = span_of::<L>(&tok);
-      if cache.push_back(tok).is_ok() {
-        want.push(span);
+    for (i, tok) in self.corpus(n).into_iter().enumerate() {
+      // A refusal here is expected — `filled` is driven past the capacity — so this is the arm
+      // that keeps what was accepted rather than the one that asserts acceptance. Either way the
+      // `Ok` reference is read: see [`checked_push`](Self::checked_push).
+      if let Ok(placed) = self.checked_push_back(
+        &mut cache,
+        tok,
+        &format!("push_back #{i} filling a fresh cache"),
+      ) {
+        want.push(placed);
       }
     }
     (cache, want)
+  }
+
+  // ── every value a `Cache` method hands back is read, not counted ─────────────────
+  //
+  // A value reduced to `is_ok()`/`is_some()` is a value the kit did not check, and #183's own
+  // review found that class twice in two rounds — first a pop whose entry was discarded
+  // (`check_peek_across_mutations`), then a push whose returned reference was (every push in the
+  // kit). Both were invisible for the same reason: everything downstream observes **storage**,
+  // and neither the popped entry nor the returned reference is storage.
+  //
+  // So the class is closed rather than the occurrences — and closed by ENUMERATION, not by
+  // looking harder, which is the difference between a class that is finished and one that keeps
+  // producing findings. A `Cache` method returns an `Option` or a `Result`, so there are exactly
+  // four shapes a value can arrive in, and every one of them is now accounted for:
+  //
+  //   * `Option::Some`  — compared, through the entry comparison below.
+  //   * `Option::None`  — presence-only, at twelve sites, because **absence is the law under
+  //                       test**: a drained cache that must not answer, an empty cache that must
+  //                       not answer. Nothing came back, so presence is not a weaker check there
+  //                       — it is the whole check. Each carries a comment at the site.
+  //
+  //                       That bound is on the RETURN, and #183's ninth round found it being
+  //                       read as a bound on the CALL. `pop_front_if` and `try_pop_front_if` —
+  //                       the only two `Cache` methods that run CALLER CODE, which is a closed
+  //                       list read off the trait rather than an inspection of this file — hand
+  //                       an entry over *before* they learn what to return. A `None` therefore
+  //                       says nothing about what the predicate was shown, and check 9's
+  //                       DECLINING arm is compared rather than counted for exactly that
+  //                       reason: it used to sit in this bullet, and a cache could answer
+  //                       `None`, remove nothing, keep every span in place, and still run the
+  //                       caller's validation predicate against an entry it never held there.
+  //
+  //                       The two empty-cache probes stay in this bullet on a different footing
+  //                       and are sound: their law is that the predicate must NOT RUN at all,
+  //                       asserted directly beside them, so on any conforming path nothing is
+  //                       handed to anyone. A cache that runs one anyway fails on the run, the
+  //                       louder violation; what it was shown is then not compared, which is
+  //                       claim accuracy and not a certification any cache can pass.
+  //   * `Result::Ok`    — compared, by [`checked_push`](Self::checked_push).
+  //   * `Result::Err`   — compared. At the sites that drive a refusal ON PURPOSE (checks 3 and 5)
+  //                       the caller compares it in its own round-trip wording; at the sites that
+  //                       expected acceptance,
+  //                       [`unexpected_refusal`](Self::unexpected_refusal) compares it before the
+  //                       refusal panic can discard it.
+  //
+  // There is no fifth shape. But an enumeration by shape is not an enumeration by SITE, and that
+  // is where four review rounds in a row went wrong: a single call site can be two shapes at
+  // once — checks 3 and 5 each have one `push_back`/`push_front` whose `Err` is *sometimes*
+  // legitimate and sometimes not — so an enumeration organised by shape classified them once, as
+  // "expected refusal", and never saw the other branch.
+  //
+  // So the account above is an enumeration by hand, and it stays one here: nothing in this crate
+  // fails when a call to one of these methods appears at a site this comment does not know about.
+  // What keeps that residue small is the helpers below — every read of a `Cache` return value in
+  // the kit goes through one of them, so the sites are few and each one's disposition is visible
+  // at the call. A mechanical guard that scans this file and fails on an unregistered site is
+  // #221, and is deliberately not part of this change.
+
+  /// The `Ok` arm of an accepted push, compared against the entry that was offered.
+  ///
+  /// [`Cache::push_back`] and [`Cache::push_front`] both promise `Ok` with **a reference to the
+  /// cached token**, so that reference is a contract value like any other — and until #183's
+  /// second review round every push in this kit reduced it to `is_ok()`. A cache can store the
+  /// offered entry perfectly and hand back a reference assembled from a *different* resident, and
+  /// nothing downstream can tell: `front`, `back`, the pops and `peek` all read storage, which is
+  /// correct, while the value the caller was actually handed is not.
+  ///
+  /// Both push arms and all sixteen push sites route through this **one** comparison, which is
+  /// what lets a single mutant pin the read everywhere it happens. On success the caller gets its
+  /// own offered entry back as the expectation to keep — the same value it handed over, now
+  /// checked against what the cache says it placed. A refusal is passed straight through: the
+  /// round-trip is a different law, asserted by the callers that drive a refusal on purpose.
+  fn checked_push(
+    &self,
+    result: Result<CachedTokenRefOf<'_, 'inp, L>, CachedTokenOf<'inp, L>>,
+    expectation: CachedTokenOf<'inp, L>,
+    site: &str,
+  ) -> Result<CachedTokenOf<'inp, L>, CachedTokenOf<'inp, L>> {
+    let name = self.label();
+    match result {
+      Ok(placed) => {
+        let placed_span = (**placed.token().span_ref()).clone();
+        let offered_span = span_of::<L>(&expectation);
+        self.assert_ref_entry_eq(
+          &placed,
+          &expectation,
+          &format!("accepted-push {site}"),
+          format_args!(
+            "tokora cache conformance [{name} accepted-push] {site}: the push was accepted and returned a reference to {placed_span:?}, expected the entry it was just handed, {offered_span:?}. `push_back`/`push_front` promise `Ok` with a reference to the token they cached."
+          ),
+          NO_NOTE,
+        );
+        Ok(expectation)
+      }
+      Err(returned) => Err(returned),
+    }
+  }
+
+  /// The one place in the kit that calls [`Cache::push_back`], and the one place that decides
+  /// what an `Err` from it means.
+  ///
+  /// `must_accept` is the caller's expectation at THIS push, which is what the two mixed sites
+  /// (checks 3 and 5) need: the same call there can produce a warranted refusal or an
+  /// unwarranted one, and until #183's fifth review round the unwarranted branch asserted its
+  /// way out before the returned entry reached any comparison. The split is:
+  ///
+  /// * accepted — the `Ok` reference is compared against the offered entry
+  ///   ([`checked_push`](Self::checked_push)), and the offered entry is handed back as the
+  ///   caller's expectation;
+  /// * refused where a refusal is legitimate — passed straight through, because the round-trip
+  ///   is a different law and the caller asserts it in its own wording (that is where
+  ///   `REFUSAL_STATE_SWAP` and `REFUSAL_TOKEN_SWAP` fire, and moving the comparison here would
+  ///   steal their site);
+  /// * refused where the contract required acceptance —
+  ///   [`unexpected_refusal`](Self::unexpected_refusal), which compares the entry and then
+  ///   panics with the site's own refusal wording.
+  fn push_back_expecting(
+    &self,
+    cache: &mut C,
+    tok: CachedTokenOf<'inp, L>,
+    site: &str,
+    must_accept: bool,
+    refusal: core::fmt::Arguments<'_>,
+  ) -> Result<CachedTokenOf<'inp, L>, CachedTokenOf<'inp, L>> {
+    let offered = tok.clone();
+    match self.checked_push(cache.push_back(tok), offered.clone(), site) {
+      Ok(placed) => Ok(placed),
+      Err(returned) => {
+        if must_accept {
+          self.unexpected_refusal(returned, offered, site, refusal)
+        } else {
+          Err(returned)
+        }
+      }
+    }
+  }
+
+  /// [`push_back_expecting`](Self::push_back_expecting) on the prepend arm, and the one place in
+  /// the kit that calls [`Cache::push_front`].
+  fn push_front_expecting(
+    &self,
+    cache: &mut C,
+    tok: CachedTokenOf<'inp, L>,
+    site: &str,
+    must_accept: bool,
+    refusal: core::fmt::Arguments<'_>,
+  ) -> Result<CachedTokenOf<'inp, L>, CachedTokenOf<'inp, L>> {
+    let offered = tok.clone();
+    match self.checked_push(cache.push_front(tok), offered.clone(), site) {
+      Ok(placed) => Ok(placed),
+      Err(returned) => {
+        if must_accept {
+          self.unexpected_refusal(returned, offered, site, refusal)
+        } else {
+          Err(returned)
+        }
+      }
+    }
+  }
+
+  /// A `push_back` at a site where a refusal is a case to handle rather than a violation.
+  fn checked_push_back(
+    &self,
+    cache: &mut C,
+    tok: CachedTokenOf<'inp, L>,
+    site: &str,
+  ) -> Result<CachedTokenOf<'inp, L>, CachedTokenOf<'inp, L>> {
+    self.push_back_expecting(
+      cache,
+      tok,
+      site,
+      false,
+      format_args!("refusal is legitimate here"),
+    )
+  }
+
+  /// A `push_back` the contract says cannot be refused, with the site's own refusal wording.
+  ///
+  /// Returns the entry the caller offered, once the accepted push's `Ok` reference has been
+  /// checked against it — so the expectation lists the callers build are the same values they
+  /// handed over, and the cache has agreed it placed them.
+  fn accepted_push_back(
+    &self,
+    cache: &mut C,
+    tok: CachedTokenOf<'inp, L>,
+    site: &str,
+    refusal: core::fmt::Arguments<'_>,
+  ) -> CachedTokenOf<'inp, L> {
+    match self.push_back_expecting(cache, tok, site, true, refusal) {
+      Ok(placed) => placed,
+      Err(_) => unreachable!(
+        "push_back_expecting diverges through unexpected_refusal when must_accept is set"
+      ),
+    }
+  }
+
+  /// [`accepted_push_back`](Self::accepted_push_back) on the prepend arm.
+  fn accepted_push_front(
+    &self,
+    cache: &mut C,
+    tok: CachedTokenOf<'inp, L>,
+    site: &str,
+    refusal: core::fmt::Arguments<'_>,
+  ) -> CachedTokenOf<'inp, L> {
+    match self.push_front_expecting(cache, tok, site, true, refusal) {
+      Ok(placed) => placed,
+      Err(_) => unreachable!(
+        "push_front_expecting diverges through unexpected_refusal when must_accept is set"
+      ),
+    }
+  }
+
+  /// The refusal a site did not expect: the entry that came back is **compared first**, and the
+  /// site's own refusal message is the panic that follows.
+  ///
+  /// The refusal is the louder violation and the message the callers pin names it, so it is what
+  /// this ends on. But the value handed back is still a value the kit received, and dropping it
+  /// on the way to the panic was the last place in the kit that took a `Cache` return and looked
+  /// only at its shape.
+  ///
+  /// **Deliberately not in [`checked_push`](Self::checked_push)'s `Err` arm.** The sites that
+  /// drive a refusal *on purpose* — check 3's and check 5's round-trips — already compare there,
+  /// in their own wording, and that is where `REFUSAL_STATE_SWAP` and `REFUSAL_TOKEN_SWAP` fire.
+  /// Moving the comparison up into the shared helper would run it twice and would relocate those
+  /// two cells' firing site, unpinning the round-trip messages their `expected` strings name —
+  /// the same pin-theft that `STATE_LAG` nearly suffered when the accepted-push comparison was
+  /// added. So it lives here, on the path no caller compares, and nowhere else.
+  ///
+  /// No cache reaches this by conforming: getting here needs a refusal the contract does not
+  /// allow *and* a corrupted return, and the refusal alone already fails the kit. It closes a
+  /// claim rather than a hole — see the shape enumeration in the module docs.
+  fn unexpected_refusal(
+    &self,
+    returned: CachedTokenOf<'inp, L>,
+    offered: CachedTokenOf<'inp, L>,
+    site: &str,
+    refusal: core::fmt::Arguments<'_>,
+  ) -> ! {
+    let name = self.label();
+    let returned_span = span_of::<L>(&returned);
+    let offered_span = span_of::<L>(&offered);
+    self.assert_owned_entry_eq(
+      &returned,
+      &offered,
+      &format!("unexpected-refusal {site}"),
+      format_args!(
+        "tokora cache conformance [{name} unexpected-refusal] {site}: the push was refused when the contract required it be accepted, and it handed back {returned_span:?} rather than the entry it was offered, {offered_span:?}. A refusal must hand the caller its token unchanged, warranted or not."
+      ),
+      NO_NOTE,
+    );
+    panic!("{refusal}")
+  }
+
+  /// A pop whose answer the kit already knows: it must answer, and it must answer with `want`.
+  /// The one place in the kit that calls [`Cache::pop_front`] for a value it intends to keep.
+  ///
+  /// The residency sweeps drive runs of pops purely to *reach* a residency, and until #183's
+  /// second review round each of those asserted `is_some()` and threw the entry away. The entry
+  /// is never unknown at those sites — it is the next one off the end being drained — so there is
+  /// nothing to justify not comparing it, and a pop that removes the right entry while returning
+  /// a wrong one is precisely the class this kit exists to catch.
+  fn drained_front(
+    &self,
+    cache: &mut C,
+    want: &CachedTokenOf<'inp, L>,
+    site: &str,
+    absent: core::fmt::Arguments<'_>,
+    tail: &str,
+  ) -> CachedTokenOf<'inp, L> {
+    let popped = cache.pop_front();
+    self.drained(popped, want, site, absent, tail, NO_NOTE)
+  }
+
+  /// [`drained_front`](Self::drained_front) at the other end, and the one place the kit calls
+  /// [`Cache::pop_back`] for a value it intends to keep.
+  ///
+  /// The restore note is not a parameter here: `pop_back` **is** the input layer's rollback
+  /// path, at every site, so the note belongs to the end rather than to the caller — one fewer
+  /// thing a new drain can forget.
+  fn drained_back(
+    &self,
+    cache: &mut C,
+    want: &CachedTokenOf<'inp, L>,
+    site: &str,
+    absent: core::fmt::Arguments<'_>,
+    tail: &str,
+  ) -> CachedTokenOf<'inp, L> {
+    let popped = cache.pop_back();
+    self.drained(popped, want, site, absent, tail, RESTORE_NOTE)
+  }
+
+  /// The shared body of the two drains above: the pop must answer, and it must answer with
+  /// `want` in all three components.
+  ///
+  /// `tail` is the site's own explanatory sentence, appended to a uniform lede so each drain
+  /// keeps the rationale it had before the routing — what a wrong answer means at *that* site —
+  /// while the lede and the entry comparison stay in one place.
+  fn drained(
+    &self,
+    popped: Option<CachedTokenOf<'inp, L>>,
+    want: &CachedTokenOf<'inp, L>,
+    site: &str,
+    absent: core::fmt::Arguments<'_>,
+    tail: &str,
+    state_note: &str,
+  ) -> CachedTokenOf<'inp, L> {
+    let name = self.label();
+    let Some(popped) = popped else {
+      panic!("{absent}")
+    };
+    let got_span = span_of::<L>(&popped);
+    let want_span = span_of::<L>(want);
+    self.assert_owned_entry_eq(
+      &popped,
+      want,
+      site,
+      format_args!(
+        "tokora cache conformance [{name} drain] {site}: the pop removed {got_span:?}, expected {want_span:?}.{tail}"
+      ),
+      state_note,
+    );
+    popped
+  }
+
+  /// The `front()` edge read, compared in full — and the one place the kit calls
+  /// [`Cache::front`].
+  fn assert_front_entry(&self, cache: &C, want: Option<&CachedTokenOf<'inp, L>>, when: &str) {
+    let name = self.label();
+    match (want, cache.front()) {
+      (Some(expected), Some(got)) => {
+        let expected_span = span_of::<L>(expected);
+        let got_span = (**got.token().span_ref()).clone();
+        self.assert_ref_entry_eq(
+          &got,
+          expected,
+          &format!("edge-identity front() {when}"),
+          format_args!(
+            "tokora cache conformance [{name} edge-identity] {when}: front() names {got_span:?}, expected the OLDEST resident entry {expected_span:?} — the same entry front_span() must name"
+          ),
+          NO_NOTE,
+        );
+      }
+      (None, None) => {}
+      (a, b) => panic!(
+        "tokora cache conformance [{name} edge-identity] {when}: front() presence disagrees — expected {:?}, got {:?}",
+        a.map(span_of::<L>),
+        b.map(|t| (**t.token().span_ref()).clone())
+      ),
+    }
+  }
+
+  /// The `back()` edge read — the entry `InputRef::resume` rebuilds a lexer from, which is why
+  /// its state message carries [`RESTORE_NOTE`]. The one place the kit calls [`Cache::back`].
+  fn assert_back_entry(&self, cache: &C, want: Option<&CachedTokenOf<'inp, L>>, when: &str) {
+    let name = self.label();
+    match (want, cache.back()) {
+      (Some(expected), Some(got)) => {
+        let expected_span = span_of::<L>(expected);
+        let got_span = (**got.token().span_ref()).clone();
+        self.assert_ref_entry_eq(
+          &got,
+          expected,
+          &format!("edge-identity back() {when}"),
+          format_args!(
+            "tokora cache conformance [{name} edge-identity] {when}: back() names {got_span:?}, expected the NEWEST resident entry {expected_span:?} — the same entry back_span() must name"
+          ),
+          RESTORE_NOTE,
+        );
+      }
+      (None, None) => {}
+      (a, b) => panic!(
+        "tokora cache conformance [{name} edge-identity] {when}: back() presence disagrees — expected {:?}, got {:?}",
+        a.map(span_of::<L>),
+        b.map(|t| (**t.token().span_ref()).clone())
+      ),
+    }
+  }
+
+  /// `peek_one` as the triple the kit compares — the one place it is called for a value.
+  fn peeked_one(&self, cache: &C) -> Option<PeekedTriple<'inp, L>> {
+    cache.peek_one().map(|one| Self::triple(&one))
+  }
+
+  /// `pop_front_if` driven with a **recording** predicate, its argument compared against the
+  /// front entry before anything else is asserted. The one place the kit calls it for a value.
+  ///
+  /// Routed rather than written inline at each site so the predicate argument cannot be
+  /// discarded by a future edit: the closure lives here, and the comparison is unconditional.
+  fn recording_pop_front_if(
+    &self,
+    cache: &mut C,
+    want_front: &CachedTokenOf<'inp, L>,
+    answer: bool,
+    site: &str,
+    lede: &str,
+  ) -> Option<CachedTokenOf<'inp, L>> {
+    let seen: Cell<Option<PeekedTriple<'inp, L>>> = Cell::new(None);
+    let popped = cache.pop_front_if(|tok| {
+      seen.set(Some(Self::ref_triple(&tok)));
+      answer
+    });
+    self.assert_recorded_predicate_arg(seen.take().as_ref(), want_front, site, lede);
+    popped
+  }
+
+  /// [`recording_pop_front_if`](Self::recording_pop_front_if)'s twin on the fallible arm.
+  fn recording_try_pop_front_if(
+    &self,
+    cache: &mut C,
+    want_front: &CachedTokenOf<'inp, L>,
+    outcome: Result<(), &'static str>,
+    site: &str,
+    lede: &str,
+  ) -> Option<Result<CachedTokenOf<'inp, L>, &'static str>> {
+    let seen: Cell<Option<PeekedTriple<'inp, L>>> = Cell::new(None);
+    let popped = cache.try_pop_front_if::<&'static str, _>(|tok| {
+      seen.set(Some(Self::ref_triple(&tok)));
+      outcome
+    });
+    self.assert_recorded_predicate_arg(seen.take().as_ref(), want_front, site, lede);
+    popped
+  }
+
+  // ── the entry comparison every oracle reads its answers through ─────────────────
+
+  /// The kit's fundamental comparison: a cached entry is the triple (span, token, state), and a
+  /// cache that hands one back has to hand back all three of them (#183).
+  ///
+  /// `span_msg` is the calling site's own span-half message, kept **verbatim** from before the
+  /// entry observable existed, so the cells that pin its wording (`front() names`, `OLDEST
+  /// FIRST`, `a refused push_back returned a DIFFERENT token`, …) keep matching. The token and
+  /// state halves get tags of their own — `entry-token` and `entry-state` — so each of the three
+  /// components fails with its own greppable message and a mutant can pin exactly the comparison
+  /// it exists to exercise.
+  ///
+  /// **Span first, always.** A defect that moves an entry to the wrong position corrupts all
+  /// three components at once, and it is an *ordering* violation; reporting it as a token
+  /// mismatch would bury the diagnosis and break every existing expectation. The token and state
+  /// halves therefore only ever speak about an entry the span half has already agreed is the
+  /// right one.
+  ///
+  /// `state_note` is [`RESTORE_NOTE`] at the `back()`/`pop_back` sites and [`NO_NOTE`] everywhere
+  /// else.
+  fn assert_entry_eq(
+    &self,
+    got: (&L::Span, &L::Token, &L::State),
+    want: &CachedTokenOf<'inp, L>,
+    site: &str,
+    span_msg: core::fmt::Arguments<'_>,
+    state_note: &str,
+  ) {
+    let name = self.label();
+    let (got_span, got_token, got_state) = got;
+    // Bound rather than chained: `token()` builds a `Spanned<&T, &Span>` by value, so reading
+    // through it in the assertion below would borrow from a temporary that is gone by the time
+    // the message is formatted.
+    let want_entry = want.token();
+    let want_span: &L::Span = want_entry.span_ref();
+    let want_token: &L::Token = want_entry.data();
+    assert!(got_span == want_span, "{span_msg}");
+    assert!(
+      got_token == want_token,
+      "tokora cache conformance [{name} entry-token] {site}: the entry at {want_span:?} is a DIFFERENT token from the one stored there — expected {want_token:?}, got {got_token:?}. A cached entry is the triple (span, token, state); a right span with someone else's token beside it is a permuted cache, not a conforming one."
+    );
+    assert!(
+      got_state == want.state(),
+      "tokora cache conformance [{name} entry-state] {site}: the entry at {want_span:?} carries a DIFFERENT L::State from the one stored there — expected {:?}, got {got_state:?}.{state_note}",
+      want.state()
+    );
+  }
+
+  /// [`assert_entry_eq`](Self::assert_entry_eq) against an **owned** entry — what `pop_front`,
+  /// `pop_back`, a refused push and `push_many`'s overflow iterator hand back.
+  fn assert_owned_entry_eq(
+    &self,
+    got: &CachedTokenOf<'inp, L>,
+    want: &CachedTokenOf<'inp, L>,
+    site: &str,
+    span_msg: core::fmt::Arguments<'_>,
+    state_note: &str,
+  ) {
+    self.assert_entry_eq(
+      (*got.token().span_ref(), *got.token().data(), got.state()),
+      want,
+      site,
+      span_msg,
+      state_note,
+    );
+  }
+
+  /// [`assert_entry_eq`](Self::assert_entry_eq) against a **borrowed** entry — what `front`,
+  /// `back` and the `pop_front_if` predicates are handed.
+  ///
+  /// `CachedTokenRefOf`'s own parameters are already references, so every accessor adds one more
+  /// level than the owned form does; that is the whole of the extra `*`s here.
+  fn assert_ref_entry_eq(
+    &self,
+    got: &CachedTokenRefOf<'_, 'inp, L>,
+    want: &CachedTokenOf<'inp, L>,
+    site: &str,
+    span_msg: core::fmt::Arguments<'_>,
+    state_note: &str,
+  ) {
+    self.assert_entry_eq(
+      (**got.token().span_ref(), **got.token().data(), *got.state()),
+      want,
+      site,
+      span_msg,
+      state_note,
+    );
+  }
+
+  /// [`assert_entry_eq`](Self::assert_entry_eq) against one **peeked** entry, flattened to the
+  /// triple by [`peeked_entries_through`](Self::peeked_entries_through) so that the borrowed and
+  /// owned arms of [`Maybe`] are read the same way.
+  fn assert_peeked_entry_eq(
+    &self,
+    got: &PeekedTriple<'inp, L>,
+    want: &CachedTokenOf<'inp, L>,
+    site: &str,
+    span_msg: core::fmt::Arguments<'_>,
+  ) {
+    self.assert_entry_eq((&got.0, &got.1, &got.2), want, site, span_msg, NO_NOTE);
+  }
+
+  /// The token and state halves of a whole peeked run, position by position.
+  ///
+  /// The span half is compared by the caller, as one vector against another, because that is the
+  /// assertion whose wording check 6's cells pin (`OLDEST FIRST`) and whose message shows the
+  /// reader the run rather than one entry of it. This walks the same positions afterwards, so a
+  /// re-association inside a run whose spans are all in the right place still fails.
+  fn assert_peeked_run_eq(
+    &self,
+    got: &[PeekedTriple<'inp, L>],
+    want: &[CachedTokenOf<'inp, L>],
+    site: &str,
+  ) {
+    for (i, (entry, expected)) in got.iter().zip(want).enumerate() {
+      self.assert_peeked_entry_eq(
+        entry,
+        expected,
+        site,
+        format_args!(
+          "tokora cache conformance kit bug [{} bounded-peek] {site}: position {i} of the peeked run has a span the vector comparison above should already have rejected",
+          self.label()
+        ),
+      );
+    }
   }
 
   // ── 1. empty invariants ─────────────────────────────────────────────────────────
@@ -583,9 +1249,17 @@ where
       "tokora cache conformance [{name} empty-invariants/{when}]: remaining() is {}, expected the empty-cache capacity {cap}. `remaining` must be exactly how many more push_back calls will be accepted.",
       cache.remaining()
     );
+    // Presence-only by construction, here and for the three probes below: the law under test is
+    // that these do NOT answer, so there is no entry behind any of them for the entry comparison
+    // to read. This is the documented exception to "every value a Cache method hands back is
+    // read" — absence is the whole observable, not a weaker view of one.
     assert!(
-      cache.front().is_none() && cache.back().is_none(),
-      "tokora cache conformance [{name} empty-invariants/{when}]: front()/back() answered on an empty cache"
+      cache.front().is_none(),
+      "tokora cache conformance [{name} empty-invariants/{when}]: front()/back() answered on an empty cache — front() did"
+    );
+    assert!(
+      cache.back().is_none(),
+      "tokora cache conformance [{name} empty-invariants/{when}]: front()/back() answered on an empty cache — back() did"
     );
     assert!(
       cache.front_span().is_none() && cache.back_span().is_none(),
@@ -600,16 +1274,23 @@ where
     // one it never touched proves nothing about whether THIS cache's pop methods still work —
     // or still refuse to answer — after whatever produced its current empty state (#180 part A,
     // item 2).
+    // One assertion per end rather than one `&&` over both: `&&` short-circuits, so a cache that
+    // wrongly answers on `pop_front` would leave `pop_back` unprobed and its own defect unnamed.
+    // Split, each end is called and each failure says which one answered.
     assert!(
-      cache.pop_front().is_none() && cache.pop_back().is_none(),
-      "tokora cache conformance [{name} empty-invariants/{when}]: a pop answered on an empty cache"
+      cache.pop_front().is_none(),
+      "tokora cache conformance [{name} empty-invariants/{when}]: a pop answered on an empty cache — pop_front() did"
+    );
+    assert!(
+      cache.pop_back().is_none(),
+      "tokora cache conformance [{name} empty-invariants/{when}]: a pop answered on an empty cache — pop_back() did"
     );
     assert!(
       cache.peek_one().is_none(),
       "tokora cache conformance [{name} empty-invariants/{when}]: peek_one() answered on an empty cache"
     );
     assert!(
-      self.peeked_spans(cache).is_empty(),
+      self.peeked_entries(cache).is_empty(),
       "tokora cache conformance [{name} empty-invariants/{when}]: peek() appended entries from an empty cache"
     );
   }
@@ -638,15 +1319,20 @@ where
       .corpus(1)
       .pop()
       .expect("run() checked the corpus is non-empty");
-    let first_span = span_of::<L>(&first);
-    assert!(
-      fresh.push_front(first).is_ok(),
-      "tokora cache conformance [{name} retains-front]: the FIRST operation on a fresh cache — a push_front while it is empty — was refused while RETAINS_FRONT is declared true. The input layer compiles its parked-slot fallback OUT on that declaration, so a refusal here loses the token — declare `false` or retain the front."
+    // The whole entry, cloned before the push hands the original to the cache: what
+    // `assert_resident` compares is the triple, so the expectation has to carry all of it.
+    let want_first = self.accepted_push_front(
+      &mut fresh,
+      first,
+      "push_front into a fresh cache, retains-front",
+      format_args!(
+        "tokora cache conformance [{name} retains-front]: the FIRST operation on a fresh cache — a push_front while it is empty — was refused while RETAINS_FRONT is declared true. The input layer compiles its parked-slot fallback OUT on that declaration, so a refusal here loses the token — declare `false` or retain the front."
+      ),
     );
     self.assert_resident(
       &fresh,
       cap,
-      core::slice::from_ref(&first_span),
+      core::slice::from_ref(&want_first),
       "after the first-ever operation, a push_front into a fresh cache",
     );
 
@@ -654,16 +1340,33 @@ where
     // drained once, and then stops, is the same violation reached from the other side.
     let mut cache = self.make();
     let tok = self.corpus(1).pop().expect("the corpus is non-empty");
-    assert!(
-      cache.push_back(tok).is_ok(),
-      "tokora cache conformance [{name} retains-front]: push_back into an empty cache was refused while RETAINS_FRONT is true"
+    let seeded = self.accepted_push_back(
+      &mut cache,
+      tok,
+      "push_back seeding an empty cache, retains-front",
+      format_args!(
+        "tokora cache conformance [{name} retains-front]: push_back into an empty cache was refused while RETAINS_FRONT is true"
+      ),
     );
-    let popped = cache
-      .pop_front()
-      .expect("just pushed one entry, so a pop must answer");
-    assert!(
-      cache.push_front(popped).is_ok(),
-      "tokora cache conformance [{name} retains-front]: push_front into an emptied cache was refused while RETAINS_FRONT is declared true. The input layer compiles its parked-slot fallback OUT on that declaration, so a refusal here loses the token — declare `false` or retain the front."
+    // The entry the pop hands back is the one that was just pushed, and it is compared as such:
+    // it is re-pushed on the next line and becomes the residency the caller then reasons about,
+    // so a corrupt pop here would seed the expectation with its own corruption.
+    let popped = self.drained_front(
+      &mut cache,
+      &seeded,
+      "retains-front pop_front off a one-entry cache",
+      format_args!(
+        "tokora cache conformance [{name} retains-front]: the pop that empties a one-entry cache answered None"
+      ),
+      " The entry is re-pushed on the next line and becomes the residency this check then reasons about, so a corrupt pop here would seed the expectation with its own corruption.",
+    );
+    self.accepted_push_front(
+      &mut cache,
+      popped,
+      "push_front into an emptied cache, retains-front",
+      format_args!(
+        "tokora cache conformance [{name} retains-front]: push_front into an emptied cache was refused while RETAINS_FRONT is declared true. The input layer compiles its parked-slot fallback OUT on that declaration, so a refusal here loses the token — declare `false` or retain the front."
+      ),
     );
   }
 
@@ -701,15 +1404,18 @@ where
       .corpus(1)
       .pop()
       .expect("run() checked the corpus is non-empty");
-    let span = span_of::<L>(&tok);
-    assert!(
-      fresh.push_front(tok).is_ok(),
-      "tokora cache conformance [{name} push-front/into-empty]: a push_front into an EMPTY cache — the first operation this one has seen, with all {cap} slots free — was REFUSED. A push is refused only when the cache is FULL, on this arm exactly as on push_back's, and an empty cache with capacity is not full. RETAINS_FRONT is declared {declares}, which decides what the refusal costs the input layer (a parked slot, or a lost token where the fallback is compiled out), not whether it is allowed."
+    let want_fresh = self.accepted_push_front(
+      &mut fresh,
+      tok,
+      "push_front into a fresh, empty cache",
+      format_args!(
+        "tokora cache conformance [{name} push-front/into-empty]: a push_front into an EMPTY cache — the first operation this one has seen, with all {cap} slots free — was REFUSED. A push is refused only when the cache is FULL, on this arm exactly as on push_back's, and an empty cache with capacity is not full. RETAINS_FRONT is declared {declares}, which decides what the refusal costs the input layer (a parked slot, or a lost token where the fallback is compiled out), not whether it is allowed."
+      ),
     );
     self.assert_resident(
       &fresh,
       cap,
-      core::slice::from_ref(&span),
+      core::slice::from_ref(&want_fresh),
       "after a push_front into a fresh, empty cache",
     );
 
@@ -717,22 +1423,38 @@ where
     // established lazily and then torn down again with the entry that established it.
     let mut used = self.make();
     let tok = self.corpus(1).pop().expect("the corpus is non-empty");
-    assert!(
-      used.push_back(tok).is_ok(),
-      "tokora cache conformance [{name} push-front/into-empty]: push_back into an empty cache with {cap} slots free was refused"
+    let seeded = self.accepted_push_back(
+      &mut used,
+      tok,
+      "push_back seeding an empty cache, push-front/into-empty",
+      format_args!(
+        "tokora cache conformance [{name} push-front/into-empty]: push_back into an empty cache with {cap} slots free was refused"
+      ),
     );
-    let popped = used
-      .pop_front()
-      .expect("just pushed one entry, so a pop must answer");
-    let span = span_of::<L>(&popped);
-    assert!(
-      used.push_front(popped).is_ok(),
-      "tokora cache conformance [{name} push-front/into-empty]: a push_front into a cache that was filled and then emptied — all {cap} slots free again — was REFUSED. A push is refused only when the cache is FULL, and this one holds nothing."
+    // Compared against what was seeded, for the reason `check_retains_front`'s twin is: the
+    // popped entry is re-pushed and becomes the expectation this check then asserts against, so
+    // a corrupt pop would otherwise define its own correctness.
+    let popped = self.drained_front(
+      &mut used,
+      &seeded,
+      "push-front/into-empty pop_front off a one-entry cache",
+      format_args!(
+        "tokora cache conformance [{name} push-front/into-empty]: the pop that empties a one-entry cache answered None"
+      ),
+      " The entry is re-pushed on the next line and becomes the residency this check then reasons about.",
+    );
+    let want_used = self.accepted_push_front(
+      &mut used,
+      popped,
+      "push_front into a used, emptied cache",
+      format_args!(
+        "tokora cache conformance [{name} push-front/into-empty]: a push_front into a cache that was filled and then emptied — all {cap} slots free again — was REFUSED. A push is refused only when the cache is FULL, and this one holds nothing."
+      ),
     );
     self.assert_resident(
       &used,
       cap,
-      core::slice::from_ref(&span),
+      core::slice::from_ref(&want_used),
       "after a push_front into a used, emptied cache",
     );
   }
@@ -743,31 +1465,47 @@ where
     let name = self.label();
     let mut cache = self.make();
     let corpus = self.corpus(cap.saturating_add(1).max(2));
-    let mut resident: Vec<L::Span> = Vec::new();
+    let mut resident: Vec<CachedTokenOf<'inp, L>> = Vec::new();
 
     for (i, tok) in corpus.into_iter().enumerate() {
+      let offered = tok.clone();
       let span = span_of::<L>(&tok);
       let expect_accept = resident.len() < cap;
-      match cache.push_back(tok) {
-        Ok(_) => {
+      // The mixed site: this same call can produce a warranted refusal or an unwarranted one, and
+      // `must_accept` is what tells the router which. Before #183's fifth review round the
+      // unwarranted branch asserted its way out below and the returned entry was never compared.
+      let refusal = format!(
+        "tokora cache conformance [{name} exact-length]: push_back #{i} was REFUSED with {} of {cap} slots used; `remaining` promised it would be accepted",
+        resident.len()
+      );
+      match self.push_back_expecting(
+        &mut cache,
+        tok,
+        &format!("push_back #{i}"),
+        expect_accept,
+        format_args!("{refusal}"),
+      ) {
+        Ok(placed) => {
           assert!(
             expect_accept,
             "tokora cache conformance [{name} exact-length]: push_back #{i} was ACCEPTED with {} entries resident and a capacity of {cap}; `remaining` had already reached 0, so this push contradicts it",
             resident.len()
           );
-          resident.push(span);
+          resident.push(placed);
         }
         Err(returned) => {
-          assert!(
-            !expect_accept,
-            "tokora cache conformance [{name} exact-length]: push_back #{i} was REFUSED with {} of {cap} slots used; `remaining` promised it would be accepted",
-            resident.len()
-          );
           // The refusal round-trip: the token comes back unchanged, and nothing moved.
+          // "Unchanged" is the whole ENTRY — a refusal that hands back the offered span with
+          // somebody else's token or state beside it has changed it (#183).
           let back_span = span_of::<L>(&returned);
-          assert!(
-            back_span == span,
-            "tokora cache conformance [{name} refusal-round-trip]: a refused push_back returned a DIFFERENT token: pushed span {span:?}, got back {back_span:?}. A refusal must hand the caller its token unchanged."
+          self.assert_owned_entry_eq(
+            &returned,
+            &offered,
+            "refusal-round-trip push_back",
+            format_args!(
+              "tokora cache conformance [{name} refusal-round-trip]: a refused push_back returned a DIFFERENT token: pushed span {span:?}, got back {back_span:?}. A refusal must hand the caller its token unchanged."
+            ),
+            NO_NOTE,
           );
           self.assert_resident(&cache, cap, &resident, "after a refused push_back");
         }
@@ -782,7 +1520,12 @@ where
   }
 
   /// The four length/edge observables against the list the kit is tracking.
-  fn assert_resident(&self, cache: &C, cap: usize, want: &[L::Span], when: &str) {
+  ///
+  /// `want` is the list of **entries** the cache should be holding. The counts and the
+  /// `front_span`/`back_span` laws read only their spans, which is all those accessors return;
+  /// the `front()`/`back()` reads below compare the whole entry, because that is what those two
+  /// return and what a restore then resumes from (#183).
+  fn assert_resident(&self, cache: &C, cap: usize, want: &[CachedTokenOf<'inp, L>], when: &str) {
     let name = self.label();
     assert!(
       cache.len() == want.len(),
@@ -812,7 +1555,12 @@ where
       cap - want.len(),
       want.len()
     );
-    match (want.first(), cache.front_span()) {
+    // The two span accessors, against the spans of the entries the kit is tracking. These are
+    // span-valued by signature — `front_span`/`back_span` return `&L::Span` and nothing else — so
+    // the entry comparison has no purchase here; it belongs to the `front()`/`back()` reads below.
+    let want_front_span = want.first().map(span_of::<L>);
+    let want_back_span = want.last().map(span_of::<L>);
+    match (want_front_span.as_ref(), cache.front_span()) {
       (Some(expected), Some(got)) => assert!(
         got == expected,
         "tokora cache conformance [{name} fifo-append] {when}: front is {got:?}, expected the OLDEST resident entry {expected:?}"
@@ -822,7 +1570,7 @@ where
         "tokora cache conformance [{name} fifo-append] {when}: front presence disagrees — expected {a:?}, got {b:?}"
       ),
     }
-    match (want.last(), cache.back_span()) {
+    match (want_back_span.as_ref(), cache.back_span()) {
       (Some(expected), Some(got)) => assert!(
         got == expected,
         "tokora cache conformance [{name} fifo-append] {when}: back is {got:?}, expected the NEWEST resident entry {expected:?}. `push_back` appends after every resident entry."
@@ -841,29 +1589,12 @@ where
     // exactly the accessor a ring specializes off its head index rather than paying for a
     // `CachedTokenRef`, and a cache that overrides BOTH, with the cheap span half right and the
     // reference half wrong, had nothing to answer to. The entry a caller reads through `front()`
-    // carries the token and the `L::State` a restore resumes from; the span half alone does not.
-    let front_ref: Option<L::Span> = cache.front().map(|t| (**t.token().span_ref()).clone());
-    match (want.first(), &front_ref) {
-      (Some(expected), Some(got)) => assert!(
-        got == expected,
-        "tokora cache conformance [{name} edge-identity] {when}: front() names {got:?}, expected the OLDEST resident entry {expected:?} — the same entry front_span() must name"
-      ),
-      (None, None) => {}
-      (a, b) => panic!(
-        "tokora cache conformance [{name} edge-identity] {when}: front() presence disagrees — expected {a:?}, got {b:?}"
-      ),
-    }
-    let back_ref: Option<L::Span> = cache.back().map(|t| (**t.token().span_ref()).clone());
-    match (want.last(), &back_ref) {
-      (Some(expected), Some(got)) => assert!(
-        got == expected,
-        "tokora cache conformance [{name} edge-identity] {when}: back() names {got:?}, expected the NEWEST resident entry {expected:?} — the same entry back_span() must name"
-      ),
-      (None, None) => {}
-      (a, b) => panic!(
-        "tokora cache conformance [{name} edge-identity] {when}: back() presence disagrees — expected {a:?}, got {b:?}"
-      ),
-    }
+    // carries the token and the `L::State` a restore resumes from; the span half alone does not —
+    // which is why since #183 these two reads compare the whole entry and not its span. A ring
+    // that assembles its edge references out of a span array and a state array, one index apart,
+    // answers the span half perfectly.
+    self.assert_front_entry(cache, want.first(), when);
+    self.assert_back_entry(cache, want.last(), when);
   }
 
   // ── 4. pop order ────────────────────────────────────────────────────────────────
@@ -886,19 +1617,24 @@ where
           )
         })
         .clone();
-      let popped = cache
-        .pop_front()
-        .unwrap_or_else(|| panic!("tokora cache conformance [{name} order]: pop_front() is empty with {} entries still to pop", want.len() - i));
-      let got = span_of::<L>(&popped);
-      assert!(
-        got == *expected,
-        "tokora cache conformance [{name} order]: pop_front #{i} returned {got:?}, expected the OLDEST resident entry {expected:?}"
+      let popped = self.drained_front(
+        &mut cache,
+        expected,
+        &format!("order pop_front #{i}"),
+        format_args!(
+          "tokora cache conformance [{name} order]: pop_front() is empty with {} entries still to pop",
+          want.len() - i
+        ),
+        " `pop_front` removes the OLDEST resident entry.",
       );
+      let got = span_of::<L>(&popped);
       assert!(
         viewed == got,
         "tokora cache conformance [{name} order]: front() viewed {viewed:?} but pop_front() removed {got:?}; they must name the same entry"
       );
     }
+    // Presence-only, and the law: after a full drain there is no entry left for a pop to return,
+    // so absence is the whole observable. (Documented exception — see `checked_push`.)
     assert!(
       cache.pop_front().is_none(),
       "tokora cache conformance [{name} order]: pop_front() still answers after every resident entry was drained"
@@ -914,19 +1650,20 @@ where
           panic!("tokora cache conformance [{name} order]: back() is empty mid-drain")
         })
         .clone();
-      let popped = cache.pop_back().unwrap_or_else(|| {
-        panic!("tokora cache conformance [{name} order]: pop_back() is empty mid-drain")
-      });
-      let got = span_of::<L>(&popped);
-      assert!(
-        got == *expected,
-        "tokora cache conformance [{name} order]: pop_back #{i} returned {got:?}, expected the NEWEST resident entry {expected:?}. The input layer drops an abandoned continuation's entries with a run of pop_back calls, so a pop_back that is not newest-first drops the wrong tokens."
+      let popped = self.drained_back(
+        &mut cache,
+        expected,
+        &format!("order pop_back #{i}"),
+        format_args!("tokora cache conformance [{name} order]: pop_back() is empty mid-drain"),
+        " `pop_back` removes the NEWEST resident entry. The input layer drops an abandoned continuation's entries with a run of pop_back calls, so a pop_back that is not newest-first drops the wrong tokens.",
       );
+      let got = span_of::<L>(&popped);
       assert!(
         viewed == got,
         "tokora cache conformance [{name} order]: back() viewed {viewed:?} but pop_back() removed {got:?}; they must name the same entry"
       );
     }
+    // Presence-only, and the law — see the `pop_front` twin above.
     assert!(
       cache.pop_back().is_none(),
       "tokora cache conformance [{name} order]: pop_back() still answers after every resident entry was drained"
@@ -944,29 +1681,44 @@ where
     let name = self.label();
     let corpus = self.corpus(cap.saturating_add(1));
     let mut cache = self.make();
-    let mut resident: Vec<L::Span> = Vec::new();
+    let mut resident: Vec<CachedTokenOf<'inp, L>> = Vec::new();
     let mut refusals = 0usize;
 
     // One at the back, then everything else at the front: each must land BEFORE the rest.
     let mut it = corpus.into_iter();
     let first = it.next().expect("the corpus has at least two tokens");
-    let first_span = span_of::<L>(&first);
-    assert!(
-      cache.push_back(first).is_ok(),
-      "tokora cache conformance [{name} push-front]: the first push_back into an empty cache was refused"
+    let want_first = self.accepted_push_back(
+      &mut cache,
+      first,
+      "push_back seeding the prepend driver",
+      format_args!(
+        "tokora cache conformance [{name} push-front]: the first push_back into an empty cache was refused"
+      ),
     );
-    resident.push(first_span);
+    resident.push(want_first);
 
     for (i, tok) in it.enumerate() {
+      let offered = tok.clone();
       let span = span_of::<L>(&tok);
       let full = resident.len() == cap;
-      match cache.push_front(tok) {
-        Ok(_) => {
+      // The prepend arm's mixed site — see the `push_back` twin in check 3.
+      let refusal = format!(
+        "tokora cache conformance [{name} exact-length]: push_front #{i} was REFUSED with {} of {cap} slots used; a push is refused only when the cache is FULL. The input layer's put-back lands here: a refusal parks the token in the fallback slot (or panics outright, where RETAINS_FRONT is declared), so refusing early spends a resource the cache had no need of.",
+        resident.len()
+      );
+      match self.push_front_expecting(
+        &mut cache,
+        tok,
+        &format!("push_front #{i}"),
+        !full,
+        format_args!("{refusal}"),
+      ) {
+        Ok(placed) => {
           assert!(
             !full,
             "tokora cache conformance [{name} exact-length]: push_front #{i} was accepted at capacity {cap}"
           );
-          resident.insert(0, span.clone());
+          resident.insert(0, placed);
           // The prepend law itself, before the generic residency check: the entry just pushed
           // must be the one `front` names.
           match cache.front_span() {
@@ -982,18 +1734,19 @@ where
         Err(returned) => {
           // A refusal has to be EARNED, exactly as on the `push_back` arm: a cache that hands
           // the token back with room still left has refused nothing it was entitled to refuse.
-          // Without this the two halves of the same law were asymmetric, and the round-trip and
-          // residency checks below — which a cache that simply declines everything satisfies
-          // trivially — were the whole of what a refusal had to survive.
-          assert!(
-            full,
-            "tokora cache conformance [{name} exact-length]: push_front #{i} was REFUSED with {} of {cap} slots used; a push is refused only when the cache is FULL. The input layer's put-back lands here: a refusal parks the token in the fallback slot (or panics outright, where RETAINS_FRONT is declared), so refusing early spends a resource the cache had no need of.",
-            resident.len()
-          );
+          // That assertion now lives in the router above, as the `refusal` message it panics
+          // with when `must_accept` holds — same wording, but reached only *after* the returned
+          // entry has been compared. Re-asserting `full` here would be an assertion that cannot
+          // fail, since the router diverges on every refusal this arm would have caught.
           let back_span = span_of::<L>(&returned);
-          assert!(
-            back_span == span,
-            "tokora cache conformance [{name} refusal-round-trip]: a refused push_front returned a DIFFERENT token: pushed {span:?}, got back {back_span:?}"
+          self.assert_owned_entry_eq(
+            &returned,
+            &offered,
+            "refusal-round-trip push_front",
+            format_args!(
+              "tokora cache conformance [{name} refusal-round-trip]: a refused push_front returned a DIFFERENT token: pushed {span:?}, got back {back_span:?}"
+            ),
+            NO_NOTE,
           );
           self.assert_resident(&cache, cap, &resident, "after a refused push_front");
           refusals += 1;
@@ -1040,18 +1793,21 @@ where
     for depth in 1..cap {
       let (mut mixed, order) = self.front_built(cap, depth);
       for (i, expected) in order.iter().enumerate() {
-        let popped = mixed.pop_front().unwrap_or_else(|| {
-          panic!(
+        let order_spans = Self::spans_of(&order);
+        self.drained_front(
+          &mut mixed,
+          expected,
+          &format!("push-front/full-order at depth {depth} position {i}"),
+          format_args!(
             "tokora cache conformance [{name} push-front/full-order at depth {depth}]: pop_front() is empty at position {i} of the {} entries one push_back and {depth} push_front(s) put in",
             order.len()
-          )
-        });
-        let got = span_of::<L>(&popped);
-        assert!(
-          got == *expected,
-          "tokora cache conformance [{name} push-front/full-order at depth {depth}]: position {i} of the drained sequence is {got:?}, expected {expected:?}. After one push_back and {depth} push_front(s) the resident order is {order:?} — the front pushes newest-first, then the token that went to the back. `push_front` places its token before every resident entry and MOVES NONE OF THEM; front, back and len do not say that between them, since a push_front that permutes the interior leaves all three right."
+          ),
+          &format!(
+            " After one push_back and {depth} push_front(s) the resident order is {order_spans:?} — the front pushes newest-first, then the token that went to the back. `push_front` places its token before every resident entry and MOVES NONE OF THEM; front, back and len do not say that between them, since a push_front that permutes the interior leaves all three right."
+          ),
         );
       }
+      // Presence-only, and the law: nothing is left to return. (Documented exception.)
       assert!(
         mixed.pop_front().is_none(),
         "tokora cache conformance [{name} push-front/full-order at depth {depth}]: pop_front() still answers after all {} entries were drained",
@@ -1072,18 +1828,21 @@ where
       // A second cache at the same depth, since the drain above consumed the first.
       let (mut mixed, order) = self.front_built(cap, depth);
       for (i, expected) in order.iter().rev().enumerate() {
-        let popped = mixed.pop_back().unwrap_or_else(|| {
-          panic!(
+        let order_spans = Self::spans_of(&order);
+        self.drained_back(
+          &mut mixed,
+          expected,
+          &format!("push-front/full-order-from-the-back at depth {depth} pop_back #{i}"),
+          format_args!(
             "tokora cache conformance [{name} push-front/full-order-from-the-back at depth {depth}]: pop_back() is empty at position {i} of the {} entries one push_back and {depth} push_front(s) put in",
             order.len()
-          )
-        });
-        let got = span_of::<L>(&popped);
-        assert!(
-          got == *expected,
-          "tokora cache conformance [{name} push-front/full-order-from-the-back at depth {depth}]: pop_back #{i} returned {got:?}, expected {expected:?}. After one push_back and {depth} push_front(s) the resident order is {order:?}, so a newest-first drain must hand those back in reverse. Every other pop_back the kit drives runs against a cache built by push_back alone; this one runs against a residency a push_front built."
+          ),
+          &format!(
+            " After one push_back and {depth} push_front(s) the resident order is {order_spans:?}, so a newest-first drain must hand those back in reverse. Every other pop_back the kit drives runs against a cache built by push_back alone; this one runs against a residency a push_front built."
+          ),
         );
       }
+      // Presence-only, and the law: nothing is left to return. (Documented exception.)
       assert!(
         mixed.pop_back().is_none(),
         "tokora cache conformance [{name} push-front/full-order-from-the-back at depth {depth}]: pop_back() still answers after all {} entries were drained",
@@ -1111,18 +1870,21 @@ where
     for n in 2..=cap {
       let (mut mixed, order) = self.interleaved(cap, n);
       for (i, expected) in order.iter().enumerate() {
-        let popped = mixed.pop_front().unwrap_or_else(|| {
-          panic!(
+        let order_spans = Self::spans_of(&order);
+        self.drained_front(
+          &mut mixed,
+          expected,
+          &format!("push-front/interleaved-order at length {n} position {i}"),
+          format_args!(
             "tokora cache conformance [{name} push-front/interleaved-order at length {n}]: pop_front() is empty at position {i} of the {} entries the alternating build put in",
             order.len()
-          )
-        });
-        let got = span_of::<L>(&popped);
-        assert!(
-          got == *expected,
-          "tokora cache conformance [{name} push-front/interleaved-order at length {n}]: position {i} of the drained sequence is {got:?}, expected {expected:?}. Alternating push_front and push_back from empty, starting at the front, leaves the resident order {order:?} — each prepend before every entry then resident, each append after every entry then resident. Neither arm may move an entry the other one placed."
+          ),
+          &format!(
+            " Alternating push_front and push_back from empty, starting at the front, leaves the resident order {order_spans:?} — each prepend before every entry then resident, each append after every entry then resident. Neither arm may move an entry the other one placed."
+          ),
         );
       }
+      // Presence-only, and the law: nothing is left to return. (Documented exception.)
       assert!(
         mixed.pop_front().is_none(),
         "tokora cache conformance [{name} push-front/interleaved-order at length {n}]: pop_front() still answers after all {} entries were drained",
@@ -1143,7 +1905,7 @@ where
   /// rather than a case to handle. Both arms' laws are already established before this runs:
   /// check 3 for the append, and — for the very first push, which goes to the front of an empty
   /// cache — [`check_empty_push_front`](Self::check_empty_push_front).
-  fn interleaved(&self, cap: usize, n: usize) -> (C, Vec<L::Span>) {
+  fn interleaved(&self, cap: usize, n: usize) -> (C, Vec<CachedTokenOf<'inp, L>>) {
     let name = self.label();
     let corpus = self.corpus(n);
     assert!(
@@ -1153,28 +1915,41 @@ where
     );
 
     let mut cache = self.make();
-    let mut order: Vec<L::Span> = Vec::new();
+    let mut order: Vec<CachedTokenOf<'inp, L>> = Vec::new();
     for (i, tok) in corpus.into_iter().enumerate() {
-      let span = span_of::<L>(&tok);
       let to_front = i % 2 == 0;
-      let accepted = if to_front {
-        cache.push_front(tok).is_ok()
-      } else {
-        cache.push_back(tok).is_ok()
-      };
       let arm = if to_front { "push_front" } else { "push_back" };
-      assert!(
-        accepted,
+      let site = format!("{arm} #{i} building an interleaved residency");
+      // Built as a `String` rather than held as `format_args!`: a `fmt::Arguments` bound to a
+      // local borrows temporaries that are dropped at the end of that `let`, which the MSRV
+      // (1.87) rejects even where a newer rustc's temporary-lifetime rules accept it. Passing it
+      // through `format_args!("{refusal}")` keeps one copy of the wording for both arms.
+      let refusal = format!(
         "tokora cache conformance [{name} push-front/interleaved-order at length {n}]: {arm} #{i} was REFUSED with {} of {cap} slots used; a push is refused only when the cache is FULL",
         order.len()
       );
-      if to_front {
-        order.insert(0, span);
+      let placed = if to_front {
+        self.accepted_push_front(&mut cache, tok, &site, format_args!("{refusal}"))
       } else {
-        order.push(span);
+        self.accepted_push_back(&mut cache, tok, &site, format_args!("{refusal}"))
+      };
+      if to_front {
+        order.insert(0, placed);
+      } else {
+        order.push(placed);
       }
     }
     (cache, order)
+  }
+
+  /// The spans of a list of entries, for the messages that show the reader a whole sequence.
+  ///
+  /// The expectation lists are entries since #183; a message that printed them whole would have
+  /// to `Debug` a token and a state per position, which buries the ordering it is trying to show.
+  /// So the *sequence* messages stay span-valued and the *entry* messages
+  /// ([`assert_entry_eq`](Self::assert_entry_eq)) name one component at a time.
+  fn spans_of(entries: &[CachedTokenOf<'inp, L>]) -> Vec<L::Span> {
+    entries.iter().map(span_of::<L>).collect()
   }
 
   /// A fresh cache in the shape [`check_push_front`](Self::check_push_front) builds — one
@@ -1184,7 +1959,7 @@ where
   /// `depth` is bounded by `cap - 1`, so every push here has room and a refusal is a violation
   /// rather than a case to handle — the warranted-refusal law itself is checked by the caller,
   /// which drives one push past the capacity.
-  fn front_built(&self, cap: usize, depth: usize) -> (C, Vec<L::Span>) {
+  fn front_built(&self, cap: usize, depth: usize) -> (C, Vec<CachedTokenOf<'inp, L>>) {
     let name = self.label();
     let want = depth.saturating_add(1);
     let corpus = self.corpus(want);
@@ -1195,23 +1970,29 @@ where
     );
 
     let mut cache = self.make();
-    let mut order: Vec<L::Span> = Vec::new();
+    let mut order: Vec<CachedTokenOf<'inp, L>> = Vec::new();
     let mut it = corpus.into_iter();
     let back = it.next().expect("the corpus was just checked non-empty");
-    let back_span = span_of::<L>(&back);
-    assert!(
-      cache.push_back(back).is_ok(),
-      "tokora cache conformance [{name} push-front/full-order at depth {depth}]: the seeding push_back into an empty cache was refused at capacity {cap}"
+    let want_back = self.accepted_push_back(
+      &mut cache,
+      back,
+      &format!("push_back seeding a front-built residency at depth {depth}"),
+      format_args!(
+        "tokora cache conformance [{name} push-front/full-order at depth {depth}]: the seeding push_back into an empty cache was refused at capacity {cap}"
+      ),
     );
-    order.push(back_span);
+    order.push(want_back);
     for (i, tok) in it.enumerate() {
-      let span = span_of::<L>(&tok);
-      assert!(
-        cache.push_front(tok).is_ok(),
-        "tokora cache conformance [{name} push-front/full-order at depth {depth}]: push_front #{i} was REFUSED with {} of {cap} slots used; a push is refused only when the cache is FULL",
-        order.len()
+      let placed = self.accepted_push_front(
+        &mut cache,
+        tok,
+        &format!("push_front #{i} building a front-built residency at depth {depth}"),
+        format_args!(
+          "tokora cache conformance [{name} push-front/full-order at depth {depth}]: push_front #{i} was REFUSED with {} of {cap} slots used; a push is refused only when the cache is FULL",
+          order.len()
+        ),
       );
-      order.insert(0, span);
+      order.insert(0, placed);
     }
     (cache, order)
   }
@@ -1253,10 +2034,18 @@ where
     // Drained from the FRONT: the consuming path, leaving the resident suffix.
     for popped in 0..=cap {
       let (mut cache, filled) = self.filled_to_capacity(cap);
-      for i in 0..popped {
-        assert!(
-          cache.pop_front().is_some(),
-          "tokora cache conformance [{name} bounded-peek]: pop_front() answered None after {i} of {popped} pops off a cache filled to its capacity {cap}"
+      for (i, expected) in filled.iter().take(popped).enumerate() {
+        // The kit knows which entry each of these removes — `filled[i]`, oldest first — so the
+        // pop is compared rather than counted, even though its only job here is to reach a
+        // residency.
+        self.drained_front(
+          &mut cache,
+          expected,
+          &format!("bounded-peek/front-sweep pop_front #{i}"),
+          format_args!(
+            "tokora cache conformance [{name} bounded-peek]: pop_front() answered None after {i} of {popped} pops off a cache filled to its capacity {cap}"
+          ),
+          " These pops only exist to reach a residency, which is exactly why the entry they return was thrown away before #183.",
         );
       }
       let want = &filled[popped..];
@@ -1279,9 +2068,16 @@ where
     for popped in 1..=cap {
       let (mut cache, filled) = self.filled_to_capacity(cap);
       for i in 0..popped {
-        assert!(
-          cache.pop_back().is_some(),
-          "tokora cache conformance [{name} bounded-peek]: pop_back() answered None after {i} of {popped} pops off a cache filled to its capacity {cap}"
+        // Newest first, so the i-th removes `filled[cap - 1 - i]`. This is the restore path, so
+        // the state message carries the restore note.
+        self.drained_back(
+          &mut cache,
+          &filled[cap - 1 - i],
+          &format!("bounded-peek/back-sweep pop_back #{i}"),
+          format_args!(
+            "tokora cache conformance [{name} bounded-peek]: pop_back() answered None after {i} of {popped} pops off a cache filled to its capacity {cap}"
+          ),
+          " These pops only exist to reach a residency.",
         );
       }
       let want = &filled[..cap - popped];
@@ -1310,13 +2106,19 @@ where
   /// not the other is a real shape (the input layer's rollback pops the back, its consume path
   /// the front). Everything each state is then checked for is [`check_peek_at`](Self::check_peek_at)'s
   /// whole body, unchanged, so this adds a driver rather than an oracle.
+  ///
+  /// The pops themselves are an oracle, though, and are the one thing here that is not
+  /// `check_peek_at`'s: each popped **entry** is compared in full before `want` is shortened.
+  /// Every other drain in the kit runs on an instance that has never been peeked, so this is the
+  /// only place a `peek` that leaves state behind can be caught poisoning a later pop — see the
+  /// comment on the comparison itself.
   fn check_peek_across_mutations(&self, cap: usize) {
     if cap == 0 {
       return;
     }
     let name = self.label();
     let (mut cache, filled) = self.filled_to_capacity(cap);
-    let mut want: Vec<L::Span> = filled;
+    let mut want: Vec<CachedTokenOf<'inp, L>> = filled;
     self.check_peek_at(
       &cache,
       cap,
@@ -1328,16 +2130,36 @@ where
     let mut from_front = true;
     while !want.is_empty() {
       let end = if from_front { "pop_front" } else { "pop_back" };
-      let popped = if from_front {
-        cache.pop_front()
+      // The popped ENTRY, not merely its presence.
+      //
+      // This is the only drain in the kit that runs on an instance the kit has **already
+      // peeked**, and until #183's review it read nothing but `is_some()` — the value was bound,
+      // discarded, and `want` was shortened blindly. So a cache whose `peek` leaves state behind
+      // (a cached lookahead frontier, a memoised run) and whose later pops report out of it was
+      // invisible here: it removes the right entry, so the residency stays right; it returns the
+      // right span, so every span-level law stays right; and the token and the `L::State` the
+      // caller actually resumes from come from a different position. That is the #183 defect
+      // class on the peek-then-consume path — which is the path the issue's severity argument
+      // rests on, since `InputRef::resume` is lookahead followed by a rebuild — and no mutant on
+      // any return path could reach it while the value was thrown away.
+      let expected = if from_front {
+        want.first().expect("the loop guard says want is non-empty")
       } else {
-        cache.pop_back()
+        want.last().expect("the loop guard says want is non-empty")
       };
-      assert!(
-        popped.is_some(),
+      let which = if from_front { "OLDEST" } else { "NEWEST" };
+      let site = format!("bounded-peek/across-mutations {end}() #{pops}");
+      let absent = format_args!(
         "tokora cache conformance [{name} bounded-peek]: {end}() answered None with {} of {cap} entries still resident",
         want.len()
       );
+      let tail =
+        format!(" It is the {which} resident entry, off an instance this kit has ALREADY peeked.");
+      if from_front {
+        self.drained_front(&mut cache, expected, &site, absent, &tail);
+      } else {
+        self.drained_back(&mut cache, expected, &site, absent, &tail);
+      }
       if from_front {
         want.remove(0);
       } else {
@@ -1363,7 +2185,7 @@ where
   ///
   /// Check 3 drives the same fill one token further and would have failed already; this says so
   /// in the kit's own words rather than as a slice index panic.
-  fn filled_to_capacity(&self, cap: usize) -> (C, Vec<L::Span>) {
+  fn filled_to_capacity(&self, cap: usize) -> (C, Vec<CachedTokenOf<'inp, L>>) {
     let name = self.label();
     let (cache, filled) = self.filled(cap);
     assert!(
@@ -1376,12 +2198,13 @@ where
 
   /// Check 6 in full — bound, order, purity, `peek_one`, and the prefilled-buffer sweep —
   /// against a cache holding exactly `want`. `state` names the residency in every message.
-  fn check_peek_at(&self, cache: &C, cap: usize, want: &[L::Span], state: &str) {
+  fn check_peek_at(&self, cache: &C, cap: usize, want: &[CachedTokenOf<'inp, L>], state: &str) {
     let name = self.label();
     let window = <<PeekWindow as Window>::CAPACITY as Unsigned>::USIZE;
     let bound = window.min(want.len());
+    let want_spans = Self::spans_of(want);
 
-    let first = self.peeked_spans(cache);
+    let first = self.peeked_entries(cache);
     assert!(
       first.len() == bound,
       "tokora cache conformance [{name} bounded-peek] against {state}: peek() appended {} entries into an empty {window}-slot buffer, expected exactly min(len, the buffer's remaining capacity) = {bound}. The bound is the cache's CURRENT length, not the room its backing store has: an entry that has been popped is not lookahead any more.",
@@ -1396,18 +2219,28 @@ where
     // cannot fail is not a check (#180 part A, item 9). What the clause was missing is a fixture
     // that violates it and nothing else, which `DUPLICATING_PEEK` in `cache_tests.rs` now is: the
     // right count, the right first entry, the front served `bound` times over.
+    let first_spans: Vec<L::Span> = first.iter().map(|e| e.0.clone()).collect();
     assert!(
-      first == want[..bound],
-      "tokora cache conformance [{name} bounded-peek] against {state}: peek() appended {first:?}, expected the resident prefix OLDEST FIRST {:?}",
-      &want[..bound]
+      first_spans == want_spans[..bound],
+      "tokora cache conformance [{name} bounded-peek] against {state}: peek() appended {first_spans:?}, expected the resident prefix OLDEST FIRST {:?}",
+      &want_spans[..bound]
+    );
+    // …and the other two thirds of every entry the run just landed. The vector comparison above
+    // is the ORDER law and keeps its own wording; this is the entry law (#183), and it is what
+    // separates a `peek` that serves the right run from one that serves the right spans with
+    // re-associated tokens or states behind them.
+    self.assert_peeked_run_eq(
+      &first,
+      &want[..bound],
+      &format!("bounded-peek against {state}"),
     );
 
     // Purity: the cache is unchanged, and a second peek reads the same.
     self.assert_resident(cache, cap, want, &format!("after peek() against {state}"));
-    let second = self.peeked_spans(cache);
+    let second = self.peeked_entries(cache);
     assert!(
       second == first,
-      "tokora cache conformance [{name} pure-peek] against {state}: two peeks on an unchanged cache disagreed: {first:?} then {second:?}. `peek` takes &self and must be logically pure."
+      "tokora cache conformance [{name} pure-peek] against {state}: two peeks on an unchanged cache disagreed: {first:?} then {second:?}. `peek` takes &self and must be logically pure. The comparison is over whole (span, token, state) entries, so a peek that is stable in its spans and unstable in the tokens or the states behind them disagrees here too."
     );
 
     // `peek_one` is the single-slot case: it names the front, and it names nothing where a
@@ -1419,14 +2252,25 @@ where
     // residency — so a `peek_one` that is correct once and wrong on every repeat had nothing to
     // disagree with. `peek` has been held to that since the kit existed, three lines above; this
     // is the same law on the method composed from it (#180 part A, item 4).
-    let one_first: Option<L::Span> = cache.peek_one().map(|one| one.span().clone());
+    // Taken as an owned TRIPLE rather than an owned span, for the same reason the run above is:
+    // `peek_one` names an entry, and naming the right span while carrying somebody else's state
+    // is exactly the shape #183 exists to reject. The purity comparison below then covers all
+    // three components too.
+    let one_first: Option<PeekedTriple<'inp, L>> = self.peeked_one(cache);
     match (&one_first, want.first()) {
-      (Some(got), Some(expected)) => assert!(
-        got == expected,
-        "tokora cache conformance [{name} bounded-peek] against {state}: peek_one() named {got:?}, expected the front entry {expected:?}"
+      (Some(got), Some(expected)) => self.assert_peeked_entry_eq(
+        got,
+        expected,
+        &format!("bounded-peek peek_one() against {state}"),
+        format_args!(
+          "tokora cache conformance [{name} bounded-peek] against {state}: peek_one() named {:?}, expected the front entry {:?}",
+          got.0,
+          span_of::<L>(expected)
+        ),
       ),
       (Some(got), None) => panic!(
-        "tokora cache conformance [{name} bounded-peek] against {state}: peek_one() answered {got:?} with NOTHING resident"
+        "tokora cache conformance [{name} bounded-peek] against {state}: peek_one() answered {:?} with NOTHING resident",
+        got.0
       ),
       (None, Some(_)) => panic!(
         "tokora cache conformance [{name} bounded-peek] against {state}: peek_one() is empty with {} entries resident",
@@ -1434,7 +2278,7 @@ where
       ),
       (None, None) => {}
     }
-    let one_second: Option<L::Span> = cache.peek_one().map(|one| one.span().clone());
+    let one_second: Option<PeekedTriple<'inp, L>> = self.peeked_one(cache);
     assert!(
       one_second == one_first,
       "tokora cache conformance [{name} pure-peek-one] against {state}: two peek_one() calls on an unchanged cache disagreed: {one_first:?} then {one_second:?}. `peek_one` takes &self and must be logically pure, exactly as `peek` must."
@@ -1502,26 +2346,33 @@ where
   /// Only the empty-buffer shape: the prefilled sweep above already varies the room left, at
   /// [`PeekWindow`], and what this adds is the other axis — the value of `W` itself. `peek_one`
   /// is not re-driven either; it takes no window.
-  fn check_peek_window<W>(&self, cache: &C, want: &[L::Span], state: &str)
+  fn check_peek_window<W>(&self, cache: &C, want: &[CachedTokenOf<'inp, L>], state: &str)
   where
     W: Window,
   {
     let name = self.label();
     let window = <<W as Window>::CAPACITY as Unsigned>::USIZE;
     let bound = window.min(want.len());
+    let want_spans = Self::spans_of(want);
 
-    let first = self.peeked_spans_through::<W>(cache);
+    let first = self.peeked_entries_through::<W>(cache);
     assert!(
       first.len() == bound,
       "tokora cache conformance [{name} bounded-peek/window {window}] against {state}: peek() appended {} entries into an empty {window}-slot buffer, expected exactly min(len, the buffer's remaining capacity) = {bound}. `peek` is generic over W and this is a window the kit's own PeekWindow is not: the bound is the same law at every one of them.",
       first.len()
     );
+    let first_spans: Vec<L::Span> = first.iter().map(|e| e.0.clone()).collect();
     assert!(
-      first == want[..bound],
-      "tokora cache conformance [{name} bounded-peek/window {window}] against {state}: peek() appended {first:?}, expected the resident prefix OLDEST FIRST {:?}. A cache may not read W::CAPACITY and answer differently for it.",
-      &want[..bound]
+      first_spans == want_spans[..bound],
+      "tokora cache conformance [{name} bounded-peek/window {window}] against {state}: peek() appended {first_spans:?}, expected the resident prefix OLDEST FIRST {:?}. A cache may not read W::CAPACITY and answer differently for it.",
+      &want_spans[..bound]
     );
-    let second = self.peeked_spans_through::<W>(cache);
+    self.assert_peeked_run_eq(
+      &first,
+      &want[..bound],
+      &format!("bounded-peek/window {window} against {state}"),
+    );
+    let second = self.peeked_entries_through::<W>(cache);
     assert!(
       second == first,
       "tokora cache conformance [{name} pure-peek/window {window}] against {state}: two peeks on an unchanged cache disagreed: {first:?} then {second:?}. `peek` takes &self and must be logically pure at every window, not only at the kit's own."
@@ -1542,7 +2393,7 @@ where
     &self,
     cache: &C,
     cap: usize,
-    want: &[L::Span],
+    want: &[CachedTokenOf<'inp, L>],
     depth: usize,
     from: Prefill,
     state: &str,
@@ -1551,23 +2402,40 @@ where
     let window = <<PeekWindow as Window>::CAPACITY as Unsigned>::USIZE;
     let tag = from.tag();
     let prefill = self.prefill(cap, depth, from);
-    let prefill_spans: Vec<L::Span> = prefill.iter().map(|tok| span_of::<L>(tok)).collect();
+    // Cloned BEFORE the entries move into the buffer: the "peek left the prefix untouched"
+    // assertion compares whole entries since #183, so the expectation has to be the whole entry
+    // and not the span projection the kit kept before.
+    let prefill_want: Vec<CachedTokenOf<'inp, L>> = prefill.clone();
+    let prefill_spans = Self::spans_of(&prefill_want);
+    let want_spans = Self::spans_of(want);
     let remaining_at_prefill = window - depth;
     let prefilled_bound = remaining_at_prefill.min(want.len());
-    let (prefix_after, appended) = self.peeked_spans_after_prefill(cache, prefill);
+    let (prefix_after, appended) = self.peeked_entries_after_prefill(cache, prefill);
+    let prefix_spans: Vec<L::Span> = prefix_after.iter().map(|e| e.0.clone()).collect();
     assert!(
-      prefix_after == prefill_spans,
-      "tokora cache conformance [{name} bounded-peek/{tag} at depth {depth}] against {state}: peek() changed the {depth} entr(ies) already in the buffer ahead of it — got {prefix_after:?}, expected them untouched, {prefill_spans:?}. `peek` appends BEHIND what the buffer already holds; it neither overwrites nor reorders it."
+      prefix_spans == prefill_spans,
+      "tokora cache conformance [{name} bounded-peek/{tag} at depth {depth}] against {state}: peek() changed the {depth} entr(ies) already in the buffer ahead of it — got {prefix_spans:?}, expected them untouched, {prefill_spans:?}. `peek` appends BEHIND what the buffer already holds; it neither overwrites nor reorders it."
+    );
+    self.assert_peeked_run_eq(
+      &prefix_after,
+      &prefill_want,
+      &format!("bounded-peek/{tag} at depth {depth} untouched prefix against {state}"),
     );
     assert!(
       appended.len() == prefilled_bound,
       "tokora cache conformance [{name} bounded-peek/{tag} at depth {depth}] against {state}: peek() appended {} entries into a buffer already holding {depth} of {window} slots, expected exactly min(len, buffer's REMAINING capacity) = {prefilled_bound}.",
       appended.len()
     );
+    let appended_spans: Vec<L::Span> = appended.iter().map(|e| e.0.clone()).collect();
     assert!(
-      appended == want[..prefilled_bound],
-      "tokora cache conformance [{name} bounded-peek/{tag} at depth {depth}] against {state}: peek() appended {appended:?}, expected the resident prefix OLDEST FIRST {:?}. Every resident entry is served, whatever the buffer already holds: `peek` is not entitled to decide the caller has one of them already.",
-      &want[..prefilled_bound]
+      appended_spans == want_spans[..prefilled_bound],
+      "tokora cache conformance [{name} bounded-peek/{tag} at depth {depth}] against {state}: peek() appended {appended_spans:?}, expected the resident prefix OLDEST FIRST {:?}. Every resident entry is served, whatever the buffer already holds: `peek` is not entitled to decide the caller has one of them already.",
+      &want_spans[..prefilled_bound]
+    );
+    self.assert_peeked_run_eq(
+      &appended,
+      &want[..prefilled_bound],
+      &format!("bounded-peek/{tag} at depth {depth} against {state}"),
     );
 
     // Purity on THIS path too. The prefilled buffer is a different route through a cache's
@@ -1583,7 +2451,7 @@ where
       &format!("after prefilled peek() at depth {depth} against {state}"),
     );
     let (prefix_again, appended_again) =
-      self.peeked_spans_after_prefill(cache, self.prefill(cap, depth, from));
+      self.peeked_entries_after_prefill(cache, self.prefill(cap, depth, from));
     assert!(
       prefix_again == prefix_after && appended_again == appended,
       "tokora cache conformance [{name} pure-peek/{tag} at depth {depth}] against {state}: two prefilled peeks on an unchanged cache disagreed: prefix {prefix_after:?} then {prefix_again:?}, appended {appended:?} then {appended_again:?}. `peek` takes &self and must be logically pure against every shape of buffer, not only against an empty one."
@@ -1644,37 +2512,47 @@ where
     corpus.split_off(cap)
   }
 
-  /// The spans `peek` appends, in order, into a fresh, empty buffer of the kit's own window.
-  fn peeked_spans(&self, cache: &C) -> Vec<L::Span> {
-    self.peeked_spans_through::<PeekWindow>(cache)
+  /// One peeked entry as the triple the kit compares, arm-blind: the span and the token through
+  /// [`PeekedTokenExt`], the state through [`peeked_state`].
+  fn triple(entry: &MaybeRefCachedTokenOf<'_, 'inp, L>) -> PeekedTriple<'inp, L> {
+    (
+      entry.span().clone(),
+      entry.token().clone(),
+      peeked_state::<L>(entry).clone(),
+    )
   }
 
-  /// [`peeked_spans`](Self::peeked_spans) through an arbitrary window, which is what
+  /// The entries `peek` appends, in order, into a fresh, empty buffer of the kit's own window.
+  fn peeked_entries(&self, cache: &C) -> Vec<PeekedTriple<'inp, L>> {
+    self.peeked_entries_through::<PeekWindow>(cache)
+  }
+
+  /// [`peeked_entries`](Self::peeked_entries) through an arbitrary window, which is what
   /// [`check_peek_window`](Self::check_peek_window) needs and what the kit had no way to express
   /// while every buffer it built was a [`PeekWindow`] one.
-  fn peeked_spans_through<W>(&self, cache: &C) -> Vec<L::Span>
+  fn peeked_entries_through<W>(&self, cache: &C) -> Vec<PeekedTriple<'inp, L>>
   where
     W: Window,
   {
     let mut buf: GenericArrayDeque<MaybeRefCachedTokenOf<'_, 'inp, L>, W::CAPACITY> =
       GenericArrayDeque::new();
     cache.peek::<W>(&mut buf);
-    buf.iter().map(|entry| entry.span().clone()).collect()
+    buf.iter().map(Self::triple).collect()
   }
 
-  /// The prefilled-buffer counterpart of [`peeked_spans`](Self::peeked_spans): loads `prefill`
-  /// into the buffer first, calls `peek`, then splits the result into the spans standing where
-  /// the original prefix was (to check `peek` left it alone) and the spans `peek` appended
-  /// behind it, in order. This is the other shape the real call site hands `Cache::peek` —
-  /// already holding a parked token or staged overflow, where [`peeked_spans`](Self::peeked_spans)
-  /// is the empty-`buf` shape a cache hit or an overflow-free fill hands over — see
-  /// [`check_peek`](Self::check_peek) for what that shape catches, and for the one thing it
-  /// provably cannot.
-  fn peeked_spans_after_prefill(
+  /// The prefilled-buffer counterpart of [`peeked_entries`](Self::peeked_entries): loads
+  /// `prefill` into the buffer first, calls `peek`, then splits the result into the entries
+  /// standing where the original prefix was (to check `peek` left it alone) and the entries
+  /// `peek` appended behind it, in order. This is the other shape the real call site hands
+  /// `Cache::peek` — already holding a parked token or staged overflow, where
+  /// [`peeked_entries`](Self::peeked_entries) is the empty-`buf` shape a cache hit or an
+  /// overflow-free fill hands over — see [`check_peek`](Self::check_peek) for what that shape
+  /// catches, and for the one thing it provably cannot.
+  fn peeked_entries_after_prefill(
     &self,
     cache: &C,
     prefill: Vec<CachedTokenOf<'inp, L>>,
-  ) -> (Vec<L::Span>, Vec<L::Span>) {
+  ) -> (Vec<PeekedTriple<'inp, L>>, Vec<PeekedTriple<'inp, L>>) {
     let prefill_len = prefill.len();
     let mut buf: GenericArrayDeque<
       MaybeRefCachedTokenOf<'_, 'inp, L>,
@@ -1687,9 +2565,9 @@ where
       );
     }
     cache.peek::<PeekWindow>(&mut buf);
-    let mut spans = buf.iter().map(|entry| entry.span().clone());
-    let prefix = spans.by_ref().take(prefill_len).collect();
-    let appended = spans.collect();
+    let mut entries = buf.iter().map(Self::triple);
+    let prefix = entries.by_ref().take(prefill_len).collect();
+    let appended = entries.collect();
     (prefix, appended)
   }
 
@@ -1706,13 +2584,16 @@ where
     // Reuse it: push back `cap` tokens and confirm they land exactly the way a first fill would.
     let name = self.label();
     let mut want = Vec::with_capacity(cap);
-    for tok in self.corpus(cap) {
-      let span = span_of::<L>(&tok);
-      assert!(
-        cache.push_back(tok).is_ok(),
-        "tokora cache conformance [{name} clear]: push_back() was refused while refilling a cache clear() just emptied — clear() must not leave the cache permanently unable to accept pushes"
+    for (i, tok) in self.corpus(cap).into_iter().enumerate() {
+      let placed = self.accepted_push_back(
+        &mut cache,
+        tok,
+        &format!("push_back #{i} refilling a cleared cache"),
+        format_args!(
+          "tokora cache conformance [{name} clear]: push_back() was refused while refilling a cache clear() just emptied — clear() must not leave the cache permanently unable to accept pushes"
+        ),
       );
-      want.push(span);
+      want.push(placed);
     }
     self.assert_resident(
       &cache,
@@ -1739,10 +2620,15 @@ where
     // Drained from the FRONT: the consuming path, leaving the resident suffix.
     for popped in 0..=cap {
       let (mut cache, filled) = self.filled_to_capacity(cap);
-      for i in 0..popped {
-        assert!(
-          cache.pop_front().is_some(),
-          "tokora cache conformance [{name} combined-span]: pop_front() answered None after {i} of {popped} pops off a cache filled to its capacity {cap}"
+      for (i, expected) in filled.iter().take(popped).enumerate() {
+        self.drained_front(
+          &mut cache,
+          expected,
+          &format!("combined-span/front-sweep pop_front #{i}"),
+          format_args!(
+            "tokora cache conformance [{name} combined-span]: pop_front() answered None after {i} of {popped} pops off a cache filled to its capacity {cap}"
+          ),
+          " These pops only exist to reach a residency.",
         );
       }
       let want = &filled[popped..];
@@ -1754,16 +2640,21 @@ where
           want.len()
         )
       };
-      self.assert_span_at(&cache, want, &state);
+      self.assert_span_at(&cache, &Self::spans_of(want), &state);
     }
 
     // Drained from the BACK: the restore path, leaving the resident prefix.
     for popped in 1..=cap {
       let (mut cache, filled) = self.filled_to_capacity(cap);
       for i in 0..popped {
-        assert!(
-          cache.pop_back().is_some(),
-          "tokora cache conformance [{name} combined-span]: pop_back() answered None after {i} of {popped} pops off a cache filled to its capacity {cap}"
+        self.drained_back(
+          &mut cache,
+          &filled[cap - 1 - i],
+          &format!("combined-span/back-sweep pop_back #{i}"),
+          format_args!(
+            "tokora cache conformance [{name} combined-span]: pop_back() answered None after {i} of {popped} pops off a cache filled to its capacity {cap}"
+          ),
+          " These pops only exist to reach a residency.",
         );
       }
       let want = &filled[..cap - popped];
@@ -1771,7 +2662,7 @@ where
         "a partly drained cache: {} of {cap} resident, after {popped} pop_back(s) off a full one — the input layer's restore path",
         want.len()
       );
-      self.assert_span_at(&cache, want, &state);
+      self.assert_span_at(&cache, &Self::spans_of(want), &state);
     }
   }
 
@@ -1780,6 +2671,11 @@ where
   /// also [`assert_empty`](Self::assert_empty)'s concern; asserted here too so every residency
   /// [`check_span`](Self::check_span) visits — including the fully drained one — is covered by
   /// the same oracle instead of splitting the empty case out).
+  ///
+  /// **The one oracle #183 left span-valued, and deliberately.** `Cache::span` returns an
+  /// `Option<L::Span>` — a span *synthesized* from two endpoints, with no entry behind it — so
+  /// there is no token and no state to compare. `want` is therefore a span list here where every
+  /// other oracle takes entries; the callers project with [`spans_of`](Self::spans_of).
   fn assert_span_at(&self, cache: &C, want: &[L::Span], state: &str) {
     let name = self.label();
     match (want.first(), want.last(), cache.span()) {
@@ -1837,7 +2733,7 @@ where
   /// [`filled`](Self::filled), but from corpus index `offset` rather than from the start — so
   /// that the tokens before it are available to prefill a peek buffer with spans that precede the
   /// whole residency.
-  fn filled_from(&self, offset: usize, n: usize) -> (C, Vec<L::Span>) {
+  fn filled_from(&self, offset: usize, n: usize) -> (C, Vec<CachedTokenOf<'inp, L>>) {
     let name = self.label();
     let want_len = offset.saturating_add(n);
     let mut corpus = self.corpus(want_len);
@@ -1849,12 +2745,15 @@ where
     let mut cache = self.make();
     let mut want = Vec::with_capacity(n);
     for (i, tok) in corpus.split_off(offset).into_iter().enumerate() {
-      let span = span_of::<L>(&tok);
-      assert!(
-        cache.push_back(tok).is_ok(),
-        "tokora cache conformance [{name} bounded-peek]: push_back #{i} was REFUSED while filling a fresh cache to {n} of its capacity {n}; a push is refused only when the cache is FULL"
+      let placed = self.accepted_push_back(
+        &mut cache,
+        tok,
+        &format!("push_back #{i} filling from corpus offset {offset}"),
+        format_args!(
+          "tokora cache conformance [{name} bounded-peek]: push_back #{i} was REFUSED while filling a fresh cache to {n} of its capacity {n}; a push is refused only when the cache is FULL"
+        ),
       );
-      want.push(span);
+      want.push(placed);
     }
     (cache, want)
   }
@@ -1900,7 +2799,7 @@ where
         "a WRAPPED residency: {cap} of {cap} resident after {rotation} pop_front(s) and {rotation} push_back(s), so a ring's live run starts at slot {rotation} and runs past the end of its array"
       );
       self.check_peek_at(&cache, cap, &want, &state);
-      self.assert_span_at(&cache, &want, &state);
+      self.assert_span_at(&cache, &Self::spans_of(&want), &state);
     }
   }
 
@@ -1913,24 +2812,32 @@ where
   /// a combined span from a later start to an earlier end is not a value a `Span` implementation
   /// is obliged to be able to construct. A cache's residency is always in source order, and so is
   /// this one.
-  fn rotated(&self, cap: usize, rotation: usize) -> (C, Vec<L::Span>) {
+  fn rotated(&self, cap: usize, rotation: usize) -> (C, Vec<CachedTokenOf<'inp, L>>) {
     let name = self.label();
     let (mut cache, filled) = self.filled_to_capacity(cap);
-    for i in 0..rotation {
-      assert!(
-        cache.pop_front().is_some(),
-        "tokora cache conformance [{name} wrapped-run]: pop_front() answered None after {i} of {rotation} pops off a cache filled to its capacity {cap}"
+    for (i, expected) in filled.iter().take(rotation).enumerate() {
+      self.drained_front(
+        &mut cache,
+        expected,
+        &format!("wrapped-run pop_front #{i}"),
+        format_args!(
+          "tokora cache conformance [{name} wrapped-run]: pop_front() answered None after {i} of {rotation} pops off a cache filled to its capacity {cap}"
+        ),
+        " These pops only exist to rotate the ring.",
       );
     }
-    let mut want: Vec<L::Span> = filled[rotation..].to_vec();
+    let mut want: Vec<CachedTokenOf<'inp, L>> = filled[rotation..].to_vec();
     for (i, tok) in self.beyond_residency(cap, rotation).into_iter().enumerate() {
-      let span = span_of::<L>(&tok);
-      assert!(
-        cache.push_back(tok).is_ok(),
-        "tokora cache conformance [{name} wrapped-run]: push_back #{i} was REFUSED while topping a cache back up to its capacity {cap} with {} of {cap} slots used; a push is refused only when the cache is FULL",
-        want.len()
+      let placed = self.accepted_push_back(
+        &mut cache,
+        tok,
+        &format!("push_back #{i} topping up a wrapped residency"),
+        format_args!(
+          "tokora cache conformance [{name} wrapped-run]: push_back #{i} was REFUSED while topping a cache back up to its capacity {cap} with {} of {cap} slots used; a push is refused only when the cache is FULL",
+          want.len()
+        ),
       );
-      want.push(span);
+      want.push(placed);
     }
     (cache, want)
   }
@@ -1948,6 +2855,13 @@ where
 
     // Empty cache: the predicate must not run at all — there is no front to hand it — and both
     // methods answer `None` regardless of what the predicate would have said.
+    //
+    // Presence-only, and the law, for these two probes ONLY — not for the false-predicate probe
+    // further down, which discarded its argument until #183 round 9 on the strength of this same
+    // sentence. What makes these two sound is not that they answer `None`; it is that the
+    // predicate must never run, which is asserted on its own line right after each call. On the
+    // conforming path no entry is handed to anyone, so there is nothing to compare.
+    // (Documented exception — see `checked_push`.)
     let mut empty = self.make();
     let ran = Cell::new(false);
     assert!(
@@ -1984,17 +2898,34 @@ where
       return;
     }
 
-    // A false predicate removes nothing and leaves every observable untouched.
+    // A false predicate removes nothing and leaves every observable untouched — and is handed the
+    // front entry on the way to being told so.
     //
-    // This closure discards its argument, and is the only live-front predicate in this check that
-    // does. `pop_front_if`'s recording assertion is the true-predicate arm below; recording here
-    // as well would be the same test run twice, because a cache cannot answer these two calls
-    // differently. `F: FnOnce` is called exactly once, so the entry handed to the predicate is
-    // settled before the `true`/`false` that separates the arms exists, and both caches are built
-    // by the same `filled(cap)` and are in the same state when the call arrives.
+    // The RETURN here is an absence law: `None` is the whole answer, and there is no entry behind
+    // it. The predicate ARGUMENT is not, and classifying the whole site by its return is what left
+    // this arm reading its argument not at all until #183's ninth round. `pop_front_if` hands
+    // caller code a real entry *before* it learns the predicate's answer, so absence covers what
+    // comes back and covers nothing about what went out: a cache can keep storage conforming,
+    // answer `None` correctly, leave residency untouched, and still show the declining predicate
+    // someone else's token or state — and every other oracle here would agree it conformed.
+    //
+    // The old justification for discarding it was that the true-predicate arm below already pins
+    // this read, since `F: FnOnce` settles the entry before the `true`/`false` exists. That is an
+    // argument about a CONFORMING cache. These are two separate monomorphisations of
+    // `pop_front_if`, driven on two separately built instances, and an override is free to differ
+    // between them — the same adversary `POP_FRONT_IF_PREDICATES_ON_THE_BACK` already assumes one
+    // call shape away.
     let (mut cache_f, want_f) = self.filled(cap);
+    let declined = self.recording_pop_front_if(
+      &mut cache_f,
+      &want_f[0],
+      false,
+      "pop-front-if pop_front_if()'s false-predicate argument",
+      "pop_front_if()'s false predicate was handed",
+    );
+    // Presence-only, and the law, for the RETURN: a false predicate must remove nothing.
     assert!(
-      cache_f.pop_front_if(|_| false).is_none(),
+      declined.is_none(),
       "tokora cache conformance [{name} pop-front-if]: pop_front_if() removed an entry despite a false predicate"
     );
     self.assert_resident(
@@ -2013,18 +2944,15 @@ where
     // the conforming residency satisfied every one of them — a cache that decides whether to
     // remove or retain the front on the strength of unrelated lookahead, certified.
     let (mut cache_e, want_e) = self.filled(cap);
-    let seen_e = Cell::new(None);
-    let result = cache_e.try_pop_front_if::<&str, _>(|tok| {
-      // The extra `*` is the same double-borrow `pop_front_if`'s recording predicate pays; see
-      // the comment there.
-      seen_e.set(Some((**tok.token().span_ref()).clone()));
-      Err("no")
-    });
-    let saw_e = seen_e.take();
-    assert!(
-      saw_e == Some(want_e[0].clone()),
-      "tokora cache conformance [{name} pop-front-if]: try_pop_front_if()'s Err-path predicate was handed {saw_e:?}, expected the front entry {:?}",
-      want_e[0]
+    // The predicate's closure lives in the router, so the entry it is handed is recorded and
+    // compared unconditionally — it cannot be discarded by an edit here, which is what it was
+    // before #183.
+    let result = self.recording_try_pop_front_if(
+      &mut cache_e,
+      &want_e[0],
+      Err("no"),
+      "pop-front-if try_pop_front_if()'s Err-path predicate argument",
+      "try_pop_front_if()'s Err-path predicate was handed",
     );
     assert!(
       matches!(result, Some(Err("no"))),
@@ -2037,28 +2965,20 @@ where
       "after try_pop_front_if() with an Err predicate",
     );
 
-    // A true predicate sees the FRONT entry's span, and removes exactly it.
+    // A true predicate sees the FRONT entry, and removes exactly it.
     let (mut cache_t, want_t) = self.filled(cap);
-    let seen = Cell::new(None);
-    let popped_span = cache_t
-      .pop_front_if(|tok| {
-        // `tok`'s own generic params are already references (`CachedTokenRefOf`), so `.token()`
-        // and `.span_ref()` each add one more — double what `span_of` derefs for an OWNED
-        // `CachedTokenOf`, hence the extra `*` here.
-        seen.set(Some((**tok.token().span_ref()).clone()));
-        true
-      })
-      .map(|tok| span_of::<L>(&tok));
-    let saw = seen.take();
-    assert!(
-      saw == Some(want_t[0].clone()),
-      "tokora cache conformance [{name} pop-front-if]: pop_front_if()'s predicate was handed {saw:?}, expected the front entry {:?}",
-      want_t[0]
+    let popped = self.recording_pop_front_if(
+      &mut cache_t,
+      &want_t[0],
+      true,
+      "pop-front-if pop_front_if()'s predicate argument",
+      "pop_front_if()'s predicate was handed",
     );
-    assert!(
-      popped_span == Some(want_t[0].clone()),
-      "tokora cache conformance [{name} pop-front-if]: pop_front_if() with a true predicate returned {popped_span:?}, expected the front entry {:?}",
-      want_t[0]
+    self.assert_returned_front(
+      popped.as_ref(),
+      &want_t[0],
+      "pop-front-if pop_front_if() with a true predicate",
+      "pop_front_if() with a true predicate returned",
     );
     self.assert_resident(
       &cache_t,
@@ -2076,24 +2996,20 @@ where
     // later driver that reorders the two, or drives one at a residency the other does not reach,
     // does not silently lose it.
     let (mut cache_ok, want_ok) = self.filled(cap);
-    let seen_ok = Cell::new(None);
-    let popped_ok = cache_ok
-      .try_pop_front_if::<&str, _>(|tok| {
-        seen_ok.set(Some((**tok.token().span_ref()).clone()));
-        Ok(())
-      })
-      .and_then(Result::ok)
-      .map(|tok| span_of::<L>(&tok));
-    let saw_ok = seen_ok.take();
-    assert!(
-      saw_ok == Some(want_ok[0].clone()),
-      "tokora cache conformance [{name} pop-front-if]: try_pop_front_if()'s Ok-path predicate was handed {saw_ok:?}, expected the front entry {:?}",
-      want_ok[0]
-    );
-    assert!(
-      popped_ok == Some(want_ok[0].clone()),
-      "tokora cache conformance [{name} pop-front-if]: try_pop_front_if() with an Ok(()) predicate returned {popped_ok:?}, expected the front entry {:?}",
-      want_ok[0]
+    let popped_ok = self
+      .recording_try_pop_front_if(
+        &mut cache_ok,
+        &want_ok[0],
+        Ok(()),
+        "pop-front-if try_pop_front_if()'s Ok-path predicate argument",
+        "try_pop_front_if()'s Ok-path predicate was handed",
+      )
+      .and_then(Result::ok);
+    self.assert_returned_front(
+      popped_ok.as_ref(),
+      &want_ok[0],
+      "pop-front-if try_pop_front_if() with an Ok(()) predicate",
+      "try_pop_front_if() with an Ok(()) predicate returned",
     );
     self.assert_resident(
       &cache_ok,
@@ -2101,6 +3017,79 @@ where
       &want_ok[1..],
       "after try_pop_front_if() with an Ok(()) predicate",
     );
+  }
+
+  /// One recorded `pop_front_if`/`try_pop_front_if` predicate argument against the front entry.
+  ///
+  /// `lede` is the site's own wording, kept verbatim from before #183 because two cells pin it
+  /// (`pop_front_if()'s predicate was handed`, `try_pop_front_if()'s Err-path predicate was
+  /// handed`). Presence is checked here rather than at the call site so that "the predicate never
+  /// ran" reports as itself instead of as a mismatch against `None`.
+  fn assert_recorded_predicate_arg(
+    &self,
+    saw: Option<&PeekedTriple<'inp, L>>,
+    want: &CachedTokenOf<'inp, L>,
+    site: &str,
+    lede: &str,
+  ) {
+    let name = self.label();
+    let Some(saw) = saw else {
+      panic!(
+        "tokora cache conformance [{name} pop-front-if]: {lede} nothing — the predicate never ran, or recorded no entry, against a cache whose front is {:?}",
+        span_of::<L>(want)
+      )
+    };
+    self.assert_peeked_entry_eq(
+      saw,
+      want,
+      site,
+      format_args!(
+        "tokora cache conformance [{name} pop-front-if]: {lede} {:?}, expected the front entry {:?}",
+        saw.0,
+        span_of::<L>(want)
+      ),
+    );
+  }
+
+  /// One `pop_front_if`/`try_pop_front_if` return value against the front entry, in full.
+  ///
+  /// `lede` is the site's own wording, kept verbatim for the same reason
+  /// [`assert_recorded_predicate_arg`](Self::assert_recorded_predicate_arg)'s is.
+  fn assert_returned_front(
+    &self,
+    got: Option<&CachedTokenOf<'inp, L>>,
+    want: &CachedTokenOf<'inp, L>,
+    site: &str,
+    lede: &str,
+  ) {
+    let name = self.label();
+    let Some(got) = got else {
+      panic!(
+        "tokora cache conformance [{name} pop-front-if]: {lede} None, expected the front entry {:?}",
+        span_of::<L>(want)
+      )
+    };
+    self.assert_owned_entry_eq(
+      got,
+      want,
+      site,
+      format_args!(
+        "tokora cache conformance [{name} pop-front-if]: {lede} {:?}, expected the front entry {:?}",
+        span_of::<L>(got),
+        span_of::<L>(want)
+      ),
+      NO_NOTE,
+    );
+  }
+
+  /// A borrowed entry — a `front`/`back` reference or a predicate argument — as the triple, so it
+  /// can be recorded in a [`Cell`] and compared after the borrow it came from has ended.
+  fn ref_triple(entry: &CachedTokenRefOf<'_, 'inp, L>) -> PeekedTriple<'inp, L> {
+    (
+      (**entry.token().span_ref()).clone(),
+      (**entry.token().data()).clone(),
+      (*entry.state()).clone(),
+    )
   }
 
   // ── 10. push_many ────────────────────────────────────────────────────────────────
@@ -2119,7 +3108,10 @@ where
       "tokora cache conformance [{name}]: the source lexed {} token(s), but push_many's check needs {want_len} — 2 more than the capacity {cap}, to exercise the overflow return. This is a kit-usage problem, not a cache defect: lengthen the source.",
       corpus.len()
     );
-    let all_spans: Vec<L::Span> = corpus.iter().map(span_of::<L>).collect();
+    // Cloned before `push_many` takes the originals by value: the overflow comparison below is
+    // over whole entries since #183, so the expectation has to be the whole entry.
+    let all: Vec<CachedTokenOf<'inp, L>> = corpus.clone();
+    let all_spans = Self::spans_of(&all);
 
     let mut cache = self.make();
     let overflow: Vec<_> = cache.push_many(corpus.into_iter()).collect();
@@ -2130,10 +3122,23 @@ where
       all_spans.len() - cap,
       &all_spans[cap..]
     );
+    // "Unchanged" is the whole entry: a `push_many` that hands back the right spans in the right
+    // order with re-associated tokens or states behind them has changed what it refused (#183).
+    for (i, (got, expected)) in overflow.iter().zip(&all[cap..]).enumerate() {
+      self.assert_owned_entry_eq(
+        got,
+        expected,
+        &format!("push-many overflow entry #{i}"),
+        format_args!(
+          "tokora cache conformance kit bug [{name} push-many]: overflow entry #{i} has a span the vector comparison above should already have rejected"
+        ),
+        NO_NOTE,
+      );
+    }
     self.assert_resident(
       &cache,
       cap,
-      &all_spans[..cap],
+      &all[..cap],
       "after push_many() with 2 more tokens than capacity",
     );
   }

--- a/tokora/src/conformance/cache_tests.rs
+++ b/tokora/src/conformance/cache_tests.rs
@@ -28,29 +28,70 @@ use crate::{
   },
   error::token::UnexpectedToken,
   lexer::LogosLexer,
+  span::Spanned,
 };
 
-// ── The corpus lexer: one-letter words, so every capacity fills and then refuses ─────
+// ── The corpus lexer: alternating kinds, distinct payloads, an advancing state ────────
 
-#[derive(Debug, Clone, PartialEq, crate::logos::Logos)]
-#[logos(crate = crate::logos, skip r"[ \t]+")]
-enum CTok {
-  #[regex(r"[a-z]+")]
-  Word,
+/// The corpus lexer's state: a counter every token callback bumps, so the `L::State` cached
+/// beside each corpus token is a **different value at every position** (`lexed` runs 1..=12 over
+/// [`SRC`]).
+///
+/// Before #183 this was `()` — logos' default `Extras`, which is what a lexer gets when it is not
+/// given one — and a single-valued state makes the kit's state comparison vacuous: there is
+/// nothing for a cache to re-associate wrongly. Every state mutant below rests on this counter,
+/// and [`corpus_is_pairwise_distinct_on_all_three_axes`] is what stops a later `SRC` edit from
+/// quietly taking it away again.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+struct CState {
+  lexed: u32,
 }
 
-impl core::fmt::Display for CTok {
+impl crate::State for CState {
+  type Error = ();
+
+  fn check(&self) -> Result<(), Self::Error> {
+    Ok(())
+  }
+}
+
+/// Two token kinds, **alternating** over [`SRC`], each carrying its own source slice.
+///
+/// Both halves matter, and they are different properties. Alternating *kinds* is what makes a
+/// neighbour swap visible; distinct *payloads* are what make a swap between two same-kind entries
+/// at a distance visible, since the payload is the slice and no two positions share one. Before
+/// #183 this enum was a single fieldless variant — one inhabitant — so a token comparison over it
+/// could not have failed even if the kit had made one.
+#[derive(Debug, Clone, PartialEq, crate::logos::Logos)]
+#[logos(crate = crate::logos, skip r"[ \t]+", extras = CState)]
+enum CTok<'a> {
+  #[regex(r"[a-z]+", |lex| { lex.extras.lexed += 1; lex.slice() })]
+  Word(&'a str),
+  #[regex(r"[0-9]+", |lex| { lex.extras.lexed += 1; lex.slice() })]
+  Num(&'a str),
+}
+
+impl core::fmt::Display for CTok<'_> {
   fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    f.write_str("word")
+    match self {
+      Self::Word(s) => write!(f, "word {s}"),
+      Self::Num(s) => write!(f, "num {s}"),
+    }
   }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-struct CKind;
+enum CKind {
+  Word,
+  Num,
+}
 
 impl core::fmt::Display for CKind {
   fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    f.write_str("word")
+    match self {
+      Self::Word => f.write_str("word"),
+      Self::Num => f.write_str("num"),
+    }
   }
 }
 
@@ -71,12 +112,15 @@ impl<'a, T, Kind: Clone, S, Lang: ?Sized> From<UnexpectedToken<'a, T, Kind, S, L
   }
 }
 
-impl Token<'_> for CTok {
+impl<'a> Token<'a> for CTok<'a> {
   type Kind = CKind;
   type Error = CErr;
 
   fn kind(&self) -> CKind {
-    CKind
+    match self {
+      Self::Word(_) => CKind::Word,
+      Self::Num(_) => CKind::Num,
+    }
   }
 
   fn is_trivia(&self) -> bool {
@@ -84,13 +128,20 @@ impl Token<'_> for CTok {
   }
 }
 
-type CLex<'a> = LogosLexer<'a, CTok>;
+type CLex<'a> = LogosLexer<'a, CTok<'a>>;
 
 /// The corpus every cell runs over: twelve items — the widest capacity the cells use (8) plus a
 /// full 4-slot peek window behind it. The capacity is what makes every cache here fill and then
 /// refuse; the window is what the kit's peek prefill draws on, at every depth up to a buffer with
 /// no room left, from tokens the cache under test is not itself holding.
-const SRC: &str = "a b c d e f g h i j k l";
+///
+/// **Heterogeneous on all three axes** since #183. Spans are pairwise distinct from any source;
+/// the alternation of letters and digits makes the token *kinds* alternate, the slices make the
+/// token *values* pairwise distinct, and [`CState`]'s counter makes the states pairwise distinct.
+/// That is what gives the entry comparison anything to discriminate — see
+/// [`corpus_is_pairwise_distinct_on_all_three_axes`], which fails if a later edit takes any of it
+/// away.
+const SRC: &str = "a 1 b 2 c 3 d 4 e 5 f 6";
 
 // ── The built-ins ───────────────────────────────────────────────────────────────────
 
@@ -534,6 +585,196 @@ const TRY_POP_FRONT_IF_PREDICATES_ON_THE_BACK: u8 = 46;
 /// Correct at `len <= 1`, where front and back are the same entry.
 const POP_FRONT_IF_PREDICATES_ON_THE_BACK: u8 = 47;
 
+// ── #183: the entry observable — cells that corrupt the token or the state and nothing else ──
+//
+// Every cell from here down leaves the SPANS of everything it touches exactly where a conforming
+// cache would put them. That is the point: each is invisible to a kit that compares spans, which
+// is what this kit did until #183, and each fires on exactly one of the two comparisons the entry
+// observable adds. A generic fixture cannot fabricate an `L::State` value — but it can
+// **re-associate** the ones it was handed, and that is the real defect class: a struct-of-arrays
+// cache with index skew, an implementor pairing `state[i - 1]` with `token[i]`.
+//
+// The gates are the file's existing convention: each conforms at `len <= 1`, where the entry a
+// neighbour skew reaches for is the entry itself.
+
+/// The storage flagship: `push_back` stores the incoming span and token faithfully and stores the
+/// **previously accepted entry's** `L::State` beside them (the first push into an empty cache
+/// keeps its own, so there is nothing to lag behind).
+///
+/// So every span and every token in the cache is right, at every residency, and `back().state` —
+/// the exact value `InputRef::resume` clones to rebuild a lexer with `with_state` + `bump` — is
+/// always one entry behind. A ring that keeps its states in a parallel array and writes them at
+/// the pre-increment index has this shape. It fires at the first two-resident residency check 3
+/// builds, on the `back()` edge read, which is where the restore consequence is stated.
+const STATE_LAG: u8 = 48;
+/// `front()`/`back()` hand back references assembled out of **two** entries: the right span and
+/// token, with the neighbour's `L::State` beside them. `front_span`/`back_span` are untouched.
+///
+/// [`WRONG_FRONT_IDENTITY`]'s successor one level deeper. That cell made the reference name the
+/// wrong slot outright, which the span half of the edge-identity read catches; this one makes the
+/// reference name the right slot and carry the wrong state, which nothing before #183 could see —
+/// even the #180 fix compared only the reference's span.
+const EDGE_STATE_SKEW: u8 = 49;
+/// [`EDGE_STATE_SKEW`] on the other half: `front()`/`back()` return the right span and the right
+/// state with the **neighbour's token** between them.
+const EDGE_TOKEN_SKEW: u8 = 50;
+/// `pop_front`/`pop_back` remove the right entry and return it with the `L::State` of the entry
+/// that is now at that end. Honest when the pop emptied the cache, since there is no neighbour
+/// left to borrow from.
+///
+/// The `pop_back` half is the input layer's rollback path, which drops an abandoned continuation
+/// with a run of `pop_back` calls; a caller that resumes from one of those states resumes from a
+/// position the lexer never occupied.
+const POP_STATE_SKEW: u8 = 51;
+/// [`POP_STATE_SKEW`] on the token half: the right entry with the remaining neighbour's token.
+const POP_TOKEN_SKEW: u8 = 52;
+/// [`OWNED_PEEK`] with the states re-associated: every `Maybe::Owned` clone it serves carries the
+/// **front entry's** state rather than the one stored at its own position.
+///
+/// Position 0 is right by coincidence — the front is the first expected entry — exactly as
+/// [`WRONG_OWNED_PEEK`]'s first entry is, and every entry behind it carries a state no cache ever
+/// stored there. Spans and tokens are correct throughout, so the bound, the order and the
+/// exact-sequence assertion all pass.
+const OWNED_PEEK_STATE_SKEW: u8 = 53;
+/// [`WRONG_OWNED_PEEK`] **minus the span corruption**: owned clones with the right spans and the
+/// right states, and every token the front entry's.
+///
+/// This is the owned-arm instance of the same span-only comparison #183 is about. Its sibling is
+/// caught today because cloning the whole front entry moves the spans too; take that away and the
+/// kit had nothing left to notice.
+const OWNED_PEEK_TOKEN_SKEW: u8 = 54;
+/// `peek_one` answers with an owned entry carrying the front's span and token and the **back's**
+/// state. Correct at `len <= 1`, where the two ends are the same entry.
+///
+/// `peek_one` names the entry the next `pop_front` will return, so a parser that peeks one and
+/// resumes from what it was shown resumes from the wrong end of its own lookahead.
+const PEEK_ONE_STATE_SKEW: u8 = 55;
+/// [`PEEK_ONE_STATE_SKEW`] on the token half: the front's span and state with the back's token.
+const PEEK_ONE_TOKEN_SKEW: u8 = 56;
+/// A refused push hands back the offered span and token with a **resident** entry's `L::State`.
+///
+/// Span-identical to the token that was offered, so the refusal round-trip saw nothing wrong with
+/// it before #183 — and the input layer's put-back path parks exactly this value and later
+/// restores a lexer from it.
+const REFUSAL_STATE_SWAP: u8 = 57;
+/// `push_many`'s overflow iterator hands back entries with the right spans, in the right order,
+/// carrying a **resident** entry's `L::State`.
+///
+/// The override lives in `push_many` alone, so `push_back` — and therefore check 3's refusal
+/// round-trip — stays conforming and this cell reports at its own site.
+const PUSH_MANY_STATE_SWAP: u8 = 58;
+/// `try_pop_front_if` hands its predicate a reference carrying the front's span and token with
+/// the **back's** `L::State`; the removal and the return value are the conforming ones, computed
+/// from the front.
+///
+/// [`TRY_POP_FRONT_IF_PREDICATES_ON_THE_BACK`] one level deeper: that cell hands over the wrong
+/// entry, which the span half catches; this one hands over the right entry with a state the
+/// caller's validation predicate was never meant to see. A predicate that reads the state to
+/// decide whether to consume is deciding on the wrong lexer position.
+///
+/// Scoped to `try_pop_front_if` as of #183's ninth round. It skewed both methods before, which
+/// looked like twice the coverage and was not: `F: FnOnce` puts the defect on every arm, so the
+/// first recording assertion to run reports it and the others are never reached — the
+/// `pop_front_if` half could not fire while a `try_pop_front_if` arm ran earlier.
+/// [`POP_FRONT_IF_PREDICATE_ARG_STATE_SKEW`] is the sibling that covers the other method.
+const PREDICATE_ARG_STATE_SKEW: u8 = 59;
+/// [`REFUSAL_STATE_SWAP`] on the token half: the offered span and state come back with a
+/// **resident** entry's token between them.
+///
+/// Required by the #183 cross-model gate. The refusal round-trip compares the whole entry, and
+/// its state sibling corrupts only the state — so without this cell the token half at that site
+/// would be a comparison nothing could fail, which is the defect class the issue exists to close.
+const REFUSAL_TOKEN_SWAP: u8 = 60;
+/// [`PUSH_MANY_STATE_SWAP`] on the token half: overflow entries come back with the right spans
+/// and the right states and a **resident** entry's token. Required by the #183 cross-model gate,
+/// for the reason [`REFUSAL_TOKEN_SWAP`] is.
+const PUSH_MANY_TOKEN_SWAP: u8 = 61;
+/// [`PREDICATE_ARG_STATE_SKEW`] on the token half: `try_pop_front_if`'s predicate is handed the
+/// front's span and state with the **back's** token. Required by the #183 cross-model gate, for
+/// the reason [`REFUSAL_TOKEN_SWAP`] is, and scoped to the same method as its state sibling.
+const PREDICATE_ARG_TOKEN_SKEW: u8 = 62;
+/// `peek` caches a **lookahead frontier** — the `L::State` of the newest entry in the run it just
+/// served — and every later pop on that instance reports that cached state instead of the state
+/// of the entry it actually removed.
+///
+/// Caching the frontier is not the mistake; it is the exact value `InputRef::resume` wants out of
+/// `back()`. Serving it from a **pop** is. The entry removed is the right one from the right end,
+/// so the residency is correct at every step; the span returned is the removed entry's own, so
+/// every span-level law is correct; only the `L::State` the caller resumes from belongs to a
+/// different position.
+///
+/// Reachable at exactly one site, which is the point. Every other drain in the kit runs on an
+/// instance that has never been peeked — `check_pop_order`, `check_push_front`'s three drains and
+/// the residency sweeps in checks 6 and 8 all pop a cache built fresh and peek it, if at all,
+/// only afterwards — so the frontier is unset and this cell is conforming there. Only
+/// `check_peek_across_mutations` peeks an instance and then pops it, and until #183's review that
+/// drain bound the popped value and checked it for **presence alone**: no mutant on any return
+/// path could reach a value the kit discarded.
+///
+/// Honest at `len <= 1`, where the newest entry and the one a pop removes are the same one.
+const POST_PEEK_POP_STATE_SKEW: u8 = 63;
+/// Stores the offered entry **perfectly** and returns an `Ok` reference assembled from a
+/// different resident: the pushed entry's span and token beside its neighbour's `L::State`.
+///
+/// [`Cache::push_back`](crate::cache::Cache::push_back) and
+/// [`push_front`](crate::cache::Cache::push_front) promise `Ok` with *a reference to the cached
+/// token*, so this violates the contract outright — and it is invisible to everything downstream,
+/// because `front`, `back`, the pops and `peek` all read **storage**, and storage here is
+/// flawless. The only observable that diverges is the value the push call itself handed back,
+/// which every push in this kit reduced to `is_ok()` until #183's second review round.
+///
+/// Both push arms are corrupted, and both route through the kit's single accepted-push
+/// comparison, so this one cell pins that read wherever it happens. Gated on a neighbour existing
+/// after the push, so a push into an empty cache — the only push several checks ever make — is
+/// conforming.
+const WRONG_ACCEPTED_PUSH_REF: u8 = 64;
+/// Refuses a `push_back` it had room to accept **and** corrupts the entry it hands back: the
+/// offered span and token with a resident's `L::State` between them.
+///
+/// The compound is the point. A refusal with room to spare is already a violation the kit fails,
+/// and the entry the refusal returns was the last `Cache` return value the kit received and did
+/// not read — the `accepted_push_*` wrappers took `Err`, panicked on the refusal, and dropped the
+/// value. So this cell cannot certify: any cache reaching it fails on the refusal regardless.
+/// What it pins is that the kit **looks** before it panics, which is what makes the module docs'
+/// shape enumeration true rather than nearly true.
+///
+/// Gated on a `push_front` having been accepted on this instance, which is what puts the first
+/// hit at `interleaved`'s `push_back #1` — an `accepted_push_*` site — rather than at check 3's
+/// or check 5's loops, where a refusal is a case the caller handles and compares in its own
+/// wording. That separation is what keeps this cell off `REFUSAL_STATE_SWAP`'s and
+/// `REFUSAL_TOKEN_SWAP`'s firing sites.
+const UNEXPECTED_REFUSAL_ENTRY_SWAP: u8 = 65;
+/// [`UNEXPECTED_REFUSAL_ENTRY_SWAP`] at the **mixed** `push_back` site: refuses with room to
+/// spare from the moment the cache holds anything, and corrupts the entry it hands back.
+///
+/// Check 3's push is the site where the same call can produce a warranted refusal or an
+/// unwarranted one, and until #183's fifth round the unwarranted branch asserted its way out
+/// before the returned entry reached any comparison — the wrapper-level fix from round 4 did not
+/// reach it, because this site never goes through `accepted_push_back`. Fires at check 3's second
+/// push, the first `push_back` in the kit that lands on a non-empty cache with room left.
+const EARLY_PUSH_BACK_REFUSAL_ENTRY_SWAP: u8 = 66;
+/// The prepend twin: refuses a `push_front` with room to spare and corrupts what it hands back.
+///
+/// Fires in check 5's loop, at the first front push after the seeding append — the other mixed
+/// site, and the other half of what round 5 closes.
+const EARLY_PUSH_FRONT_REFUSAL_ENTRY_SWAP: u8 = 67;
+/// [`PREDICATE_ARG_STATE_SKEW`] on the `pop_front_if` arm: the predicate is handed the front's
+/// span and token with the **back's** `L::State`, and everything downstream — the removal, the
+/// return value, the residency — is the conforming behaviour computed from the front.
+///
+/// From #183's ninth round, and it is the cell for the hole that round found. Check 9's
+/// **declining** arm — a `false` predicate, which must remove nothing and answer `None` — used to
+/// throw its predicate's argument away, because the site had been classified by its RETURN. The
+/// return is genuinely an absence law; the argument is not, and `pop_front_if` hands caller code
+/// a real entry before it learns the answer. So a cache could show the declining predicate
+/// someone else's `L::State`, answer `None`, leave residency untouched, and be certified.
+///
+/// This is the mutant that makes the new comparison bite, and it lands **on the declining arm**:
+/// it is the first recording predicate check 9 runs, so this cell reports there rather than at
+/// the true-predicate arm below it. It fails on the entry comparison and not on residency —
+/// nothing is removed — which is what distinguishes it from `WRONG_POP_FRONT_IF`.
+const POP_FRONT_IF_PREDICATE_ARG_STATE_SKEW: u8 = 68;
+
 /// A `VecDeque`-backed third-party cache with a const-selected defect.
 struct Queue<'a, L, const D: u8>
 where
@@ -577,6 +818,24 @@ where
   /// cache's life. `RefCell` rather than `Cell` because it is read in place, and populated inside
   /// `peek`, which takes `&self`.
   memo: RefCell<Option<VecDeque<CachedTokenOf<'a, L>>>>,
+  /// The lookahead frontier [`POST_PEEK_POP_STATE_SKEW`]'s `peek` caches — the newest served
+  /// entry's `L::State` — and which every later pop on that instance then reports instead of the
+  /// state of the entry it removed. `RefCell` for the same reason [`memo`](Self::memo) is: it is
+  /// written inside `peek`, which takes `&self`, and `L::State` need not be `Copy`.
+  ///
+  /// Reset by `clear`, as a real cache's would be. Nothing but the pops read it, so every other
+  /// observable of every other cell is untouched.
+  frontier_state: RefCell<Option<L::State>>,
+  /// The entry [`STATE_LAG`] was last **offered**, kept so that cell's accepted-push return can
+  /// be honest while its storage is not.
+  ///
+  /// That is the shape the cell is about and the shape a struct-of-arrays cache actually has: the
+  /// state array is written at the wrong index, and the reference handed back is assembled from
+  /// the values the push was just given rather than read back out of the store. Keeping the two
+  /// apart is also what keeps the cell pinning the `back()` edge read — where the restore
+  /// consequence is stated — instead of stealing the accepted-push pin from
+  /// [`WRONG_ACCEPTED_PUSH_REF`].
+  last_offered: Option<CachedTokenOf<'a, L>>,
   /// A ring's head index, kept purely so that [`WRAPPED_RUN_PEEK`] and [`WRAPPED_RUN_SPAN`] can
   /// ask whether the live run has wrapped past the end of the backing array — `head + len > cap`.
   ///
@@ -655,6 +914,14 @@ where
     if D == COLD_START_PUSH_FRONT && !self.warmed.get() {
       return Err(self.refuse(tok));
     }
+    // Check 5's mixed site: a refusal with room, carrying a corrupted entry. Reached only after
+    // the fullness check above, so warranted refusals stay honest and this cell cannot land on
+    // the round-trip site `REFUSAL_STATE_SWAP` names.
+    if D == EARLY_PUSH_FRONT_REFUSAL_ENTRY_SWAP
+      && let Some(resident) = self.items.back()
+    {
+      return Err(Self::with_state(&tok, resident.state.clone()));
+    }
     // A refusal by an EMPTY cache with every slot free — reached only after the full check
     // above, so nothing about the refusal's shape is wrong; what is missing is the fullness that
     // would have warranted it, at the one state check 5 has to seed its way past.
@@ -683,6 +950,12 @@ where
       // `push_back` left there ever moves, which is what makes every point observable the kit
       // reads — front, back, len, remaining — agree with a conforming cache.
       self.items.swap(1, 2);
+    }
+    // The prepend arm's twin of the accepted-push skew above.
+    if D == WRONG_ACCEPTED_PUSH_REF && self.items.len() >= 2 {
+      let own = self.items.front().expect("len >= 2");
+      let neighbour = self.items.get(1).expect("len >= 2");
+      return Ok(Self::ref_with_foreign_state(own, neighbour));
     }
     Ok(self.items.front().expect("just pushed").as_ref())
   }
@@ -719,7 +992,9 @@ where
         self.graveyard.push_front(tok.clone());
       }
     }
-    popped
+    // #183: the restore path's own pop, handing back the right entry with the new back's state or
+    // token beside it.
+    self.skew_popped(popped, self.items.back())
   }
 
   fn pop_front_if<F>(&mut self, predicate: F) -> Option<CachedTokenOf<'a, L>>
@@ -745,6 +1020,26 @@ where
       if let Some(peeked) = self.items.back().map(CachedToken::as_ref)
         && predicate(peeked)
       {
+        return self.pop_front_impl();
+      }
+      return None;
+    }
+    // #183: the predicate is handed the RIGHT entry with the back's state beside it. The removal
+    // and the return value below are the conforming ones, taken from the front, so only what the
+    // caller's validation predicate was shown diverges.
+    //
+    // `pop_front_if`'s own selector, separate from `try_pop_front_if`'s below. One selector used
+    // to skew both methods, which read as covering both and could only ever report at one of
+    // them: `F: FnOnce` makes the defect present on every arm, so the FIRST recording assertion
+    // to run consumes it and no later one is reached. Split, each method's predicate-argument
+    // read is pinned by a mutant that can actually land on it (#183 round 9).
+    if D == POP_FRONT_IF_PREDICATE_ARG_STATE_SKEW && self.items.len() >= 2 {
+      let answer = {
+        let front = self.items.front().expect("len >= 2");
+        let back = self.items.back().expect("len >= 2");
+        predicate(Self::ref_with_foreign_state(front, back))
+      };
+      if answer {
         return self.pop_front_impl();
       }
       return None;
@@ -783,6 +1078,26 @@ where
       }
       return None;
     }
+    // The same #183 skew on this arm, under `try_pop_front_if`'s OWN selectors — a caller's
+    // validation predicate is run against the entry either method hands over, so each method
+    // carries a mutant of its own rather than sharing one that only the earlier arm can consume.
+    // `POP_FRONT_IF_PREDICATE_ARG_STATE_SKEW` is the sibling on the other method.
+    if (D == PREDICATE_ARG_STATE_SKEW || D == PREDICATE_ARG_TOKEN_SKEW) && self.items.len() >= 2 {
+      let answer = {
+        let front = self.items.front().expect("len >= 2");
+        let back = self.items.back().expect("len >= 2");
+        let skewed = if D == PREDICATE_ARG_STATE_SKEW {
+          Self::ref_with_foreign_state(front, back)
+        } else {
+          Self::ref_with_foreign_token(front, back)
+        };
+        predicate(skewed)
+      };
+      return match answer {
+        Ok(()) => self.pop_front_impl().map(Ok),
+        Err(e) => Some(Err(e)),
+      };
+    }
     if let Some(peeked) = self.items.front().map(CachedToken::as_ref) {
       return match predicate(peeked) {
         Ok(()) => self.pop_front_impl().map(Ok),
@@ -802,10 +1117,23 @@ where
         // The refused token is dropped instead of handed back through the overflow iterator —
         // `push_back` above still ran, so residency up to capacity is unaffected; only the
         // overflow report is silently swallowed.
-        None
-      } else {
-        refused
+        return None;
       }
+      // #183: the overflow comes back at the right spans, in the right order, with a RESIDENT
+      // entry's state (or token) substituted. The override is HERE and not in `push_back`, so
+      // check 3's refusal round-trip stays conforming and this cell can only report at
+      // `push_many`'s own site.
+      if D == PUSH_MANY_STATE_SWAP || D == PUSH_MANY_TOKEN_SWAP {
+        let over = refused?;
+        let Some(resident) = self.items.back() else {
+          return Some(over);
+        };
+        return Some(match D {
+          PUSH_MANY_STATE_SWAP => Self::with_state(&over, resident.state.clone()),
+          _ => Self::with_token(&over, resident.token.data.clone()),
+        });
+      }
+      refused
     })
   }
 
@@ -821,6 +1149,8 @@ where
     // A ring's `clear` puts the head back at slot zero, so a cleared cache does not start out
     // wrapped.
     self.head = 0;
+    // A cleared cache has no lookahead frontier, so a real cache would drop it here too.
+    *self.frontier_state.borrow_mut() = None;
     if D == POISONING_CLEAR {
       // The cache is genuinely empty right after this — every check-1 observable answers
       // correctly — but `push_back` refuses everything from here on regardless of capacity.
@@ -842,6 +1172,15 @@ where
     let tainted = self.prefilled.get();
     if !buf.is_empty() {
       self.prefilled.set(true);
+    }
+    // Cached before any of the branches below, so it is set on every peek this instance answers
+    // however it answers it. Caching the newest served entry's state is a reasonable thing for a
+    // cache to do — it is the value `InputRef::resume` reads off `back()`; the defect is in
+    // `skew_popped`, which reports it out of a POP.
+    if D == POST_PEEK_POP_STATE_SKEW
+      && let Some(back) = self.items.back()
+    {
+      *self.frontier_state.borrow_mut() = Some(back.state.clone());
     }
     // The window off the TYPE, not off the buffer. `buf.capacity()` is the same number, but the
     // two cells below are statements about a cache that branches on its `W` parameter, and this
@@ -1031,6 +1370,32 @@ where
       }
       return;
     }
+    if D == OWNED_PEEK_STATE_SKEW || D == OWNED_PEEK_TOKEN_SKEW {
+      // #183 on the owned arm: the run, the order and the bound are `OWNED_PEEK`'s, and every
+      // clone carries the FRONT entry's state (or token) instead of the one stored at its own
+      // position. Position 0 is right by coincidence and everything behind it is a value no cache
+      // ever stored there — with the spans left exactly where a conforming peek puts them, which
+      // is the whole difference from `WRONG_OWNED_PEEK`.
+      //
+      // Guarded on `fill > 0` for the same reason that cell is: an empty cache or a full buffer
+      // must still append nothing.
+      if fill > 0 {
+        let front = self
+          .items
+          .front()
+          .expect("fill > 0 implies at least one resident entry")
+          .clone();
+        for tok in self.items.iter().take(fill) {
+          let served = if D == OWNED_PEEK_STATE_SKEW {
+            Self::with_state(tok, front.state.clone())
+          } else {
+            Self::with_token(tok, front.token.data.clone())
+          };
+          buf.push_back(Maybe::Owned(served));
+        }
+      }
+      return;
+    }
     for tok in self.items.iter().take(fill) {
       buf.push_back(Maybe::Ref(tok.as_ref()));
     }
@@ -1056,6 +1421,19 @@ where
         return None;
       }
     }
+    // #183: the FRONT entry — the right one — served through the owned arm with the BACK's state
+    // (or token) beside it. Correct at `len <= 1`, where the two ends are the same entry, and
+    // pure, since it is a function of the residency alone.
+    if (D == PEEK_ONE_STATE_SKEW || D == PEEK_ONE_TOKEN_SKEW) && self.items.len() >= 2 {
+      let front = self.items.front().expect("len >= 2");
+      let back = self.items.back().expect("len >= 2");
+      let served = if D == PEEK_ONE_STATE_SKEW {
+        Self::with_state(front, back.state.clone())
+      } else {
+        Self::with_token(front, back.token.data.clone())
+      };
+      return Some(Maybe::Owned(served));
+    }
     self.items.front().map(|tok| Maybe::Ref(tok.as_ref()))
   }
 
@@ -1064,12 +1442,32 @@ where
       // The wrong END, while `front_span` below keeps naming the right one.
       return self.items.back().map(CachedToken::as_ref);
     }
+    // #183: the right END, assembled with the neighbour's state or token. Gated on a neighbour
+    // existing, so `len <= 1` is conforming — at one resident entry the front IS its own
+    // neighbour and there is nothing to skew.
+    if self.items.len() >= 2 {
+      let own = self.items.front().expect("len >= 2");
+      let neighbour = self.items.get(1).expect("len >= 2");
+      if let Some(skewed) = Self::skewed_edge(own, neighbour) {
+        return Some(skewed);
+      }
+    }
     self.items.front().map(CachedToken::as_ref)
   }
 
   fn back(&self) -> Option<CachedTokenRefOf<'_, 'a, L>> {
     if D == WRONG_BACK_IDENTITY {
       return self.items.front().map(CachedToken::as_ref);
+    }
+    // [`front`](Self::front)'s #183 skew at the other end — and the end that matters most, since
+    // `back()` is the entry `InputRef::resume` rebuilds a lexer from.
+    let len = self.items.len();
+    if len >= 2 {
+      let own = self.items.back().expect("len >= 2");
+      let neighbour = self.items.get(len - 2).expect("len >= 2");
+      if let Some(skewed) = Self::skewed_edge(own, neighbour) {
+        return Some(skewed);
+      }
     }
     self.items.back().map(CachedToken::as_ref)
   }
@@ -1163,6 +1561,8 @@ where
       stashed: None,
       peek_one_at_len: Cell::new(None),
       memo: RefCell::new(None),
+      frontier_state: RefCell::new(None),
+      last_offered: None,
       head: 0,
     }
   }
@@ -1173,6 +1573,100 @@ where
     self.head + self.items.len() > self.cap
   }
 
+  // ── #183: the four re-associations every entry cell below is built out of ──────────
+  //
+  // A fixture generic over `L` cannot invent an `L::State` or an `L::Token`; what it can do is
+  // pair one entry's span with another entry's state or token, which is exactly the defect a
+  // struct-of-arrays cache with index skew has. These four constructors are the whole of the
+  // machinery, so every cell below is a gate and one call.
+
+  /// A clone of `entry` carrying `state` instead of its own — the span and the token untouched.
+  fn with_state(entry: &CachedTokenOf<'a, L>, state: L::State) -> CachedTokenOf<'a, L> {
+    let mut out = entry.clone();
+    out.state = state;
+    out
+  }
+
+  /// A clone of `entry` carrying `token` instead of its own — the span and the state untouched.
+  fn with_token(entry: &CachedTokenOf<'a, L>, token: L::Token) -> CachedTokenOf<'a, L> {
+    let mut out = entry.clone();
+    out.token.data = token;
+    out
+  }
+
+  /// A reference-shaped entry assembled out of two resident ones: `own`'s span and token beside
+  /// `state_from`'s state. What a cache that reads its edges out of parallel arrays, one index
+  /// apart, hands a caller.
+  fn ref_with_foreign_state<'s>(
+    own: &'s CachedTokenOf<'a, L>,
+    state_from: &'s CachedTokenOf<'a, L>,
+  ) -> CachedTokenRefOf<'s, 'a, L> {
+    CachedToken::new(
+      Spanned::new(&own.token.span, &own.token.data),
+      &state_from.state,
+    )
+  }
+
+  /// [`ref_with_foreign_state`](Self::ref_with_foreign_state) on the other half: `own`'s span and
+  /// state beside `token_from`'s token.
+  fn ref_with_foreign_token<'s>(
+    own: &'s CachedTokenOf<'a, L>,
+    token_from: &'s CachedTokenOf<'a, L>,
+  ) -> CachedTokenRefOf<'s, 'a, L> {
+    CachedToken::new(
+      Spanned::new(&own.token.span, &token_from.token.data),
+      &own.state,
+    )
+  }
+
+  /// The two edge cells' shared body: the entry at one end of the queue, handed back with its
+  /// neighbour's state ([`EDGE_STATE_SKEW`]) or its neighbour's token ([`EDGE_TOKEN_SKEW`]).
+  /// `None` when neither cell is selected or the queue is too short for a neighbour to exist, in
+  /// which case the caller answers conformingly.
+  fn skewed_edge<'s>(
+    own: &'s CachedTokenOf<'a, L>,
+    neighbour: &'s CachedTokenOf<'a, L>,
+  ) -> Option<CachedTokenRefOf<'s, 'a, L>> {
+    match D {
+      EDGE_STATE_SKEW => Some(Self::ref_with_foreign_state(own, neighbour)),
+      EDGE_TOKEN_SKEW => Some(Self::ref_with_foreign_token(own, neighbour)),
+      _ => None,
+    }
+  }
+
+  /// The two pop cells' shared body: the right entry, carrying the state ([`POP_STATE_SKEW`]) or
+  /// the token ([`POP_TOKEN_SKEW`]) of whatever is left at that end of the queue.
+  ///
+  /// Honest when the pop emptied the cache — there is no neighbour to borrow from, and a cell
+  /// that answered wrongly there would be caught by a residency the entry comparison does not
+  /// need to reach.
+  fn skew_popped(
+    &self,
+    popped: Option<CachedTokenOf<'a, L>>,
+    neighbour: Option<&CachedTokenOf<'a, L>>,
+  ) -> Option<CachedTokenOf<'a, L>> {
+    let tok = popped?;
+    // [`POST_PEEK_POP_STATE_SKEW`]: the state an earlier `peek` on THIS instance cached, reported
+    // by every pop after it. Gated on a peek having happened rather than on the residency — the
+    // frontier is what makes it wrong, and there is no frontier until something peeked. Cloned
+    // out of the `RefCell` before the `if let` so no borrow guard outlives the scrutinee.
+    if D == POST_PEEK_POP_STATE_SKEW {
+      let frontier = self.frontier_state.borrow().clone();
+      return match frontier {
+        Some(frontier) => Some(Self::with_state(&tok, frontier)),
+        None => Some(tok),
+      };
+    }
+    let Some(neighbour) = neighbour else {
+      return Some(tok);
+    };
+    match D {
+      POP_STATE_SKEW => Some(Self::with_state(&tok, neighbour.state.clone())),
+      POP_TOKEN_SKEW => Some(Self::with_token(&tok, neighbour.token.data.clone())),
+      _ => Some(tok),
+    }
+  }
+
   /// The refusal round-trip — or, under `SWAPPING_REFUSAL`, its violation: the caller is handed a
   /// resident entry instead of the token it offered, which silently swallows that token.
   fn refuse(&mut self, tok: CachedTokenOf<'a, L>) -> CachedTokenOf<'a, L> {
@@ -1181,6 +1675,18 @@ where
     {
       self.items.push_back(tok);
       return other;
+    }
+    // #183: the offered token comes back at its own span, with a RESIDENT entry's state or token
+    // substituted. Span-identical to what was offered, so the round-trip saw nothing wrong with
+    // it while it compared spans — and the input layer parks this value and later restores from
+    // it.
+    if (D == REFUSAL_STATE_SWAP || D == REFUSAL_TOKEN_SWAP)
+      && let Some(resident) = self.items.back()
+    {
+      return match D {
+        REFUSAL_STATE_SWAP => Self::with_state(&tok, resident.state.clone()),
+        _ => Self::with_token(&tok, resident.token.data.clone()),
+      };
     }
     tok
   }
@@ -1203,10 +1709,50 @@ where
     if self.items.len() == self.cap {
       return Err(self.refuse(tok));
     }
+    // #183 round 4: a refusal the contract does not allow — there is room — reached only once a
+    // prepend has landed on this instance, which is the gate that puts the first hit on an
+    // `accepted_push_*` site rather than on the two loops that drive refusals deliberately.
+    //
+    // The corruption is applied HERE and not in `refuse`, which the capacity check above shares:
+    // routing it through there would corrupt the WARRANTED refusals too, and this cell would
+    // land on check 3's round-trip — `REFUSAL_STATE_SWAP`'s site — instead of on the unexpected
+    // one it exists for. (It did, the first time this cell was written.)
+    if D == UNEXPECTED_REFUSAL_ENTRY_SWAP && self.front_pushes.get() > 0 {
+      return Err(match self.items.back() {
+        Some(resident) => Self::with_state(&tok, resident.state.clone()),
+        None => tok,
+      });
+    }
+    // The same shape at check 3's MIXED site: refuse with room from the first non-empty cache,
+    // and corrupt the entry handed back. Reached before any `accepted_push_back`, so it lands on
+    // the branch round 4's wrapper-level fix could not see.
+    if D == EARLY_PUSH_BACK_REFUSAL_ENTRY_SWAP
+      && let Some(resident) = self.items.back()
+    {
+      return Err(Self::with_state(&tok, resident.state.clone()));
+    }
     self.warmed.set(true);
     // Read before the move below, for `STALE_SPAN_AFTER_POP_BACK`'s `span()` override — see
     // that constant's doc for why this is never cleared or refreshed by a pop.
     self.last_pushed_back_span = Some((*tok.token().span_ref()).clone());
+    // #183's storage flagship: the span and the token go in faithfully, and the state that goes
+    // in beside them is the previously accepted entry's. The first push into an empty cache has
+    // no predecessor and keeps its own, which is why check 3's first residency is conforming and
+    // the second is not.
+    //
+    // The `Ok` reference this arm returns is built from the entry it was OFFERED, not read back
+    // out of the store — see `last_offered`. That keeps the cell's single divergence in storage,
+    // where its doc says it is, so it pins the `back()` edge read rather than the accepted-push
+    // read that `WRONG_ACCEPTED_PUSH_REF` exists for.
+    if D == STATE_LAG {
+      let lagged = match self.items.back() {
+        Some(prev) => Self::with_state(&tok, prev.state.clone()),
+        None => tok.clone(),
+      };
+      self.last_offered = Some(tok);
+      self.items.push_back(lagged);
+      return Ok(self.last_offered.as_ref().expect("just set").as_ref());
+    }
     self.items.push_back(tok);
     if D == INTERLEAVED_PUSH_BACK_REORDERS && self.front_pushes.get() > 0 && self.items.len() > 3 {
       // A slot computed from a head index a `push_front` has since moved. Interior only — index 2
@@ -1214,6 +1760,14 @@ where
       // the head nor the tail this push just established ever moves. Gated on a prepend having
       // happened at all, which is what no driver in the kit ever put in front of a `push_back`.
       self.items.swap(1, 2);
+    }
+    // #183 round 3: storage above is faithful; the reference handed back is not. Assembled from
+    // the entry just pushed and its neighbour's state, so nothing that reads the store can see it.
+    if D == WRONG_ACCEPTED_PUSH_REF && self.items.len() >= 2 {
+      let n = self.items.len();
+      let own = self.items.get(n - 1).expect("len >= 2");
+      let neighbour = self.items.get(n - 2).expect("len >= 2");
+      return Ok(Self::ref_with_foreign_state(own, neighbour));
     }
     Ok(self.items.back().expect("just pushed").as_ref())
   }
@@ -1248,7 +1802,9 @@ where
         self.graveyard.push_back(tok.clone());
       }
     }
-    popped
+    // #183: the right entry with the new front's state or token beside it, under the two pop
+    // cells and nowhere else.
+    self.skew_popped(popped, self.items.front())
   }
 }
 
@@ -1445,8 +2001,16 @@ fn cache_kit_catches_a_try_pop_front_if_that_predicates_on_the_back() {
 /// `try_pop_front_if` finding is an assertion missing where the property is claimed, and this is
 /// the same property claimed by an assertion with no mutant behind it. Both halves of check 9's
 /// "the predicate sees the front entry" are witnessed as of this pair.
+///
+/// The `expected` string names the **declining** arm as of #183's ninth round, and this is the
+/// one firing site in the kit that round moved. It is the same assertion on the same method —
+/// `assert_recorded_predicate_arg`'s span half, reached through `recording_pop_front_if` — at an
+/// earlier call: the false-predicate arm did not read its argument at all before that round, so
+/// the true-predicate arm below was the first `pop_front_if` that looked. Closing the hole put a
+/// reader in front of it. The move was found by the before/after firing-message diff rather than
+/// reasoned about, and the vacated arm still carries the identical routed assertion.
 #[test]
-#[should_panic(expected = "pop_front_if()'s predicate was handed")]
+#[should_panic(expected = "pop_front_if()'s false predicate was handed")]
 fn cache_kit_catches_a_pop_front_if_that_predicates_on_the_back() {
   run_queue::<POP_FRONT_IF_PREDICATES_ON_THE_BACK>();
 }
@@ -1756,4 +2320,360 @@ fn cache_kit_catches_a_memoising_peek() {
 #[should_panic(expected = "push-front/into-empty")]
 fn cache_kit_catches_a_push_front_refused_by_an_empty_cache() {
   run_queue::<EMPTY_REFUSING_PUSH_FRONT>();
+}
+
+// ── #183: the entry observable, and the fifteen cells that keep it from being vacuous ────
+//
+// Every cell below leaves the spans of everything it touches where a conforming cache would put
+// them, so **every one of them passed the kit in full before #183**. Each pins exactly one of the
+// two comparisons the entry observable adds, at one site, through the `entry-token` and
+// `entry-state` message tags: an `expected` string that named only the site would match the span
+// half too and prove nothing.
+
+/// The corpus is the substrate every entry cell below stands on, and it is silent when it breaks:
+/// a `SRC` edit that reintroduced a repeated token payload, or a lexer change that stopped the
+/// state advancing, would leave every mutant here *passing* — the kit would compare, and the
+/// comparison would be vacuous, which is the exact defect class #183 exists to close, one level
+/// down.
+///
+/// So the distinctness is asserted directly, off the lexer rather than through the kit: twelve
+/// items, pairwise distinct spans, tokens and states, with the kinds alternating so that a
+/// neighbour skew is visible on the kind and not only on the payload.
+#[test]
+fn corpus_is_pairwise_distinct_on_all_three_axes() {
+  let mut lexer = <CLex<'_> as Lexer<'_>>::new(SRC);
+  let mut spans = Vec::new();
+  let mut tokens = Vec::new();
+  let mut states = Vec::new();
+  while spans.len() < 12 {
+    let Some(res) = lexer.lex() else { break };
+    let span = lexer.span();
+    let state = *lexer.state();
+    let tok = res.expect("the corpus source lexes cleanly");
+    spans.push(span);
+    tokens.push(tok);
+    states.push(state);
+  }
+  assert_eq!(
+    spans.len(),
+    12,
+    "SRC must lex to the twelve items the widest capacity (8) plus a full 4-slot peek window \
+     needs; it lexed {} — every `beyond_residency`/`filled_from` demand in the kit is bounded by \
+     capacity + window, so a shorter SRC turns cell failures into kit-usage panics",
+    spans.len()
+  );
+  for i in 0..spans.len() {
+    assert_eq!(
+      tokens[i].kind(),
+      if i % 2 == 0 { CKind::Word } else { CKind::Num },
+      "SRC's token kinds must alternate, so a cache that swaps two neighbours is visible on the \
+       kind and not only on the payload; position {i} is {:?}",
+      tokens[i].kind()
+    );
+    assert_eq!(
+      states[i].lexed,
+      u32::try_from(i).expect("twelve fits") + 1,
+      "the corpus state must advance once per token, so the state cached beside each entry is \
+       that entry's own"
+    );
+    for j in (i + 1)..spans.len() {
+      assert_ne!(
+        spans[i], spans[j],
+        "corpus spans must be pairwise distinct: positions {i} and {j} share one"
+      );
+      assert_ne!(
+        tokens[i], tokens[j],
+        "corpus tokens must be pairwise distinct, or the kit's token comparison cannot \
+         discriminate a swap between positions {i} and {j}"
+      );
+      assert_ne!(
+        states[i], states[j],
+        "corpus states must be pairwise distinct, or the kit's state comparison cannot \
+         discriminate a re-association between positions {i} and {j}"
+      );
+    }
+  }
+}
+
+/// Mutant 1, the storage flagship: `push_back` stores every span and every token faithfully and
+/// stores the **previous** entry's `L::State` beside them.
+///
+/// The expected message names the `back()` edge read, which is the entry `InputRef::resume`
+/// rebuilds a lexer from and the one whose state message carries the restore consequence. It
+/// fires at the first two-resident residency check 3 builds — the shallowest residency at which a
+/// lag is a lag at all.
+#[test]
+#[should_panic(expected = "entry-state] edge-identity back()")]
+fn cache_kit_catches_a_push_back_that_stores_the_previous_entrys_state() {
+  run_queue::<STATE_LAG>();
+}
+
+/// Mutant 2: `front()`/`back()` name the right slot and carry the neighbour's state.
+///
+/// The expected message names the `front()` read, which is the first edge the residency oracle
+/// compares. `WRONG_FRONT_IDENTITY` is the same accessor caught by the span half; this cell is
+/// what is left of that defect once the span is right, and nothing before #183 could see it.
+#[test]
+#[should_panic(expected = "entry-state] edge-identity front()")]
+fn cache_kit_catches_an_edge_reference_carrying_the_neighbours_state() {
+  run_queue::<EDGE_STATE_SKEW>();
+}
+
+/// Mutant 3: [`EDGE_STATE_SKEW`] on the token half.
+#[test]
+#[should_panic(expected = "entry-token] edge-identity front()")]
+fn cache_kit_catches_an_edge_reference_carrying_the_neighbours_token() {
+  run_queue::<EDGE_TOKEN_SKEW>();
+}
+
+/// Mutant 4: `pop_front`/`pop_back` return the right entry with the remaining neighbour's state.
+///
+/// The expected message names check 4's first `pop_front`, which is the first pop in the whole
+/// kit that leaves a neighbour behind — the pops in checks 2 and 5's empty-cache drivers empty
+/// the cache, and this cell is honest there by construction.
+#[test]
+#[should_panic(expected = "entry-state] order pop_front #0")]
+fn cache_kit_catches_a_pop_that_returns_the_neighbours_state() {
+  run_queue::<POP_STATE_SKEW>();
+}
+
+/// Mutant 5: [`POP_STATE_SKEW`] on the token half.
+#[test]
+#[should_panic(expected = "entry-token] order pop_front #0")]
+fn cache_kit_catches_a_pop_that_returns_the_neighbours_token() {
+  run_queue::<POP_TOKEN_SKEW>();
+}
+
+/// Mutant 6: the owned peek arm serves the right run with every state replaced by the front's.
+///
+/// The expected message names the empty-buffer peek at the full cache — `bounded-peek against`,
+/// which is the run comparison and not `peek_one`'s or the prefilled sweep's. Position 0 is right
+/// by coincidence, exactly as `WRONG_OWNED_PEEK`'s is, so it takes a residency of two before the
+/// kit is asked anything at all.
+#[test]
+#[should_panic(expected = "entry-state] bounded-peek against")]
+fn cache_kit_catches_an_owned_peek_that_serves_one_state_for_every_entry() {
+  run_queue::<OWNED_PEEK_STATE_SKEW>();
+}
+
+/// Mutant 7: `WRONG_OWNED_PEEK` **minus the span corruption** — the owned-arm instance of the
+/// span-only comparison #183 is about.
+#[test]
+#[should_panic(expected = "entry-token] bounded-peek against")]
+fn cache_kit_catches_an_owned_peek_that_serves_one_token_for_every_entry() {
+  run_queue::<OWNED_PEEK_TOKEN_SKEW>();
+}
+
+/// Mutant 8: `peek_one` names the front and carries the back's state.
+///
+/// The expected message names `peek_one()` specifically, so this cell cannot be satisfied by the
+/// run comparison above it — `peek` is untouched here, and a cell whose `expected` said only
+/// `bounded-peek` would not have said which of the two it pinned.
+#[test]
+#[should_panic(expected = "entry-state] bounded-peek peek_one()")]
+fn cache_kit_catches_a_peek_one_that_carries_the_backs_state() {
+  run_queue::<PEEK_ONE_STATE_SKEW>();
+}
+
+/// Mutant 9: [`PEEK_ONE_STATE_SKEW`] on the token half.
+#[test]
+#[should_panic(expected = "entry-token] bounded-peek peek_one()")]
+fn cache_kit_catches_a_peek_one_that_carries_the_backs_token() {
+  run_queue::<PEEK_ONE_TOKEN_SKEW>();
+}
+
+/// Mutant 10: a refused push hands the offered token back at its own span with a resident's
+/// state.
+///
+/// `SWAPPING_REFUSAL` is the same site caught by the span half — it hands back a whole different
+/// entry. This is what survives when the span is right, and it is the value the input layer's
+/// put-back parks and later restores a lexer from.
+#[test]
+#[should_panic(expected = "entry-state] refusal-round-trip push_back")]
+fn cache_kit_catches_a_refusal_that_swaps_in_a_residents_state() {
+  run_queue::<REFUSAL_STATE_SWAP>();
+}
+
+/// Mutant 13 (added by the #183 cross-model gate): the refusal round-trip's **token** half.
+///
+/// Without this cell that half would be a comparison nothing in the suite could fail: mutant 10
+/// corrupts only the state, and no other cell reaches a refused push's return value at all.
+#[test]
+#[should_panic(expected = "entry-token] refusal-round-trip push_back")]
+fn cache_kit_catches_a_refusal_that_swaps_in_a_residents_token() {
+  run_queue::<REFUSAL_TOKEN_SWAP>();
+}
+
+/// Mutant 11: `push_many`'s overflow comes back at the right spans, in order, with a resident's
+/// state.
+///
+/// The override is in `push_many` alone, so check 3's refusal round-trip stays conforming and the
+/// cell reports at its own site — which is what makes the `expected` string a pin on **this**
+/// comparison rather than on the refusal one.
+#[test]
+#[should_panic(expected = "entry-state] push-many overflow entry #0")]
+fn cache_kit_catches_a_push_many_that_rewrites_the_overflows_state() {
+  run_queue::<PUSH_MANY_STATE_SWAP>();
+}
+
+/// Mutant 14 (added by the #183 cross-model gate): the `push_many` overflow's **token** half, for
+/// the reason [`cache_kit_catches_a_refusal_that_swaps_in_a_residents_token`] exists.
+#[test]
+#[should_panic(expected = "entry-token] push-many overflow entry #0")]
+fn cache_kit_catches_a_push_many_that_rewrites_the_overflows_token() {
+  run_queue::<PUSH_MANY_TOKEN_SWAP>();
+}
+
+/// Mutant 12: `try_pop_front_if` hands its predicate the front entry carrying the back's state,
+/// and is otherwise conforming.
+///
+/// The expected message names the **Err** path, which is the first of check 9's two
+/// `try_pop_front_if` recording predicates to run. `TRY_POP_FRONT_IF_PREDICATES_ON_THE_BACK` is
+/// the same site caught by the span half; this is a predicate shown the right token at a lexer
+/// position it never occupied.
+///
+/// Scoped to `try_pop_front_if` in #183's ninth round, when the declining `pop_front_if` arm
+/// gained a reader and became the first recording predicate in the check. This mutant used to
+/// skew both methods and could only ever report at whichever ran first, so the `pop_front_if`
+/// half was coverage-shaped and never fired; scoping it here keeps this cell on the site its
+/// `expected` has always named, and [`cache_kit_catches_a_declining_predicate_shown_the_backs_state`]
+/// pins the other method for real.
+#[test]
+#[should_panic(
+  expected = "entry-state] pop-front-if try_pop_front_if()'s Err-path predicate argument"
+)]
+fn cache_kit_catches_a_predicate_shown_the_backs_state() {
+  run_queue::<PREDICATE_ARG_STATE_SKEW>();
+}
+
+/// Mutant 15 (added by the #183 cross-model gate): the predicate argument's **token** half, for
+/// the reason [`cache_kit_catches_a_refusal_that_swaps_in_a_residents_token`] exists.
+#[test]
+#[should_panic(
+  expected = "entry-token] pop-front-if try_pop_front_if()'s Err-path predicate argument"
+)]
+fn cache_kit_catches_a_predicate_shown_the_backs_token() {
+  run_queue::<PREDICATE_ARG_TOKEN_SKEW>();
+}
+
+/// Mutant 16, from #183's own adversarial review: `peek` caches a lookahead frontier and every
+/// later pop on that instance reports its `L::State` instead of the removed entry's.
+///
+/// This is the #183 defect class surviving **inside** the #183 fix, on the peek-then-consume path
+/// the issue's severity argument rests on. It is also the one site the PR's residual-coverage
+/// argument did not cover: that argument is about comparisons reached through a return path some
+/// other mutant already corrupts, and this one was reached by nothing, because
+/// `check_peek_across_mutations` bound its popped value and asserted `is_some()` on it. **A
+/// discarded value cannot be pinned by a mutant on any return path** — the only fix is to compare
+/// it, which is what the drain now does.
+///
+/// The expected message names the drain's **first** pop. Every other drain in the kit pops an
+/// instance that has never been peeked, so the frontier is unset and this fixture is conforming at
+/// all of them — which is what makes the `expected` string a pin on the across-mutations drain
+/// specifically, and not on `check_pop_order`'s.
+///
+/// Only the state half is a cell of its own, and deliberately. The comparison goes through the
+/// shared [`CacheHarness::assert_entry_eq`](super::cache) helper, so the removable units here are
+/// the whole call — which this cell catches — and the helper's token branch, which seven cells
+/// above already pin. A token sibling would re-pin a branch that is pinned, not a site that is
+/// not; the state half is the one to spend the cell on, since `L::State` is what a resume rebuilds
+/// the lexer from.
+#[test]
+#[should_panic(expected = "entry-state] bounded-peek/across-mutations pop_front() #0")]
+fn cache_kit_catches_a_peek_that_poisons_the_state_of_later_pops() {
+  run_queue::<POST_PEEK_POP_STATE_SKEW>();
+}
+
+/// Mutant 17, from #183's third review round: the push stores perfectly and returns an `Ok`
+/// reference assembled from a different resident.
+///
+/// Rounds 2 and 3 found the same class in two places — a value a `Cache` method handed back that
+/// the kit reduced to presence: first a popped entry, then an accepted push's reference. So the
+/// kit now reads **every** such value, and this cell is what keeps the push half of that from
+/// being a check nothing can fail. The contract is explicit — `Ok` carries *a reference to the
+/// cached token* — and the violation is invisible to every other oracle here, because they all
+/// observe storage and this cell's storage is flawless.
+///
+/// The expected message names `push_back #1` in check 3, which is the first accepted push in the
+/// whole kit that lands with a neighbour already resident: every earlier one goes into an empty
+/// cache, where the entry pushed and the entry beside it are the same one and this cell is
+/// conforming.
+///
+/// One cell for both arms, because both route through the kit's single accepted-push comparison —
+/// the same granularity argument the two rounds before this one recorded: the removable units are
+/// that one call, which this pins, and the shared entry helper's branches, which nine cells above
+/// already pin.
+#[test]
+#[should_panic(expected = "entry-state] accepted-push push_back #1")]
+fn cache_kit_catches_an_accepted_push_that_returns_the_wrong_reference() {
+  run_queue::<WRONG_ACCEPTED_PUSH_REF>();
+}
+
+/// Mutant 18, from #183's fourth review round, and the one that finishes the class: a push
+/// refused with room to spare that also corrupts the entry it hands back.
+///
+/// The `accepted_push_*` wrappers used to take `Err`, panic on the refusal and drop the returned
+/// value — the last `Cache` return in the kit read for its shape and not its contents. This cell
+/// is what makes the fix bite, and the `expected` string is the evidence for **which** assertion
+/// fires: `entry-state] unexpected-refusal`, the entry comparison, not the refusal panic that
+/// follows it. Without the comparison the refusal message would be all that ever appeared.
+///
+/// It is a claim-accuracy cell rather than a coverage one, and says so plainly: reaching it needs
+/// a refusal the contract forbids, which the kit already fails on. No cache is certified because
+/// of this. What was untrue before it is the kit's claim that every value a `Cache` method hands
+/// back is compared or is a documented exception — and an enumeration with an unlisted third case
+/// is the same defect class as an oracle that does not look, one level up.
+#[test]
+#[should_panic(
+  expected = "entry-state] unexpected-refusal push_back #1 building an interleaved residency"
+)]
+fn cache_kit_catches_an_unwarranted_refusal_that_corrupts_the_returned_entry() {
+  run_queue::<UNEXPECTED_REFUSAL_ENTRY_SWAP>();
+}
+
+/// Mutant 19, from #183's fifth review round: the **mixed** `push_back` site.
+///
+/// Round 4 put the unexpected-refusal comparison in the `accepted_push_*` wrappers, which was
+/// right and incomplete — check 3's push never goes through a wrapper, because a refusal there is
+/// sometimes legitimate. The same call, two meanings, and the unwarranted one asserted its way
+/// out before the entry was read. The comparison now lives in `push_back_expecting`, told which
+/// meaning applies by `must_accept`, and this cell is what makes that bite.
+///
+/// The `expected` string carries a trailing colon so it pins **this** site: mutant 18's message
+/// continues `push_back #1 building an interleaved residency`, and a bare `#1` would match both.
+#[test]
+#[should_panic(expected = "entry-state] unexpected-refusal push_back #1:")]
+fn cache_kit_catches_an_early_push_back_refusal_that_corrupts_the_returned_entry() {
+  run_queue::<EARLY_PUSH_BACK_REFUSAL_ENTRY_SWAP>();
+}
+
+/// Mutant 20: the prepend twin of mutant 19, at check 5's mixed site.
+#[test]
+#[should_panic(expected = "entry-state] unexpected-refusal push_front #0:")]
+fn cache_kit_catches_an_early_push_front_refusal_that_corrupts_the_returned_entry() {
+  run_queue::<EARLY_PUSH_FRONT_REFUSAL_ENTRY_SWAP>();
+}
+
+/// Mutant 21, from #183's ninth review round: the **declining** `pop_front_if` predicate is shown
+/// the back's `L::State`, and everything else about the call conforms.
+///
+/// The round's finding was a classification error, not a missing assertion. Check 9's
+/// false-predicate arm sat among the kit's absence exceptions — "it returns `None`, so there is
+/// no entry to compare" — which is true of the RETURN and says nothing about the ARGUMENT.
+/// `pop_front_if` hands caller code a real entry *before* it learns the answer, so a cache can
+/// answer `None` correctly, remove nothing, keep every span in place, and still run the caller's
+/// validation predicate against a lexer position that entry never occupied.
+///
+/// The `expected` string names `false-predicate argument`, which pins the declining arm
+/// specifically: `POP_FRONT_IF_PREDICATE_ARG_STATE_SKEW` is wrong on every `pop_front_if` arm —
+/// `F: FnOnce` settles the entry before the answer exists — and this is simply the first of them
+/// the kit now reads.
+///
+/// It fails on the **entry comparison**, not on residency, and that is the whole point of the
+/// cell: `WRONG_POP_FRONT_IF` already covers a declining call that removes something. This one
+/// removes nothing, so every residency and return oracle in check 9 agrees it conformed.
+#[test]
+#[should_panic(expected = "entry-state] pop-front-if pop_front_if()'s false-predicate argument")]
+fn cache_kit_catches_a_declining_predicate_shown_the_backs_state() {
+  run_queue::<POP_FRONT_IF_PREDICATE_ARG_STATE_SKEW>();
 }


### PR DESCRIPTION
Closes #183