### PR TITLE
perf(tokora): name a node's kind up front, with a demote-on-error door

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,70 @@ with it. `ci/changelog_structure.sh` enforces every clause above and will red un
   `CachedToken` gains no `PartialEq` impl (the kit compares componentwise for the message quality
   that buys).
 
+- **`CstEmitter::cst_start` now returns an `EventMark`, and a new `CstEmitter::cst_demote`
+  spends it — the up-front node bracket.** `node(kind, p)` driven as a `ParseInput` used to
+  name its node's kind *after* the sub-parse: entry minted an inert tombstone (`cst_mark`) and
+  a successful exit retro-wrapped it (`cst_start_at` + `cst_finish`), three events per node.
+  It now names the kind at entry (`cst_start`) and closes on both exits — `cst_finish` on
+  success, `cst_demote` on failure — two events per node. Measured on the GraphQL `alias`
+  corpus: **−57.7 µs** median over six paired reps, 9,013 events removed from a 64,085-event
+  log, which is ~3.8% of the lossless parse and ~19% of the gap to `apollo-parser`;
+  **−7.4 µs** on `supergraph`, **−0.3 µs** on `example_query`, no corpus slower and 14/14
+  paired reps same-signed.
+
+  What breaks — two shapes, both in the emitter layer, none in a grammar. An emitter that
+  **overrides** `cst_start` must now return the `EventMark` naming the slot it opened: a
+  wrapper forwards the inner's value unchanged, and an emitter with no event channel should
+  not override the method at all and inherits the defaulted inert mark. And an emitter that
+  overrides any structuring method should also forward `cst_demote`, for the same reason it
+  forwards the rest — a wrapper that forwards `cst_start` and inherits the `cst_demote` no-op
+  leaves its inner carrying a dangling open node for every `Err` a `node()` sees. `cst_demote`
+  is defaulted, so that is a silent gap rather than a compile error, the same class
+  `commit_token` already had; the sink's composition census now covers it. Grammars are
+  untouched: `node`, `node_at` and `node_opt` are unchanged at their call sites, and the three
+  surfaces that forward the event channel (`EmitterView`, `InputRef`, `ParseState`) carry
+  `cst_demote` alongside the rest.
+
+  What deliberately did *not* change: only `ParseInput for Node` took the up-front bracket.
+  `TryParseInput for Node`, both `NodeAt` impls, `NodeOpt`, `cst_mark` / `cst_start_at` /
+  `Marker` and the whole pratt driver stay retro, and they stay retro for a reason rather than
+  by omission — a declining parser's kind is not knowable at entry (a decline must leave
+  *nothing*, on a path that also consumes nothing), `node_at` exists precisely to name a kind
+  decided after its first child, and a pratt wrap's kind is a function of an operator not yet
+  read.
+
+  The law it amends: `cst/event.rs` argues at length that no operation rewrites the kind of an
+  interior slot. `cst_demote` does, and it is lawful in that one direction with no journal
+  entry — the write's author is the frame that appended the slot, so any truncation erasing the
+  branch that made the write erases the slot itself, while any truncation keeping the slot
+  keeps a demotion that is permanently true: the bracket exited with an error, and no rewind
+  re-runs an exited frame. The banned direction stays banned. Completing a tombstone in place
+  lets a rolled-back branch's decision survive its own truncation, because the completer is not
+  the frame that appended the slot.
+
+  The misuse wall around `cst_demote` is scoped to what it can actually prove. Three spends are
+  refused in **every** build — a stale mark, a foreign sink's mark, and a mark whose slot is not
+  a live `StartNode` of the demoted kind — and so, now, is a demote naming the reserved
+  `TOMBSTONE` kind, which no `cst_start` can ever have opened. What the wall cannot see is a
+  start whose node was already **finished**: the finish is appended *above* the slot, so the slot
+  cannot witness it. A debug build catches that at the misuse site with an exact suffix scan; a
+  release build refuses it at materialization as a typed `FinishError` — the demote removes one
+  frame push and no pop, so the walk underflows and both `finish` and `finish_partial` return
+  `OrphanFinish`. It is never a silently wrong tree.
+
+  `cargo semver-checks` reports this, and that is expected and acknowledged here rather than
+  suppressed there: `cst_start`'s return type changed on a public trait, and `cst_demote` is a
+  new defaulted trait method. Both are intentional, both are described above, and 0.9.0 is the
+  vehicle.
+
+  The change costs a diagnostics-only parse **nothing, verified rather than asserted**: over
+  `Fatal` / `Verbose` / `Silent` the event methods are defaulted `#[inline(always)]` no-ops and
+  the handback is a dead `Copy` constant, and a fixture exercising the whole `node` family
+  compiles to a **byte-identical binary** before and after — positive control, perturbing
+  `cst_demote`'s default to a `black_box` changes it. The four-corpora tree-identity gate is
+  byte-identical on all four, error corpora included.
+  — *(#169)*
+
 ### Changed
 
 - **MSRV raised to 1.95.** The previous floor, 1.87, was not a forced minimum — the crate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,11 +147,11 @@ with it. `ci/changelog_structure.sh` enforces every clause above and will red un
   name its node's kind *after* the sub-parse: entry minted an inert tombstone (`cst_mark`) and
   a successful exit retro-wrapped it (`cst_start_at` + `cst_finish`), three events per node.
   It now names the kind at entry (`cst_start`) and closes on both exits — `cst_finish` on
-  success, `cst_demote` on failure — two events per node. Measured on the GraphQL `alias`
-  corpus: **−57.7 µs** median over six paired reps, 9,013 events removed from a 64,085-event
-  log, which is ~3.8% of the lossless parse and ~19% of the gap to `apollo-parser`;
-  **−7.4 µs** on `supergraph`, **−0.3 µs** on `example_query`, no corpus slower and 14/14
-  paired reps same-signed.
+  success, `cst_demote` on failure — two events per **successful** node. Measured on the
+  GraphQL `alias` corpus: **−47.1 µs** median over sixteen paired reps, 9,013 events removed
+  from a 64,085-event log, which is ~3.8% of the lossless parse and ~19% of the gap to
+  `apollo-parser`; **−7.0 µs** on `supergraph`, **−0.3 µs** on `example_query`, no corpus
+  slower and 24/24 paired reps same-signed.
 
   What breaks — two shapes, both in the emitter layer, none in a grammar. An emitter that
   **overrides** `cst_start` must now return the `EventMark` naming the slot it opened: a
@@ -174,24 +174,68 @@ with it. `ci/changelog_structure.sh` enforces every clause above and will red un
   decided after its first child, and a pratt wrap's kind is a function of an operator not yet
   read.
 
-  The law it amends: `cst/event.rs` argues at length that no operation rewrites the kind of an
-  interior slot. `cst_demote` does, and it is lawful in that one direction with no journal
-  entry — the write's author is the frame that appended the slot, so any truncation erasing the
-  branch that made the write erases the slot itself, while any truncation keeping the slot
-  keeps a demotion that is permanently true: the bracket exited with an error, and no rewind
-  re-runs an exited frame. The banned direction stays banned. Completing a tombstone in place
-  lets a rolled-back branch's decision survive its own truncation, because the completer is not
-  the frame that appended the slot.
+  The law it does **not** amend, and that is the point. `cst/event.rs` states that the
+  parse-time event buffer mutates only by append and suffix-truncate. `cst_demote` obeys it: the
+  failing exit **appends** an `Event::Demote` naming its own start, exactly as `cst_start_at`
+  appends a `StartAt` naming its target, and materialization's canonicalization pass applies
+  every surviving demote to its slot (`events[target].kind = TOMBSTONE`) at the one moment no
+  live mark can exist — the sink has been consumed. Both of the bracket's exits are therefore
+  appends, which gives them **one** rollback law: a session point rolled back into the window
+  between a `cst_start` and its exit truncates that exit and the node is open again, success and
+  failure alike.
 
-  The misuse wall around `cst_demote` is scoped to what it can actually prove. Three spends are
-  refused in **every** build — a stale mark, a foreign sink's mark, and a mark whose slot is not
-  a live `StartNode` of the demoted kind — and so, now, is a demote naming the reserved
-  `TOMBSTONE` kind, which no `cst_start` can ever have opened. What the wall cannot see is a
-  start whose node was already **finished**: the finish is appended *above* the slot, so the slot
-  cannot witness it. A debug build catches that at the misuse site with an exact suffix scan; a
-  release build refuses it at materialization as a typed `FinishError` — the demote removes one
-  frame push and no pop, so the walk underflows and both `finish` and `finish_partial` return
-  `OrphanFinish`. It is never a silently wrong tree.
+  An earlier draft of this entry claimed an in-place kind rewrite was lawful without a journal
+  entry. It is not, and the counter-example is why the encoding is what it is: a rollback whose
+  target lands *between* the slot and the demote keeps the slot and keeps the rewrite, so
+  `finish` returned a balanced buffer with one fewer node than the checkpoint promised —
+  undetectable by anything downstream, on a history the public API can write (`EventMark` is a
+  `Copy` POD and session points are non-lexical). The single-sentence law now covers all three
+  interior writes the sink has: `cst_start_at`'s journaled `forward_parent` link, the recovery
+  hole's splice floored above every live mark, and canonicalization.
+
+  Canonicalization is **guarded by a latch**, and that is measured rather than tidy. It is one
+  linear pass over the event log, and an unguarded pass costs a parse that never took a failing
+  bracket exit — which is *every* parse of a predictive grammar, GraphQL included — a real
+  `O(events)`: **+75 µs** median over eight paired reps on a 231 KB / ~220,000-event document
+  whose demote count is exactly zero, 8/8 same-signed. The sink therefore carries a latching
+  `demotes` hint, set when a `Demote` is appended and never cleared. It is in the `degraded`
+  cell class rather than the memo class, and the direction of its imprecision is what makes it
+  safe: nothing ever writes `false` after construction, so a rewind that truncates the last
+  surviving `Demote` merely leaves the hint set and buys one no-op pass — the opposite error,
+  which would let an abandoned node materialize, is unrepresentable, and a `debug_assert!` at
+  materialization holds that direction.
+
+  Four things this costs, stated rather than left to be discovered:
+
+  - **A demoted slot is no longer a retro-wrap anchor.** It holds its real kind for the whole
+    parse, so `cst_start_at` refuses the mark at its tombstone wall. The affordance was one PR
+    old, unreleased and had no consumers; recovery tooling that wants to wrap an abandoned
+    region takes its own `cst_mark`.
+  - **A double demote is no longer refused in every build.** The slot is unchanged by a demote,
+    so it cannot witness that it was already demoted — the same reason it cannot witness a
+    finish. It drops to the calibration this surface already uses for demote-after-finish:
+    caught at cause in a **debug** build by the exact suffix recount (a prior `Demote` is a −1
+    above the mark), refused typed at materialization in **release** as
+    `FinishError::StaleDemote`, through `finish` and `finish_partial` alike.
+  - **A debug build now refuses two raw brackets whose closings *interleave*.** Because the
+    demote is an event, demoting an *enclosing* start puts a −1 above an inner still-open slot,
+    and the inner bracket's own demote then dips the recount. Release admits that order and
+    materialises exactly the tree the innermost-first order builds — canonicalization is
+    positional and tombstones both slots either way — so this is a **strictness choice on the
+    raw surface, not detection of a release defect**: debug enforces innermost-first closings;
+    release admits the out-of-order shape. No grammar can meet it, because `node` and `node_opt`
+    mint and spend their mark inside one call frame and their exits nest structurally. Pinned
+    from both ends: the emit-site refusal through the public surface, and the two closing orders'
+    trees asserted byte-equal.
+  - **The two brackets' error paths no longer leave byte-identical buffers — they
+    *materialize* identically.** The up-front shape carries the demote event; canonicalization
+    turns its slot into exactly the inert tombstone the retro shape left, before the walk begins.
+    That is what the four-corpora byte-identity gate measures, and it still passes on all four.
+
+  The rest of the misuse wall is unchanged and unconditional: a stale mark, a foreign sink's
+  mark, a mark whose slot is not a live `StartNode` of the demoted kind, and a demote naming the
+  reserved `TOMBSTONE` kind are all refused in **every** build. `FinishError::StaleDemote` is a
+  new variant of a `#[non_exhaustive]` enum.
 
   `cargo semver-checks` reports this, and that is expected and acknowledged here rather than
   suppressed there: `cst_start`'s return type changed on a public trait, and `cst_demote` is a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,11 +147,11 @@ with it. `ci/changelog_structure.sh` enforces every clause above and will red un
   name its node's kind *after* the sub-parse: entry minted an inert tombstone (`cst_mark`) and
   a successful exit retro-wrapped it (`cst_start_at` + `cst_finish`), three events per node.
   It now names the kind at entry (`cst_start`) and closes on both exits — `cst_finish` on
-  success, `cst_demote` on failure — two events per **successful** node. Measured on the
-  GraphQL `alias` corpus: **−47.1 µs** median over sixteen paired reps, 9,013 events removed
-  from a 64,085-event log, which is ~3.8% of the lossless parse and ~19% of the gap to
-  `apollo-parser`; **−7.0 µs** on `supergraph`, **−0.3 µs** on `example_query`, no corpus
-  slower and 24/24 paired reps same-signed.
+  success, `cst_demote` on failure — two events per **successful** node. Paired and
+  interleaved with `apollo-parser` as the drift control, measured on the shipped append-only
+  encoding described below: **−44.5 µs** median on the GraphQL `alias` corpus and
+  **−315.2 µs** on a backtracking fixture, over 32 paired reps, 16/16 and 8/8 same-signed, no
+  corpus slower. `alias` alone removes 9,013 events from a 64,085-event log.
 
   What breaks — two shapes, both in the emitter layer, none in a grammar. An emitter that
   **overrides** `cst_start` must now return the `EventMark` naming the slot it opened: a
@@ -263,10 +263,14 @@ with it. `ci/changelog_structure.sh` enforces every clause above and will red un
   slot strictly below the appended event — and no accepted stream's output changes: the guard
   only converts invalid raw streams from accept to typed refusal.
 
-  `cargo semver-checks` reports this, and that is expected and acknowledged here rather than
-  suppressed there: `cst_start`'s return type changed on a public trait, and `cst_demote` is a
-  new **required** trait method. Both are intentional, both are described above (the second in
-  the entry below), and 0.9.0 is the vehicle.
+  `cargo semver-checks` reports three lints here, all expected and acknowledged rather than
+  suppressed: `trait_method_return_value_added` (`cst_start`'s return type changed on a public
+  trait, above) and `trait_method_added` (`cst_demote` is a new **required** trait method,
+  described in the entry below) are both intentional, and so is
+  `enum_no_repr_variant_discriminant_changed` — inserting `FinishError::StaleDemote` above in
+  declaration order, rather than appending it, shifts the fieldless discriminant of the
+  fourteen variants after it. Nothing in the crate casts them and `FinishError` carries no
+  `#[repr]`, so those values were never a contract. 0.9.0 is the vehicle for all three.
 
   The change costs a diagnostics-only parse **nothing, verified rather than asserted**: over
   `Fatal` / `Verbose` / `Silent` the event methods are `#[inline(always)]` no-ops — four

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,34 @@ with it. `ci/changelog_structure.sh` enforces every clause above and will red un
   reserved `TOMBSTONE` kind are all refused in **every** build. `FinishError::StaleDemote` is a
   new variant of a `#[non_exhaustive]` enum.
 
+  **The stale-mark panic is not reachable from `node()`, and the wall that keeps it unreachable
+  is now pinned.** A review round raised the shape it would take: a `SessionPointId` opened
+  *before* the bracket, settled inside its inner parser, rewinding the sink below the bracket's
+  own `cst_start` so the failing exit spends a staled mark and panics in a release build. At the
+  sink the mechanism is real, and it is now driven directly through the raw surface, where it is
+  the published contract. Through the combinator it does not compile: a settle needs an id whose
+  `'closure` brand is **invariant**, and `ParseInput::parse_input`'s handle lifetime is
+  universally quantified, so the id can enter neither direction of the unification. Two
+  compile-fail cases pin it — the closure form and a hand-written `ParseInput` — because there
+  is no runtime backstop underneath: `take_point`'s settle scan is newest-first and would
+  *accept* a pre-bracket point, so the type system is the whole defence, and an untested
+  type-system guarantee is one signature change away from silently ceasing to hold. The reading
+  that this was a regression from the retro encoding does not hold either: under the identical
+  drive the retro shape panics too, on its **success** exit, at the older `node_at` mark wall.
+  The theorem, its three legs, and the duty it places on any future session-verb surface are
+  written up in the `parser::node` module docs.
+
+  One real gap did come out of that round, and it is closed. Canonicalization checked that a
+  `Demote`'s target held a live, un-demoted `StartNode`, but not that the target sat **below**
+  the demote itself. A raw-injected `Demote { target: 1 }` ahead of the start it named
+  materialized a tree with that node silently erased — the only stale-demote shape whose residue
+  stays balanced, so nothing downstream could catch it. One compare, before the slot read and in
+  `u64` space (which also removes a latent 32-bit truncation alias, where a target past `2^32`
+  wrapped onto a nearby slot), now refuses it as `FinishError::StaleDemote` through both finish
+  doors. No legal stream is affected — the emission wall derives `target` from a validated live
+  slot strictly below the appended event — and no accepted stream's output changes: the guard
+  only converts invalid raw streams from accept to typed refusal.
+
   `cargo semver-checks` reports this, and that is expected and acknowledged here rather than
   suppressed there: `cst_start`'s return type changed on a public trait, and `cst_demote` is a
   new defaulted trait method. Both are intentional, both are described above, and 0.9.0 is the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,12 +156,10 @@ with it. `ci/changelog_structure.sh` enforces every clause above and will red un
   What breaks — two shapes, both in the emitter layer, none in a grammar. An emitter that
   **overrides** `cst_start` must now return the `EventMark` naming the slot it opened: a
   wrapper forwards the inner's value unchanged, and an emitter with no event channel should
-  not override the method at all and inherits the defaulted inert mark. And an emitter that
-  overrides any structuring method should also forward `cst_demote`, for the same reason it
-  forwards the rest — a wrapper that forwards `cst_start` and inherits the `cst_demote` no-op
-  leaves its inner carrying a dangling open node for every `Err` a `node()` sees. `cst_demote`
-  is defaulted, so that is a silent gap rather than a compile error, the same class
-  `commit_token` already had; the sink's composition census now covers it. Grammars are
+  not override the method at all and inherits the defaulted inert mark. And **every**
+  implementor now writes `cst_demote`, because it is a required method rather than a defaulted
+  one — a wrapper forwards it, a diagnostics-only emitter discards it in one line. That is the
+  next entry, and it is the half of this migration the compiler can point at. Grammars are
   untouched: `node`, `node_at` and `node_opt` are unchanged at their call sites, and the three
   surfaces that forward the event channel (`EmitterView`, `InputRef`, `ParseState`) carry
   `cst_demote` alongside the rest.
@@ -267,15 +265,69 @@ with it. `ci/changelog_structure.sh` enforces every clause above and will red un
 
   `cargo semver-checks` reports this, and that is expected and acknowledged here rather than
   suppressed there: `cst_start`'s return type changed on a public trait, and `cst_demote` is a
-  new defaulted trait method. Both are intentional, both are described above, and 0.9.0 is the
-  vehicle.
+  new **required** trait method. Both are intentional, both are described above (the second in
+  the entry below), and 0.9.0 is the vehicle.
 
   The change costs a diagnostics-only parse **nothing, verified rather than asserted**: over
-  `Fatal` / `Verbose` / `Silent` the event methods are defaulted `#[inline(always)]` no-ops and
-  the handback is a dead `Copy` constant, and a fixture exercising the whole `node` family
-  compiles to a **byte-identical binary** before and after — positive control, perturbing
-  `cst_demote`'s default to a `black_box` changes it. The four-corpora tree-identity gate is
-  byte-identical on all four, error corpora included.
+  `Fatal` / `Verbose` / `Silent` the event methods are `#[inline(always)]` no-ops — four
+  inherited, `cst_demote` written out per emitter with the identical body — and the handback is
+  a dead `Copy` constant; a fixture exercising the whole `node` family compiles to a
+  **byte-identical binary** before and after — positive control, perturbing `cst_demote`'s body
+  to a `black_box` changes it. The four-corpora tree-identity gate is byte-identical on all
+  four, error corpora included.
+  — *(#169)*
+
+- **`CstEmitter::cst_demote` is a required method, not a defaulted one.** Every implementor
+  writes it: a wrapper by forwarding to its inner, an emitter with no event channel with a
+  one-line discard. The other four CST methods keep their no-op defaults, and that asymmetry is
+  a rule rather than an inconsistency — it is stated once in the trait docs and it governs what
+  may be added to this trait later.
+
+  **Why.** The method arrived defaulted in the entry above, and the review round after it built
+  the trap by construction: a 0.8-era wrapper that correctly forwarded all four CST methods
+  fails its rebase onto 0.9.0 with *exactly one* diagnostic, `E0053` on `cst_start`, whose
+  rustc fix-it writes the minimal migration itself and names `cst_demote` nowhere. Apply the
+  suggestion and the wrapper compiles with zero warnings, is byte-perfect on every success
+  path, and starves only the failing exit — the inner channel keeps a `StartNode` that no exit
+  closes, on error paths, silently. A wrapper that was correct becomes incorrect with no change
+  on its part, steered there by the compiler's own suggestion. Nothing downstream can recover
+  it either: the starved stream is byte-identical to the one an escaped panic leaves, so strict
+  `finish` refuses a grammar that did everything right (`UnclosedNodes`, misattributed) and
+  `finish_partial` materializes the node the grammar retracted. There is no sink-side wall to
+  build — the sink cannot tell a swallowed demote from a legal panic residue — which is why the
+  wall is the type system.
+
+  **Why only this one.** Grade each default by what happens when it is inherited alone over an
+  otherwise-forwarded channel. `cst_start`, `cst_finish`, `cst_mark` and `cst_start_at` each
+  fail toward an *absence* announced loudly on a path every test walks: `OrphanFinish` or
+  `MismatchedFinish`, `UnclosedNodes` on the first successful parse, or the identity-wall panic
+  in every build. `cst_demote` fails toward a *presence*, silently, through the door built for
+  error recovery, on the paths test suites cover worst. `Emitter::commit_token` keeps its own
+  default under this same test rather than in spite of it — its absence is loud and it has
+  typed finish-time backstops (`StructureWithoutTokens`, `UncoveredGap`). So the rule, and it
+  is the one that governs growth: **a method whose default cannot be backstopped and whose
+  absence fails toward a silently wrong tree does not get a default.** A CST method added after
+  this one either passes that test or ships behind a new bound.
+
+  **Migration**, both populations, one line each:
+
+  - *A wrapper or instrumentor* — forward it, exactly as it forwards `cst_start`:
+    `fn cst_demote(&mut self, mark: EventMark, kind: u16) { self.inner.cst_demote(mark, kind) }`.
+  - *An emitter with no event channel* — discard it:
+    `fn cst_demote(&mut self, _: EventMark, _: u16) {}`. The shipped `Fatal`, `Silent`,
+    `Verbose` and `Ignored` do exactly that, and the line is not noise: such an emitter really
+    does discard the failing exit, and now says so where its own reviewer reads it.
+
+  This lands the second half of the same migration in the same release. Both errors appear on
+  one rebase, adjacent and self-explanatory: `E0053` with a fix-it, `E0046` naming the method.
+  Deferring was not an option — after 1.0 a trait can only grow defaults, which is this trap
+  again. Cost measured before the decision: four one-line stubs in the crate's own diagnostics
+  emitters and one in the fuzz fixture; the recording `Sink`, the `&mut U` blanket and every
+  in-tree wrapper already implemented it; no impls in the guide, the book, any doctest or any
+  consumer in the org. `tests/ui/cst_demote_cannot_be_inherited.rs` pins the `E0046`, and its
+  real subject is the future — the day someone re-adds the default "for convenience" that case
+  starts compiling, and a `compile_fail` case that compiles is a failing test. It is the only
+  signal there would be.
   — *(#169)*
 
 ### Changed
@@ -698,8 +750,8 @@ with it. `ci/changelog_structure.sh` enforces every clause above and will red un
     logs a tagged call per operation, including the five members the surface deliberately
     withholds, so a forward that lands on `commit_token` is visible too. The three existing
     recorders could not do this: `Verbose` funnels eleven capability channels into one error
-    channel and inherits the no-op `CstEmitter`, and the tracking and counting emitters hold
-    plain counters.
+    channel and its `CstEmitter` impl records nothing, and the tracking and counting emitters
+    hold plain counters.
 
     The suite is proven discriminating: six sibling re-pointings each red exactly the delegation
     closure of the mutated body and nothing else — one test for a `ParseState` leaf, two when an

--- a/tokora/src/cst/event.rs
+++ b/tokora/src/cst/event.rs
@@ -4,31 +4,49 @@
 //!
 //! # The two verbs
 //!
-//! An event buffer changes in exactly two ways: **append** (the `cst_*` emission methods) and
-//! **suffix-truncate** (an emitter [`rewind`](crate::emitter::Emitter::rewind)). Retro-parenting
-//! is expressed by **appending** a `StartAt` that names an earlier tombstone, never by
-//! completing the tombstone in place. This is what makes rewind-by-truncation exact: the prefix
-//! below any live mark is immutable, so truncating to the mark restores the buffer to precisely
-//! the state it had when the mark was captured. (The one journaled exception is the
-//! `forward_parent` *acceleration* field a `StartAt` writes back onto its
-//! target tombstone; the sink's undo journal reverse-replays those writes on rewind, so the
-//! law holds observationally — see `Sink` under the `rowan` feature.)
+//! **The parse-time event buffer mutates only by append and suffix-truncate; interior writes
+//! are either journaled undo-state riding an append, or occur where no live mark can exist.**
 //!
-//! # One interior kind write is lawful, in the other direction
+//! Append is the `cst_*` emission methods, suffix-truncate is an emitter
+//! [`rewind`](crate::emitter::Emitter::rewind). Every structural decision is expressed by
+//! appending an event that *names* an earlier slot, never by rewriting that slot in place:
+//! retro-parenting appends a `StartAt` naming an earlier tombstone, and the failing exit of an
+//! up-front bracket appends a `Demote` naming its own
+//! start. This is what makes rewind-by-truncation exact: the prefix below any live mark is
+//! immutable, so truncating to the mark restores the buffer to precisely the state it had when
+//! the mark was captured — for **both** exits of a bracket alike. A rollback into the window
+//! between a bracket's start and its exit truncates that exit, whichever it was, and the open
+//! node returns.
 //!
-//! [`cst_demote`](crate::emitter::CstEmitter::cst_demote) rewrites a real-kind `StartNode`
-//! appended by [`cst_start`](crate::emitter::CstEmitter::cst_start) back to the [`TOMBSTONE`]
-//! kind, on the failing exit of the bracket that appended it. It needs no journal entry,
-//! **structurally**: the write's author is the frame that appended the slot, so any truncation
-//! erasing the branch that made the write erases the slot itself, while any truncation keeping
-//! the slot keeps a demotion that is permanently true — the bracket exited with an error and no
-//! rewind re-runs an exited frame. Un-demoting on rewind would resurrect a dangling open node
-//! whose finish never fired.
+//! The interior-write clause covers exactly three sites, and the census is closed:
 //!
-//! The banned direction stays banned: **completing a tombstone in place** lets a rolled-back
-//! branch's decision survive its own truncation, because the completer is not the frame that
-//! appended the slot. That asymmetry — who wrote it relative to who appended it — is the whole
-//! of why one direction is free and the other needs the append-only encoding.
+//! - the `forward_parent` *acceleration* field a `StartAt` writes back onto its target
+//!   tombstone — **journaled** undo-state riding the `StartAt`'s own append; the sink's undo
+//!   journal reverse-replays those writes on rewind, so the law holds observationally (see
+//!   `Sink` under the `rowan` feature);
+//! - the recovery hole's prefix-preserving splice, **floored above every live mark** so no
+//!   mark's prefix can change under it (`wrap_hole`);
+//! - **materialization's canonicalization pass**, which runs on the owned buffer at the one
+//!   moment no live mark can exist (the sink is consumed) and applies every surviving
+//!   `Demote` to its target — see below.
+//!
+//! The banned direction stays banned: **completing a tombstone in place** — rewriting an
+//! earlier slot's kind during the parse — lets a rolled-back branch's decision survive its own
+//! truncation, because the truncation that erases the deciding branch does not erase the slot
+//! the decision was written on. That is why *both* directions of the kind rewrite are encoded
+//! as appended events, and neither is a parse-time interior write.
+//!
+//! # Canonicalization: where the demotion actually lands
+//!
+//! [`cst_demote`](crate::emitter::CstEmitter::cst_demote) appends a
+//! `Demote` event naming the slot its [`cst_start`](crate::emitter::CstEmitter::cst_start)
+//! appended; the slot itself keeps its real kind for the whole parse. Materialization then
+//! canonicalizes the buffer it owns in one pass — `events[target].kind = TOMBSTONE` for every
+//! surviving `Demote` — after which the abandoned node is byte-identical to the inert slot an
+//! unspent [`cst_mark`](crate::emitter::CstEmitter::cst_mark) leaves, and the replay walk is
+//! blind to both. A `Demote` can never outlive its target (`target` is strictly below the
+//! `Demote`'s own index and truncation is a suffix operation), so the pass has nothing to
+//! reconcile.
 //!
 //! # The depth model
 //!
@@ -39,6 +57,9 @@
 //! - `StartAt` opens a retro-wrap (hoisted to its target at
 //!   materialization): **+1** at its own index;
 //! - `FinishNode` closes the innermost open node: **−1**;
+//! - `Demote` un-opens the node its target opened: **−1** at its own index (the pair
+//!   `StartNode(+1) … Demote(−1)` nets zero, exactly as the canonicalized
+//!   `StartNode(TOMBSTONE)` does);
 //! - `Token` and `Diag` are neutral: **0**.
 //!
 //! Both verbs preserve "every prefix has depth ≥ 0 or is diagnosed at materialization": a
@@ -67,10 +88,12 @@ use crate::{Lexer, emitter::CstEmitter};
 /// [`cst_mark`](crate::emitter::CstEmitter::cst_mark): an inert placeholder that materializes
 /// into nothing unless a later `StartAt` names it as a retro-wrap target.
 ///
-/// It is also the kind **restored by** [`cst_demote`](crate::emitter::CstEmitter::cst_demote):
-/// the failing exit of an up-front bracket rewrites its own `StartNode` back to this value, so
-/// a node that was opened and then abandoned leaves exactly the inert slot an unspent
-/// `cst_mark` leaves (see the law amendment in the [module docs](self)).
+/// It is also the kind **canonicalization writes** onto the target of a surviving
+/// `Demote` event: the failing exit of an up-front bracket appends a `Demote` naming its own
+/// start, and materialization applies it to the slot, so a node that was opened and then
+/// abandoned *materializes* exactly as the inert slot an unspent `cst_mark` leaves (see the
+/// canonicalization note in the [module docs](self)). During the parse the slot still carries
+/// its real kind — the demotion is an appended event, not an interior write.
 ///
 /// The value is `u16::MAX`, and the slot is **reserved across the whole shared kind space**:
 /// a dialect's unified kind enum (node kinds and token images alike) must never map anything
@@ -110,8 +133,9 @@ pub(crate) enum Event<S> {
   StartNode {
     /// The node kind, or [`TOMBSTONE`] while the slot is an inert mark — either because
     /// [`cst_mark`](crate::emitter::CstEmitter::cst_mark) appended it that way, or because
-    /// [`cst_demote`](crate::emitter::CstEmitter::cst_demote) rewrote a real kind back to it
-    /// on a failing bracket exit. The two are indistinguishable by design.
+    /// materialization's canonicalization pass applied a surviving [`Demote`](Event::Demote)
+    /// to it. The two are indistinguishable by design *at materialization*; during the parse
+    /// only the first exists, because the demotion rides an appended event.
     kind: u16,
     /// Relative forward offset to the newest [`StartAt`](Event::StartAt) targeting this
     /// tombstone, if any — the head of its wrap chain. Maintained under the sink's undo
@@ -141,17 +165,42 @@ pub(crate) enum Event<S> {
     /// The kind of the node this finish intends to close.
     kind: u16,
   },
+  /// Un-opens the node the [`StartNode`](Event::StartNode) at `target` opened — the
+  /// **failing exit** of an up-front bracket
+  /// ([`cst_demote`](crate::emitter::CstEmitter::cst_demote)), and the exact mirror of
+  /// [`StartAt`](Event::StartAt): an appended event naming an earlier slot, never an
+  /// in-place rewrite of it.
+  ///
+  /// Appending rather than rewriting is what gives the bracket's two exits **one** rollback
+  /// law. A rewrite would survive a rollback into the window between the start and the
+  /// demote — the truncation keeps the slot and keeps the rewrite — so the failing exit
+  /// would silently drop a node the restore contract promised was open again. Appended, the
+  /// `Demote` truncates with everything else above the mark and the open node returns,
+  /// which is precisely the truncate-and-reopen semantics the success exit's `FinishNode`
+  /// already has.
+  ///
+  /// Materialization's canonicalization pass applies every surviving `Demote` to its target
+  /// (`events[target].kind = TOMBSTONE`) before the replay walk, which then skips the
+  /// `Demote` itself; a `Demote` survives a truncation **iff** its target does, because
+  /// `target` is strictly below the `Demote`'s own index and truncation is a suffix
+  /// operation.
+  Demote {
+    /// The absolute buffer index of the `StartNode` this demote un-opens; always `<` this
+    /// event's own index, validated at emission (identity, bounds, era and slot kind) and
+    /// again at canonicalization.
+    target: u64,
+  },
   /// Retro-opens a node of `kind` at the buffer position of the tombstone at `target` —
   /// the **append-only** form of retro-parenting. Same-target `StartAt`s open in reverse
   /// buffer order at materialization (the later wrap is the outer node, because its
   /// finish is necessarily appended later). The in-place alternative (**completing** the
-  /// tombstone by rewriting its kind) is banned by law: the completer is not the frame that
-  /// appended the slot, so the write sits below a live emitter mark and survives the
-  /// truncation that was supposed to erase the branch that made it.
+  /// tombstone by rewriting its kind) is banned by law: the write would sit below a live
+  /// emitter mark and survive the truncation that was supposed to erase the branch that
+  /// made it.
   ///
-  /// The demotion [`cst_demote`](crate::emitter::CstEmitter::cst_demote) performs is the
-  /// mirror image and is lawful for exactly the reason this one is not — its writer *is* the
-  /// appending frame. See the law amendment in the [module docs](self).
+  /// [`Demote`](Event::Demote) is the mirror image and is lawful for exactly the same
+  /// reason this one is: it, too, is an appended event naming an earlier slot. See the
+  /// [module docs](self).
   StartAt {
     /// The node kind of the retro-wrap.
     kind: u16,
@@ -204,8 +253,8 @@ pub(crate) enum Event<S> {
 impl<S> Event<S> {
   /// This event's contribution to the derived open-node depth (the module-level depth
   /// model): `+1` for a real [`StartNode`](Self::StartNode) or a [`StartAt`](Self::StartAt),
-  /// `-1` for a [`FinishNode`](Self::FinishNode), `0` for everything else (tombstones
-  /// included).
+  /// `-1` for a [`FinishNode`](Self::FinishNode) or a [`Demote`](Self::Demote), `0` for
+  /// everything else (tombstones included).
   #[inline(always)]
   pub(crate) const fn depth_delta(&self) -> i64 {
     match self {
@@ -217,7 +266,7 @@ impl<S> Event<S> {
         }
       }
       Self::StartAt { .. } => 1,
-      Self::FinishNode { .. } => -1,
+      Self::FinishNode { .. } | Self::Demote { .. } => -1,
       Self::Token { .. } | Self::Diag { .. } => 0,
     }
   }
@@ -244,7 +293,8 @@ impl<S> Event<S> {
 ///   from;
 /// - [`cst_start`](crate::emitter::CstEmitter::cst_start) names the **open node** it appends —
 ///   the handle a later [`cst_demote`](crate::emitter::CstEmitter::cst_demote) un-opens it
-///   with, on the failing exit of an up-front bracket.
+///   with, on the failing exit of an up-front bracket, by appending a `Demote` event that names
+///   the slot.
 ///
 /// One type, because two parallel position handles over one event stream would be two
 /// staleness rules and two validation walls for the same hazard. The spend verbs do not
@@ -254,10 +304,12 @@ impl<S> Event<S> {
 /// the slot at all, since no `cst_start` can have opened a node of it. No slot satisfies both
 /// verbs, and no argument can make one satisfy the other.
 ///
-/// What the walls do **not** claim is lifecycle: a mark whose node has already been closed
-/// still names a live `StartNode` of its kind, so a release build's `cst_demote` accepts it.
-/// That misuse is refused downstream instead, typed and through both materialization doors —
-/// see [`cst_demote`](crate::emitter::CstEmitter::cst_demote).
+/// What the walls do **not** claim is lifecycle: the slot is *content*, and a demote is an
+/// appended event rather than a rewrite of it, so a mark whose node has already been closed —
+/// or already demoted — still names a live `StartNode` of its kind, and a release build's
+/// `cst_demote` accepts it. Both misuses are refused downstream instead, typed and through
+/// both materialization doors, with a debug-build detection at the misuse site; see
+/// [`cst_demote`](crate::emitter::CstEmitter::cst_demote).
 ///
 /// A mark is a **positional witness plus identity**: `index` names the slot, `era` names the
 /// truncation history it was issued under, and `sink` names the one recording sink that
@@ -673,6 +725,7 @@ mod tests {
       prev: None,
     };
     let fin: Event<()> = Event::FinishNode { kind: 7 };
+    let demote: Event<()> = Event::Demote { target: 0 };
     let tok: Event<()> = Event::Token { kind: 7, span: () };
     let diag: Event<()> = Event::Diag { error_span: None };
 
@@ -680,11 +733,37 @@ mod tests {
     assert_eq!(tomb.depth_delta(), 0);
     assert_eq!(wrap.depth_delta(), 1);
     assert_eq!(fin.depth_delta(), -1);
+    assert_eq!(
+      demote.depth_delta(),
+      -1,
+      "the failing exit un-opens exactly what its start opened: Start(+1) … Demote(−1) nets \
+       zero, the same as the canonicalized tombstone"
+    );
     assert_eq!(tok.depth_delta(), 0);
     assert_eq!(diag.depth_delta(), 0);
 
     assert!(tomb.is_tombstone());
     assert!(!start.is_tombstone());
+    assert!(
+      !demote.is_tombstone(),
+      "a Demote names a tombstone-to-be; it is not one"
+    );
+  }
+
+  /// The `Demote` variant costs the log nothing: `StartAt` already carries a `u64` target
+  /// alongside a kind and a link, so the widest variant is unchanged and the buffer's
+  /// per-event footprint does not move.
+  #[test]
+  fn the_demote_variant_does_not_widen_the_event() {
+    use core::mem::size_of;
+
+    type Ev = Event<crate::span::SimpleSpan>;
+    assert_eq!(
+      size_of::<Ev>(),
+      32,
+      "the event log's element is 32 bytes for a two-usize span; adding Demote must not \
+       widen it (StartAt already carries u64 + u16 + Option<NonZeroU32>)"
+    );
   }
 
   /// An inert mark can never name a real slot: its index is `u64::MAX`, above any

--- a/tokora/src/cst/event.rs
+++ b/tokora/src/cst/event.rs
@@ -187,7 +187,7 @@ pub(crate) enum Event<S> {
   Demote {
     /// The absolute buffer index of the `StartNode` this demote un-opens; always `<` this
     /// event's own index, validated at emission (identity, bounds, era and slot kind) and
-    /// again at canonicalization.
+    /// again at canonicalization (including the positional `target < index` half).
     target: u64,
   },
   /// Retro-opens a node of `kind` at the buffer position of the tombstone at `target` —

--- a/tokora/src/cst/event.rs
+++ b/tokora/src/cst/event.rs
@@ -5,15 +5,30 @@
 //! # The two verbs
 //!
 //! An event buffer changes in exactly two ways: **append** (the `cst_*` emission methods) and
-//! **suffix-truncate** (an emitter [`rewind`](crate::emitter::Emitter::rewind)). No operation
-//! rewrites the *kind* of an interior slot — retro-parenting is expressed by **appending** a
-//! `StartAt` that names an earlier tombstone, never by completing the
-//! tombstone in place. This is what makes rewind-by-truncation exact: the prefix below any
-//! live mark is immutable, so truncating to the mark restores the buffer to precisely the
-//! state it had when the mark was captured. (The one journaled exception is the
+//! **suffix-truncate** (an emitter [`rewind`](crate::emitter::Emitter::rewind)). Retro-parenting
+//! is expressed by **appending** a `StartAt` that names an earlier tombstone, never by
+//! completing the tombstone in place. This is what makes rewind-by-truncation exact: the prefix
+//! below any live mark is immutable, so truncating to the mark restores the buffer to precisely
+//! the state it had when the mark was captured. (The one journaled exception is the
 //! `forward_parent` *acceleration* field a `StartAt` writes back onto its
 //! target tombstone; the sink's undo journal reverse-replays those writes on rewind, so the
 //! law holds observationally — see `Sink` under the `rowan` feature.)
+//!
+//! # One interior kind write is lawful, in the other direction
+//!
+//! [`cst_demote`](crate::emitter::CstEmitter::cst_demote) rewrites a real-kind `StartNode`
+//! appended by [`cst_start`](crate::emitter::CstEmitter::cst_start) back to the [`TOMBSTONE`]
+//! kind, on the failing exit of the bracket that appended it. It needs no journal entry,
+//! **structurally**: the write's author is the frame that appended the slot, so any truncation
+//! erasing the branch that made the write erases the slot itself, while any truncation keeping
+//! the slot keeps a demotion that is permanently true — the bracket exited with an error and no
+//! rewind re-runs an exited frame. Un-demoting on rewind would resurrect a dangling open node
+//! whose finish never fired.
+//!
+//! The banned direction stays banned: **completing a tombstone in place** lets a rolled-back
+//! branch's decision survive its own truncation, because the completer is not the frame that
+//! appended the slot. That asymmetry — who wrote it relative to who appended it — is the whole
+//! of why one direction is free and the other needs the append-only encoding.
 //!
 //! # The depth model
 //!
@@ -52,6 +67,11 @@ use crate::{Lexer, emitter::CstEmitter};
 /// [`cst_mark`](crate::emitter::CstEmitter::cst_mark): an inert placeholder that materializes
 /// into nothing unless a later `StartAt` names it as a retro-wrap target.
 ///
+/// It is also the kind **restored by** [`cst_demote`](crate::emitter::CstEmitter::cst_demote):
+/// the failing exit of an up-front bracket rewrites its own `StartNode` back to this value, so
+/// a node that was opened and then abandoned leaves exactly the inert slot an unspent
+/// `cst_mark` leaves (see the law amendment in the [module docs](self)).
+///
 /// The value is `u16::MAX`, and the slot is **reserved across the whole shared kind space**:
 /// a dialect's unified kind enum (node kinds and token images alike) must never map anything
 /// to it. The recording sink asserts the reservation at emission time — unconditionally, in
@@ -88,7 +108,10 @@ pub(crate) enum Event<S> {
   /// that would otherwise be structurally dropped, are the two silent corruptions the
   /// journal and the reachability check exist to kill).
   StartNode {
-    /// The node kind, or [`TOMBSTONE`] while the slot is an inert mark.
+    /// The node kind, or [`TOMBSTONE`] while the slot is an inert mark — either because
+    /// [`cst_mark`](crate::emitter::CstEmitter::cst_mark) appended it that way, or because
+    /// [`cst_demote`](crate::emitter::CstEmitter::cst_demote) rewrote a real kind back to it
+    /// on a failing bracket exit. The two are indistinguishable by design.
     kind: u16,
     /// Relative forward offset to the newest [`StartAt`](Event::StartAt) targeting this
     /// tombstone, if any — the head of its wrap chain. Maintained under the sink's undo
@@ -121,9 +144,14 @@ pub(crate) enum Event<S> {
   /// Retro-opens a node of `kind` at the buffer position of the tombstone at `target` —
   /// the **append-only** form of retro-parenting. Same-target `StartAt`s open in reverse
   /// buffer order at materialization (the later wrap is the outer node, because its
-  /// finish is necessarily appended later). The in-place alternative (rewriting the
-  /// tombstone's kind) is banned by law: an interior write below a live emitter mark
-  /// survives the truncation that was supposed to erase the branch that made it.
+  /// finish is necessarily appended later). The in-place alternative (**completing** the
+  /// tombstone by rewriting its kind) is banned by law: the completer is not the frame that
+  /// appended the slot, so the write sits below a live emitter mark and survives the
+  /// truncation that was supposed to erase the branch that made it.
+  ///
+  /// The demotion [`cst_demote`](crate::emitter::CstEmitter::cst_demote) performs is the
+  /// mirror image and is lawful for exactly the reason this one is not — its writer *is* the
+  /// appending frame. See the law amendment in the [module docs](self).
   StartAt {
     /// The node kind of the retro-wrap.
     kind: u16,
@@ -208,17 +236,36 @@ impl<S> Event<S> {
   }
 }
 
-/// A validated handle to a tombstone appended by
-/// [`cst_mark`](crate::emitter::CstEmitter::cst_mark): the anchor a later
-/// [`cst_start_at`](crate::emitter::CstEmitter::cst_start_at) retro-wraps from.
+/// A validated handle to one slot of the event buffer, in either of the two provenances that
+/// mint one:
 ///
-/// A mark is a **positional witness plus identity**: `index` names the tombstone's buffer
-/// slot, `era` names the truncation history it was issued under, and `sink` names the one
-/// recording sink that minted it. Index-in-bounds is *not* validity — a rewind can truncate
-/// the tombstone away and unrelated events can regrow over the same index — and `(index,
-/// era)` is *not* identity — two fresh sinks both mint `(0, 0)` — so the recording sink
-/// checks all three at every spend and **panics in every build** on a stale *or foreign*
-/// mark (the savepoint posture; see the [module docs](self)).
+/// - [`cst_mark`](crate::emitter::CstEmitter::cst_mark) names the **tombstone** it appends —
+///   the anchor a later [`cst_start_at`](crate::emitter::CstEmitter::cst_start_at) retro-wraps
+///   from;
+/// - [`cst_start`](crate::emitter::CstEmitter::cst_start) names the **open node** it appends —
+///   the handle a later [`cst_demote`](crate::emitter::CstEmitter::cst_demote) un-opens it
+///   with, on the failing exit of an up-front bracket.
+///
+/// One type, because two parallel position handles over one event stream would be two
+/// staleness rules and two validation walls for the same hazard. The spend verbs do not
+/// cross, and neither verb needs to be told which provenance it was handed: `cst_start_at`
+/// demands a live tombstone at the slot, `cst_demote` demands a live `StartNode` of the kind
+/// its start was given — and refuses the reserved [`TOMBSTONE`] kind outright, before reading
+/// the slot at all, since no `cst_start` can have opened a node of it. No slot satisfies both
+/// verbs, and no argument can make one satisfy the other.
+///
+/// What the walls do **not** claim is lifecycle: a mark whose node has already been closed
+/// still names a live `StartNode` of its kind, so a release build's `cst_demote` accepts it.
+/// That misuse is refused downstream instead, typed and through both materialization doors —
+/// see [`cst_demote`](crate::emitter::CstEmitter::cst_demote).
+///
+/// A mark is a **positional witness plus identity**: `index` names the slot, `era` names the
+/// truncation history it was issued under, and `sink` names the one recording sink that
+/// minted it. Index-in-bounds is *not* validity — a rewind can truncate the slot away and
+/// unrelated events can regrow over the same index — and `(index, era)` is *not* identity —
+/// two fresh sinks both mint `(0, 0)` — so the recording sink checks all three at every spend
+/// and **panics in every build** on a stale *or foreign* mark (the savepoint posture; see the
+/// [module docs](self)).
 ///
 /// Marks are freely `Copy` and may legitimately outlive combinator frames (a pratt driver
 /// holds one across arbitrarily many operator iterations, spending it once per fold). A
@@ -260,11 +307,16 @@ impl EventMark {
   }
 
   /// The inert mark returned by the defaulted
-  /// [`cst_mark`](crate::emitter::CstEmitter::cst_mark) of an emitter with no event
+  /// [`cst_mark`](crate::emitter::CstEmitter::cst_mark) **and**
+  /// [`cst_start`](crate::emitter::CstEmitter::cst_start) of an emitter with no event
   /// channel. Its witness is the reserved [`INERT_SINK`](Self::INERT_SINK) id (which no
   /// recording sink ever carries) and its index is `u64::MAX` (which no buffer reaches),
   /// so a recording sink that is handed one panics at the identity wall rather than
-  /// wrapping anything.
+  /// wrapping or demoting anything.
+  ///
+  /// It is a compile-time constant of a `Copy` POD, which is what makes the up-front
+  /// bracket's handback free over a diagnostics-only emitter: the value is dead on arrival
+  /// and the whole bracket inlines away.
   #[inline(always)]
   pub(crate) const fn inert() -> Self {
     Self {

--- a/tokora/src/cst/sink.rs
+++ b/tokora/src/cst/sink.rs
@@ -9,7 +9,8 @@
 //!
 //! | # | Cell | Class | Rewind/restore semantics |
 //! |---|------|-------|--------------------------|
-//! | E1 | [`Sink::events`] | **ground truth** (a second emission log) | append + suffix-truncate to the mark — the same two verbs as `Verbose`'s log (plus the one censused prefix-preserving splice of the hole wrap, entirely above every live mark, and the two censused interior writes: `cst_start_at`'s journaled `forward_parent` link and `cst_demote`'s structurally-unjournaled kind demotion — see the law in [`event`](super::event)) |
+//! | E1 | [`Sink::events`] | **ground truth** (a second emission log) | append + suffix-truncate to the mark — the same two verbs as `Verbose`'s log (plus the one censused prefix-preserving splice of the hole wrap, entirely above every live mark, and the one censused interior write: `cst_start_at`'s journaled `forward_parent` link — see the law in [`event`](super::event)) |
+//! | — | [`Sink::demotes`] | **latching hint** (an `Event::Demote` was appended at some point) | never restored, never cleared — a rewind may leave it set over a buffer with no `Demote` left, which costs one no-op canonicalization pass at materialization and can never skip a needed one |
 //! | E2 | [`Sink::journal`] | **undo journal** (the Verbose-parallel-maps discipline lifted to events) | rewind pops entries written above the mark, reverse order, restoring each overwritten `forward_parent`; never grows on rewind |
 //! | E3 | [`Sink::ledger`] | **monotone era source + truncation witness** | rewind APPENDS to it (a rewind *is* a truncation) and never removes; rewinding it would false-accept a stale mark |
 //! | E4 | [`Sink::rows`] | **release stack + per-checkpoint depth ledger + inner reading** | push at `checkpoint()` (freezing the depth and the inner emitter's own checkpoint reading), pop at `release()` (kept) and `rewind()` (spent, the popped row's inner reading is the inner's rewind target); depth entries are frozen facts about prefixes, never live counters |
@@ -152,15 +153,15 @@ struct DegradedRewind {
 
 /// One undo-journal entry: an in-place `forward_parent` write performed by
 /// [`cst_start_at`](CstEmitter::cst_start_at) on its target tombstone, recorded so a rewind
-/// can reverse it. In-place event mutation is otherwise banned by law; this one acceleration
-/// field is the single **journaled** exception, and it is legal *only because* every write is
-/// journaled.
+/// can reverse it. Parse-time in-place event mutation is otherwise banned by law; this one
+/// acceleration field is the single **journaled** exception, and it is legal *only because*
+/// every write is journaled.
 ///
-/// The law's other exception, [`cst_demote`](CstEmitter::cst_demote)'s kind rewrite, is
-/// deliberately **not** here: its writer is the frame that appended the slot, so every
-/// truncation that could want the write undone erases the slot it was made on, and a journal
-/// entry would have nothing to restore onto. See the law amendment in
-/// [`event`](super::event).
+/// [`cst_demote`](CstEmitter::cst_demote) needs no entry here, and not because its write is
+/// exempt: it **performs no parse-time write at all**. The failing exit appends an
+/// `Event::Demote` naming its own start, exactly as `cst_start_at` appends a `StartAt` naming
+/// its target, and materialization applies it. An appended event needs no undo — the
+/// truncation *is* the undo. See the law in [`event`](super::event).
 #[derive(Debug, Clone, Copy)]
 struct JournalEntry {
   /// The event-log length immediately after the append that carried this write (the
@@ -402,6 +403,22 @@ where
   inner: E,
   /// E1 — the event buffer: the second emission log (ground truth).
   events: Vec<Event<L::Span>>,
+  /// Whether an `Event::Demote` was ever appended to [`Sink::events`] — the guard that keeps
+  /// materialization's canonicalization pass off a parse that never took a failing bracket
+  /// exit, which is every parse of a predictive grammar.
+  ///
+  /// **Latching, and deliberately outside the rewind timeline**, in the [`Sink::degraded`]
+  /// class rather than the memo class — and the direction of the imprecision is what makes
+  /// that safe. Nothing ever writes `false` after construction, so the hint can only ever be
+  /// *over*-set: a rewind that truncates the last surviving `Demote` leaves it standing, the
+  /// pass then runs, finds nothing and returns. The opposite error — a clear over a surviving
+  /// `Demote`, which would let an abandoned node materialize — is unrepresentable rather than
+  /// merely unlikely. A `debug_assert!` at materialization holds the direction.
+  ///
+  /// It is a hint about the buffer and not a fact about a prefix, which is why it is not the
+  /// #98 memo class: no reader derives anything from it, and the one reader that consults it
+  /// gets the identical answer with the hint forced to `true`.
+  demotes: bool,
   /// E2 — the undo journal for the `forward_parent` acceleration writes.
   journal: Vec<JournalEntry>,
   /// E4 — the mark stack: one row per live checkpoint capture, holding the frozen depth and
@@ -484,6 +501,10 @@ where
     inner: _,
     // — E1, ground truth: append + suffix-truncate (+ the censused hole-wrap splice).
     events: _,
+    // — latching hint: an `Event::Demote` was appended. Set once, NEVER cleared and never
+    // rewound. Over-setting costs one no-op canonicalization pass; under-setting is
+    // unrepresentable, which is the only direction that could matter.
+    demotes: _,
     // — E2, undo journal: rewind reverse-replays and truncates by `at_len`.
     journal: _,
     // — E4, release stack + depth ledger: push at checkpoint, pop at release/rewind.
@@ -574,6 +595,7 @@ where
     Self {
       inner,
       events: Vec::with_capacity(capacity),
+      demotes: false,
       journal: Vec::new(),
       rows: RefCell::new(Vec::new()),
       floor: MarkRow::ZERO,
@@ -699,32 +721,52 @@ where
   /// the **slot content**, which is what keeps the two mark provenances from crossing: a
   /// retro-wrap spend demands a live `TOMBSTONE`, a demote demands a live `StartNode` of
   /// exactly the kind its `cst_start` was given. So a `cst_mark` tombstone cannot be demoted
-  /// (its kind is `TOMBSTONE`, which no `cst_start` is allowed to name), a `cst_start` mark
-  /// cannot be retro-wrapped (the tombstone wall refuses it), and a mark cannot be demoted
-  /// twice (the first demote leaves `TOMBSTONE` behind).
+  /// (its kind is `TOMBSTONE`, which no `cst_start` is allowed to name) and a `cst_start` mark
+  /// cannot be retro-wrapped (the tombstone wall refuses it).
   ///
-  /// That last sentence is only true because the **reserved kind is refused before the slot is
-  /// read at all**. A content-only comparison would let `cst_demote(mark, TOMBSTONE)` satisfy
-  /// itself against any live tombstone — a `cst_mark` slot, or one already carrying a live
-  /// `forward_parent` from a retro wrap — and write `TOMBSTONE` over `TOMBSTONE`: in release a
-  /// silent no-op on a slot the caller does not own, in debug a fire of `cst_demote`'s own
-  /// `forward_parent` assert far from the mistake. One compare against an immediate closes it
-  /// in every build, because no `cst_start` can ever have opened a `TOMBSTONE`-kind node.
+  /// The provenance separation is only airtight because the **reserved kind is refused before
+  /// the slot is read at all**. A content-only comparison would let `cst_demote(mark,
+  /// TOMBSTONE)` satisfy itself against any live tombstone — a `cst_mark` slot, or one already
+  /// carrying a live `forward_parent` from a retro wrap — and append a `Demote` naming a slot
+  /// the caller never opened. One compare against an immediate closes it in every build,
+  /// because no `cst_start` can ever have opened a `TOMBSTONE`-kind node.
   ///
   /// # What this wall cannot see, and what refuses it instead
   ///
-  /// A start whose node was **already finished** passes here in a release build, and no check
-  /// that reads the slot can do better: the finish is appended *above* the slot, so the slot
-  /// cannot witness its own close. What that misuse costs is bounded and typed rather than
-  /// silent. The demote removes exactly one frame push from the stream (the start becomes a
-  /// tombstone, whose [`depth_delta`](Event::depth_delta) is 0) and removes no pop, so pops
-  /// exceed pushes and the replay walk underflows; `materialize` refuses at the first surplus
-  /// finish ([`FinishError::OrphanFinish`](crate::cst::FinishError::OrphanFinish), or
-  /// `MismatchedFinish` sooner when the kinds misalign first). Both public doors are the *same*
-  /// walk, and `close_open_nodes` relaxes only end-of-stream opens and gap tiling — never a
-  /// balance underflow — so [`finish`](Self::finish) and
-  /// [`finish_partial`](Self::finish_partial) refuse it alike. A debug build does not wait for
-  /// materialization: the exact suffix scan below catches it at the misuse site.
+  /// The demotion is an **appended event**, not a rewrite of the slot, so the slot is unchanged
+  /// by it: neither a finish nor a prior demote leaves a trace the slot itself can witness.
+  /// Two misuses therefore pass this wall in a release build, and no check that reads the slot
+  /// alone can do better:
+  ///
+  /// - **demoting a start whose node was already finished** — the finish is appended *above*
+  ///   the slot;
+  /// - **demoting the same start twice** — the first `Demote` is appended above the slot too.
+  ///
+  /// Both are bounded and typed rather than silent, and both are caught at the two tiers this
+  /// crate calibrates such checks to. A **debug** build catches each at the misuse site, on the
+  /// exact suffix recount below: a surviving finish that closed the marked node dips the
+  /// running sum, and so does a prior `Demote` naming it (both are −1 above the slot). A
+  /// **release** build refuses at materialization, typed and through both doors — a
+  /// finished-then-demoted start leaves pops exceeding pushes, so the replay walk underflows at
+  /// the surplus finish ([`FinishError::OrphanFinish`](crate::cst::FinishError::OrphanFinish),
+  /// or `MismatchedFinish` sooner when the kinds misalign first), and a double demote is
+  /// refused by canonicalization
+  /// ([`FinishError::StaleDemote`](crate::cst::FinishError::StaleDemote)), whose second pass
+  /// over the same target finds a slot the first already tombstoned. Both public doors are the
+  /// *same* walk over the *same* canonicalized buffer, and `close_open_nodes` relaxes only
+  /// end-of-stream opens and gap tiling — never a balance underflow and never corruption — so
+  /// [`finish`](Self::finish) and [`finish_partial`](Self::finish_partial) refuse alike.
+  ///
+  /// # One shape the debug scan refuses that release accepts
+  ///
+  /// The recount is positional, so it also fires on a **third** dip route that is not a misuse
+  /// at all: a `Demote` naming an **enclosing** start, emitted while this node was still open —
+  /// two brackets whose exits interleave instead of nesting. Release admits that order and
+  /// materialises exactly the tree the innermost-first order builds (canonicalization tombstones
+  /// both slots either way), so the scan is a **strictness choice on the raw surface**, not
+  /// early detection of a release defect: debug enforces innermost-first closings; release
+  /// admits the out-of-order shape. The blessed `node()` bracket cannot produce it — it mints
+  /// and spends its mark inside one call frame — so the stricter reading costs no legal code.
   ///
   /// Every check but that scan runs in every build, identity first, for the reason
   /// [`validate_mark`](Self::validate_mark) gives: the positional and era halves are only
@@ -756,44 +798,91 @@ where
       "cst_demote on a mark that does not name a live open node of kind {kind}: the slot the \
        mark named holds no such start any more. Either a rewind truncated it (the frame that \
        opened the node was rolled back, and the demote belongs to a branch that no longer \
-       exists), or the mark was already demoted (a demoted start reverts to the tombstone \
-       kind), or it came from cst_mark, whose tombstones are spent by cst_start_at and never \
-       demoted. Rewriting whatever else sits at that index would be the wrong-tree class \
-       nothing downstream can detect."
+       exists), or it came from cst_mark, whose tombstones are spent by cst_start_at and never \
+       demoted. Naming whatever else sits at that index would be the wrong-tree class nothing \
+       downstream can detect."
     );
 
-    // Detect-at-cause for the one misuse the slot itself cannot witness — a start whose node
-    // was already closed. Debug-only, and that is the calibration this surface already takes:
-    // `cst_finish`'s global-underflow check is a `debug_assert!` for the same reason, because
-    // the release backstop here is a TYPED refusal through both finish doors (see the doc
-    // comment) and not a wrong tree. Paying an O(suffix) recount in release would tax the
-    // failure path of every backtracking grammar to make a loud detection merely earlier.
+    // Detect-at-cause, debug-only — the calibration this surface already takes: `cst_finish`'s
+    // global-underflow check is a `debug_assert!` for the same reason, because the release
+    // backstop here is a TYPED refusal through both finish doors (see the doc comment) and not
+    // a wrong tree. Paying an O(suffix) recount in release would tax the failure path of every
+    // backtracking grammar to make a loud detection merely earlier.
     //
     // The predicate is EXACT, not heuristic, and — the #98 lesson — it consults no frozen
     // baseline and no memo. It recounts the LIVE suffix strictly above the mark's own
     // already-validated slot, so every truncation has already removed whatever it removed.
-    // While the marked node is still open the running sum cannot dip below zero: stack
-    // discipline pairs every surviving finish above the slot with a start above the slot (a
-    // completed child nets 0 and never dips on the way; an unspent tombstone and a token are
-    // 0 outright; a `StartAt` sits above the slot in EMISSION order whatever it hoists to, its
-    // +1 before its −1). A dip is therefore reachable only through a finish that closed the
-    // marked node itself, which is exactly demote-illegality. The sum is kind-blind, so the
-    // hoist-order inversion that forbids an emit-site kind check in `cst_finish` cannot reach
-    // it. The suffix total is deliberately NOT required to be 0: an open child above the mark
-    // is a different bug, already walled at materialization as `UnclosedNodes`.
+    //
+    // WHAT A DIP MEANS, positionally. Every event above the slot that pairs WITHIN the suffix
+    // nets zero and never dips on the way: a completed child (`Start` +1 … `Finish` −1), a
+    // nested bracket that took its own failing exit (`Start` +1 … its own `Demote` −1), an
+    // unspent tombstone and a token (0 outright), a `StartAt` (which sits above the slot in
+    // EMISSION order whatever it hoists to, its +1 before its −1). So a dip below zero means
+    // the suffix holds a CLOSING event whose opening event is not in the suffix — and since the
+    // marked node's own start is at the slot and every enclosing start is below it, that
+    // closing event closes the marked node or an ancestor of it. There are exactly three
+    // shapes, and they are NOT all misuse:
+    //
+    //   1. a surviving `FinishNode` — this node already took its success exit (or a finish
+    //      meant for an ancestor, which stack discipline lands on this node anyway);
+    //   2. a prior `Demote` naming THIS slot — a double demote;
+    //   3. a `Demote` naming an ENCLOSING start — an ancestor bracket emitted its failing exit
+    //      while this node was still open, i.e. closings out of innermost-first order.
+    //
+    // (1) and (2) are misuse: the bracket owes exactly one closing exit and took one already.
+    // (3) IS NOT. Materialization canonicalizes both slots and builds exactly the tree the
+    // innermost-first order builds, and the two orders' trees are pinned equal
+    // (`interleaved_and_innermost_first_demotes_materialize_the_same_tree`). So this assert is
+    // a STRICTNESS CHOICE on the raw surface, not early detection of a release defect:
+    // **debug enforces innermost-first closings; release admits the out-of-order shape and
+    // materialises the same tree.**
+    //
+    // Firing on (3) is not the #98 false-positive class, because the blessed brackets cannot
+    // reach it: `node()` mints and spends its mark inside one call frame, so nested brackets
+    // close last-in-first-out structurally. Only a hand-rolled raw sequence can interleave two
+    // brackets' exits, and on that surface the stricter reading is the useful one.
+    //
+    // The sum is kind-blind, so the hoist-order inversion that forbids an emit-site kind check
+    // in `cst_finish` cannot reach it. The suffix total is deliberately NOT required to be 0:
+    // an open child above the mark is a different bug, already walled at materialization as
+    // `UnclosedNodes`.
+    // The dipping event IS the diagnosis, so the report names which of the three it is rather
+    // than enumerating all three at the reader. The previous message asserted one shape ("the
+    // node was already closed") for a condition with three causes, and misdiagnosed the two it
+    // did not name — the defect class this repo keeps closing.
     #[cfg(debug_assertions)]
     {
       let mut depth: i64 = 0;
       for ev in &self.events[index as usize + 1..] {
         depth += ev.depth_delta();
-        assert!(
-          depth >= 0,
-          "cst_demote of a start whose node was already closed: a surviving cst_finish above \
-           the mark closed the node this mark names. The bracket owes exactly one closing \
-           exit, and this node took the success exit already. (In release builds this misuse \
-           surfaces at materialization as a typed FinishError — OrphanFinish or \
-           MismatchedFinish — through both finish and finish_partial.)"
-        );
+        if depth < 0 {
+          let shape = match ev {
+            Event::FinishNode { .. } => {
+              "a surviving cst_finish closed this node — the bracket already took its SUCCESS \
+               exit, and it owes exactly one closing exit. Misuse: a release build refuses the \
+               residue typed at materialization (OrphanFinish, or MismatchedFinish when the \
+               kinds misalign first), through both finish doors"
+            }
+            Event::Demote { target } if *target == index => {
+              "a prior cst_demote already named THIS slot — a DOUBLE demote, and the bracket \
+               owes exactly one closing exit. Misuse: a release build refuses it typed at \
+               materialization (StaleDemote), through both finish doors"
+            }
+            Event::Demote { .. } => {
+              "a cst_demote of an ENCLOSING start was emitted while this node was still open — \
+               two raw brackets whose closings INTERLEAVE instead of nesting. This one is NOT a \
+               release defect: materialization canonicalizes both slots and builds exactly the \
+               tree the innermost-first order builds, so release admits it and debug does not. \
+               Emit this bracket's demote before its ancestor's. The blessed node() bracket \
+               cannot produce the shape at all, because it mints and spends its mark inside one \
+               call frame"
+            }
+            // `depth_delta` is negative for exactly those two variants, so nothing else can
+            // carry the sum below zero.
+            _ => unreachable!("only FinishNode and Demote carry a negative depth delta"),
+          };
+          panic!("cst_demote below a closing event this mark's node did not open: {shape}.");
+        }
       }
     }
   }
@@ -871,14 +960,18 @@ where
     //
     // `EventMark`s need no term of their own here — but ONLY because a mark *materializes* an
     // event and this scan breaks on any structural event, so `at` is always above every mark's
-    // slot and every `StartAt` target. That holds for **both** mark provenances and in every
-    // state a marked slot can be in: `cst_mark` appends a tombstone `StartNode`, `cst_start`
-    // appends a real-kind `StartNode`, and `cst_demote` rewrites the second into the first
-    // **in place** — the slot never stops being a `StartNode`, so it never stops breaking the
-    // scan, and its index never moves. The up-front bracket therefore needs no floor term of
-    // its own. **If a future design ever de-materialises marks — hands out an index with no
-    // event standing behind it — that immunity is gone and the floor must be extended to
-    // cover them.**
+    // slot and every `StartAt` target. That holds for **both** mark provenances and for the
+    // whole life of a marked slot: `cst_mark` appends a tombstone `StartNode`, `cst_start`
+    // appends a real-kind `StartNode`, and nothing during the parse rewrites either — the
+    // failing exit appends an `Event::Demote` naming the slot instead, and the canonicalization
+    // that acts on it runs at materialization, after this sink is consumed. The slot is a
+    // `StartNode` from its append to the end of the parse, so it never stops breaking the scan
+    // and its index never moves. A `Demote` event breaks the scan too (it is neither a `Token`
+    // nor a `Diag`), so one can never sit inside a wrapped token run and be renamed by the
+    // splice, and its `target` — a `StartNode` index — is below the run for the same reason.
+    // The up-front bracket therefore needs no floor term of its own. **If a future design ever
+    // de-materialises marks — hands out an index with no event standing behind it — that
+    // immunity is gone and the floor must be extended to cover them.**
     let floor = self
       .rows
       .borrow()
@@ -1512,36 +1605,22 @@ where
   {
     self.validate_start_mark(&mark, kind);
 
-    // THE ONE UNJOURNALED INTERIOR WRITE, and it is unjournaled *structurally* — see the law
-    // amendment in `cst/event.rs`. The write's author is the frame that appended this very
-    // slot, so a truncation reaching the write also reaches the slot: any rewind that would
-    // want the demote undone has already erased the thing it would undo it on. What survives
-    // a truncation ABOVE the slot is a demotion that is permanently true — the bracket exited
-    // with an error, and no rewind re-runs an exited frame. Un-demoting would resurrect a
-    // dangling open node whose finish never fires.
+    // APPEND, never rewrite — the mirror of `cst_start_at` below, and the whole of why the
+    // bracket's two exits obey ONE rollback law. Rewriting the slot's kind here would survive a
+    // rollback whose target sits between the slot and this call: the truncation keeps the slot
+    // and keeps the rewrite, so the failing exit would silently drop a node that, by the
+    // restore contract, is open again — while the success exit's appended `FinishNode`
+    // truncates and the node correctly returns. Appending makes the failing exit acquire the
+    // success exit's blessed truncate-and-reopen semantics exactly.
     //
-    // The wall above is an unconditional `assert!`, so the slot IS a `StartNode` of `kind` in
-    // every build — the `else` arm is dead rather than a fallback, and spelling it that way is
-    // what keeps a future refactor of the wall from turning this into a silent no-op.
-    let Event::StartNode {
-      kind: k,
-      forward_parent,
-    } = &mut self.events[mark.index() as usize]
-    else {
-      unreachable!("validate_start_mark proved the slot is a StartNode of this kind")
-    };
-    // No `StartAt` can name a real-kind start: `cst_start_at` validates its target through the
-    // tombstone wall first, so this field is untouched since the append and the demoted slot
-    // is byte-identical to a never-spent `cst_mark` tombstone. The one shape that used to
-    // reach this assert with a live pointer — a retro-wrapped tombstone demoted with the
-    // reserved kind, which a content-only wall admits — is now refused above in every build,
-    // so this stays a debug canary over an argument the wall has already proved.
-    debug_assert!(
-      forward_parent.is_none(),
-      "a real-kind StartNode carries a forward_parent: only cst_start_at writes that field \
-       and its target must be a tombstone"
-    );
-    *k = TOMBSTONE;
+    // Materialization applies it: one canonicalization pass sets `events[target].kind =
+    // TOMBSTONE` per surviving `Demote`, at the one moment no live mark can exist. A `Demote`
+    // can never orphan its target — `target` is strictly below this index and truncation is a
+    // suffix operation, so the two survive and die together, in the same era.
+    self.demotes = true;
+    self.events.push(Event::Demote {
+      target: mark.index(),
+    });
   }
 
   fn cst_mark(&mut self) -> EventMark
@@ -1873,6 +1952,11 @@ where
   /// plain `assert!`s) are unconditional — refused in every build — so this hook is their
   /// only bypass at all, not merely their debug-build bypass.
   pub(crate) fn push_raw_event_for_tests(&mut self, event: Event<L::Span>) {
+    // The latch's invariant is "set whenever a Demote is in the buffer", and this hook is the
+    // one route that appends an event without going through an emission door, so it maintains
+    // it here rather than leaving the canonicalization pass to be skipped over an injected
+    // demote.
+    self.demotes |= matches!(event, Event::Demote { .. });
     self.events.push(event);
   }
 }

--- a/tokora/src/cst/sink.rs
+++ b/tokora/src/cst/sink.rs
@@ -9,7 +9,7 @@
 //!
 //! | # | Cell | Class | Rewind/restore semantics |
 //! |---|------|-------|--------------------------|
-//! | E1 | [`Sink::events`] | **ground truth** (a second emission log) | append + suffix-truncate to the mark — the same two verbs as `Verbose`'s log (plus the one censused prefix-preserving splice of the hole wrap, entirely above every live mark) |
+//! | E1 | [`Sink::events`] | **ground truth** (a second emission log) | append + suffix-truncate to the mark — the same two verbs as `Verbose`'s log (plus the one censused prefix-preserving splice of the hole wrap, entirely above every live mark, and the two censused interior writes: `cst_start_at`'s journaled `forward_parent` link and `cst_demote`'s structurally-unjournaled kind demotion — see the law in [`event`](super::event)) |
 //! | E2 | [`Sink::journal`] | **undo journal** (the Verbose-parallel-maps discipline lifted to events) | rewind pops entries written above the mark, reverse order, restoring each overwritten `forward_parent`; never grows on rewind |
 //! | E3 | [`Sink::ledger`] | **monotone era source + truncation witness** | rewind APPENDS to it (a rewind *is* a truncation) and never removes; rewinding it would false-accept a stale mark |
 //! | E4 | [`Sink::rows`] | **release stack + per-checkpoint depth ledger + inner reading** | push at `checkpoint()` (freezing the depth and the inner emitter's own checkpoint reading), pop at `release()` (kept) and `rewind()` (spent, the popped row's inner reading is the inner's rewind target); depth entries are frozen facts about prefixes, never live counters |
@@ -153,7 +153,14 @@ struct DegradedRewind {
 /// One undo-journal entry: an in-place `forward_parent` write performed by
 /// [`cst_start_at`](CstEmitter::cst_start_at) on its target tombstone, recorded so a rewind
 /// can reverse it. In-place event mutation is otherwise banned by law; this one acceleration
-/// field is the single exception, and it is legal *only because* every write is journaled.
+/// field is the single **journaled** exception, and it is legal *only because* every write is
+/// journaled.
+///
+/// The law's other exception, [`cst_demote`](CstEmitter::cst_demote)'s kind rewrite, is
+/// deliberately **not** here: its writer is the frame that appended the slot, so every
+/// truncation that could want the write undone erases the slot it was made on, and a journal
+/// entry would have nothing to restore onto. See the law amendment in
+/// [`event`](super::event).
 #[derive(Debug, Clone, Copy)]
 struct JournalEntry {
   /// The event-log length immediately after the append that carried this write (the
@@ -663,15 +670,132 @@ where
     let is_current = !self.ledger.is_stale(mark.era(), index);
     assert!(
       in_bounds && is_tombstone && is_current,
-      "stale EventMark: the tombstone this mark named no longer exists on the live \
-       timeline (a rewind truncated it{}). The wrap intent died with the branch that \
-       conceived it; spending the mark anyway would wrap an unrelated region.",
-      if in_bounds {
-        " and the buffer regrew over its index"
+      "stale EventMark: this mark no longer names a live tombstone — {}. Spending it anyway \
+       would wrap an unrelated region: the wrong-tree class nothing downstream can detect.",
+      // Only evaluated on the failure path, so the extra discrimination costs the spend
+      // nothing. The last arm is the wrong-provenance misuse, which is not staleness at all
+      // and would otherwise be reported as a rewind that never happened.
+      if !in_bounds {
+        "a rewind truncated it away, so the wrap intent died with the branch that conceived it"
+      } else if !is_current {
+        "a rewind truncated it away and the buffer regrew over its index, so the wrap intent \
+         died with the branch that conceived it"
+      } else if matches!(self.events[index as usize], Event::StartNode { .. }) {
+        "the slot holds a real-kind StartNode, so the mark came from `cst_start` and not from \
+         `cst_mark`. An up-front start is closed by `cst_finish` or reverted by `cst_demote`; \
+         it is never a retro-wrap target, because wrapping an already-open node would nest it \
+         inside a wrap of itself"
       } else {
-        ""
+        "the slot holds no node start at all"
       },
     );
+  }
+
+  /// Validates a **start** mark before a demote — the panic-in-every-build wall for the
+  /// up-front bracket's failing exit, and the mirror of [`validate_mark`](Self::validate_mark).
+  ///
+  /// The two walls take the same three positional checks (issued by this sink, index in
+  /// bounds, no truncation younger than the mark's era reached the index) and then diverge on
+  /// the **slot content**, which is what keeps the two mark provenances from crossing: a
+  /// retro-wrap spend demands a live `TOMBSTONE`, a demote demands a live `StartNode` of
+  /// exactly the kind its `cst_start` was given. So a `cst_mark` tombstone cannot be demoted
+  /// (its kind is `TOMBSTONE`, which no `cst_start` is allowed to name), a `cst_start` mark
+  /// cannot be retro-wrapped (the tombstone wall refuses it), and a mark cannot be demoted
+  /// twice (the first demote leaves `TOMBSTONE` behind).
+  ///
+  /// That last sentence is only true because the **reserved kind is refused before the slot is
+  /// read at all**. A content-only comparison would let `cst_demote(mark, TOMBSTONE)` satisfy
+  /// itself against any live tombstone — a `cst_mark` slot, or one already carrying a live
+  /// `forward_parent` from a retro wrap — and write `TOMBSTONE` over `TOMBSTONE`: in release a
+  /// silent no-op on a slot the caller does not own, in debug a fire of `cst_demote`'s own
+  /// `forward_parent` assert far from the mistake. One compare against an immediate closes it
+  /// in every build, because no `cst_start` can ever have opened a `TOMBSTONE`-kind node.
+  ///
+  /// # What this wall cannot see, and what refuses it instead
+  ///
+  /// A start whose node was **already finished** passes here in a release build, and no check
+  /// that reads the slot can do better: the finish is appended *above* the slot, so the slot
+  /// cannot witness its own close. What that misuse costs is bounded and typed rather than
+  /// silent. The demote removes exactly one frame push from the stream (the start becomes a
+  /// tombstone, whose [`depth_delta`](Event::depth_delta) is 0) and removes no pop, so pops
+  /// exceed pushes and the replay walk underflows; `materialize` refuses at the first surplus
+  /// finish ([`FinishError::OrphanFinish`](crate::cst::FinishError::OrphanFinish), or
+  /// `MismatchedFinish` sooner when the kinds misalign first). Both public doors are the *same*
+  /// walk, and `close_open_nodes` relaxes only end-of-stream opens and gap tiling — never a
+  /// balance underflow — so [`finish`](Self::finish) and
+  /// [`finish_partial`](Self::finish_partial) refuse it alike. A debug build does not wait for
+  /// materialization: the exact suffix scan below catches it at the misuse site.
+  ///
+  /// Every check but that scan runs in every build, identity first, for the reason
+  /// [`validate_mark`](Self::validate_mark) gives: the positional and era halves are only
+  /// meaningful against the issuing sink's own history.
+  fn validate_start_mark(&self, mark: &EventMark, kind: u16) {
+    assert!(
+      mark.sink() == self.witness,
+      "EventMark was minted by a different sink (or by a no-event emitter's defaulted \
+       cst_start): marks are only spendable on the sink that issued them"
+    );
+    // Before the slot is read: the reserved kind names no node a `cst_start` could have
+    // opened, so no start mark can legally be demoted with it. See the doc comment for the
+    // two shapes this refuses that a content-only check admits.
+    assert!(
+      kind != TOMBSTONE,
+      "cst_demote with the reserved TOMBSTONE kind: no cst_start can open a TOMBSTONE-kind \
+       node (no validator admits it), so no start mark can legally be demoted with it — a \
+       cst_mark tombstone is spent by cst_start_at, never by cst_demote"
+    );
+    let index = mark.index();
+    let slot = if self.ledger.is_stale(mark.era(), index) {
+      None
+    } else {
+      self.events.get(index as usize)
+    };
+    let matches_kind = matches!(slot, Some(Event::StartNode { kind: k, .. }) if *k == kind);
+    assert!(
+      matches_kind,
+      "cst_demote on a mark that does not name a live open node of kind {kind}: the slot the \
+       mark named holds no such start any more. Either a rewind truncated it (the frame that \
+       opened the node was rolled back, and the demote belongs to a branch that no longer \
+       exists), or the mark was already demoted (a demoted start reverts to the tombstone \
+       kind), or it came from cst_mark, whose tombstones are spent by cst_start_at and never \
+       demoted. Rewriting whatever else sits at that index would be the wrong-tree class \
+       nothing downstream can detect."
+    );
+
+    // Detect-at-cause for the one misuse the slot itself cannot witness — a start whose node
+    // was already closed. Debug-only, and that is the calibration this surface already takes:
+    // `cst_finish`'s global-underflow check is a `debug_assert!` for the same reason, because
+    // the release backstop here is a TYPED refusal through both finish doors (see the doc
+    // comment) and not a wrong tree. Paying an O(suffix) recount in release would tax the
+    // failure path of every backtracking grammar to make a loud detection merely earlier.
+    //
+    // The predicate is EXACT, not heuristic, and — the #98 lesson — it consults no frozen
+    // baseline and no memo. It recounts the LIVE suffix strictly above the mark's own
+    // already-validated slot, so every truncation has already removed whatever it removed.
+    // While the marked node is still open the running sum cannot dip below zero: stack
+    // discipline pairs every surviving finish above the slot with a start above the slot (a
+    // completed child nets 0 and never dips on the way; an unspent tombstone and a token are
+    // 0 outright; a `StartAt` sits above the slot in EMISSION order whatever it hoists to, its
+    // +1 before its −1). A dip is therefore reachable only through a finish that closed the
+    // marked node itself, which is exactly demote-illegality. The sum is kind-blind, so the
+    // hoist-order inversion that forbids an emit-site kind check in `cst_finish` cannot reach
+    // it. The suffix total is deliberately NOT required to be 0: an open child above the mark
+    // is a different bug, already walled at materialization as `UnclosedNodes`.
+    #[cfg(debug_assertions)]
+    {
+      let mut depth: i64 = 0;
+      for ev in &self.events[index as usize + 1..] {
+        depth += ev.depth_delta();
+        assert!(
+          depth >= 0,
+          "cst_demote of a start whose node was already closed: a surviving cst_finish above \
+           the mark closed the node this mark names. The bracket owes exactly one closing \
+           exit, and this node took the success exit already. (In release builds this misuse \
+           surfaces at materialization as a typed FinishError — OrphanFinish or \
+           MismatchedFinish — through both finish and finish_partial.)"
+        );
+      }
+    }
   }
 
   /// Records one committed token. The token channel has exactly **one** door — the
@@ -745,11 +869,16 @@ where
     // reported span backward over already-committed tokens gets the wrap narrowed to its own
     // transaction, and the report itself forwarded untouched.
     //
-    // `EventMark`s need no term of their own here — but ONLY because `cst_mark`
-    // *materializes* a tombstone `StartNode` and this scan breaks on any structural event, so
-    // `at` is always above every tombstone and every `StartAt` target. **If a future design
-    // ever de-materialises marks — hands out an index with no event standing behind it — that
-    // immunity is gone and the floor must be extended to cover them.**
+    // `EventMark`s need no term of their own here — but ONLY because a mark *materializes* an
+    // event and this scan breaks on any structural event, so `at` is always above every mark's
+    // slot and every `StartAt` target. That holds for **both** mark provenances and in every
+    // state a marked slot can be in: `cst_mark` appends a tombstone `StartNode`, `cst_start`
+    // appends a real-kind `StartNode`, and `cst_demote` rewrites the second into the first
+    // **in place** — the slot never stops being a `StartNode`, so it never stops breaking the
+    // scan, and its index never moves. The up-front bracket therefore needs no floor term of
+    // its own. **If a future design ever de-materialises marks — hands out an index with no
+    // event standing behind it — that immunity is gone and the floor must be extended to
+    // cover them.**
     let floor = self
       .rows
       .borrow()
@@ -1312,7 +1441,7 @@ where
   E: Emitter<'inp, L, Lang> + ValueKeyedEmitter,
   Lang: ?Sized,
 {
-  fn cst_start(&mut self, kind: u16)
+  fn cst_start(&mut self, kind: u16) -> EventMark
   where
     L: Lexer<'inp>,
   {
@@ -1321,10 +1450,12 @@ where
       "node kind outside the dialect's own kind space (the tombstone kind, u16::MAX, is \
        reserved and no validator admits it)"
     );
+    let index = self.events.len() as u64;
     self.events.push(Event::StartNode {
       kind,
       forward_parent: None,
     });
+    EventMark::new(index, self.ledger.era(), self.witness)
   }
 
   fn cst_finish(&mut self, kind: u16)
@@ -1373,6 +1504,44 @@ where
        to close instead"
     );
     self.events.push(Event::FinishNode { kind });
+  }
+
+  fn cst_demote(&mut self, mark: EventMark, kind: u16)
+  where
+    L: Lexer<'inp>,
+  {
+    self.validate_start_mark(&mark, kind);
+
+    // THE ONE UNJOURNALED INTERIOR WRITE, and it is unjournaled *structurally* — see the law
+    // amendment in `cst/event.rs`. The write's author is the frame that appended this very
+    // slot, so a truncation reaching the write also reaches the slot: any rewind that would
+    // want the demote undone has already erased the thing it would undo it on. What survives
+    // a truncation ABOVE the slot is a demotion that is permanently true — the bracket exited
+    // with an error, and no rewind re-runs an exited frame. Un-demoting would resurrect a
+    // dangling open node whose finish never fires.
+    //
+    // The wall above is an unconditional `assert!`, so the slot IS a `StartNode` of `kind` in
+    // every build — the `else` arm is dead rather than a fallback, and spelling it that way is
+    // what keeps a future refactor of the wall from turning this into a silent no-op.
+    let Event::StartNode {
+      kind: k,
+      forward_parent,
+    } = &mut self.events[mark.index() as usize]
+    else {
+      unreachable!("validate_start_mark proved the slot is a StartNode of this kind")
+    };
+    // No `StartAt` can name a real-kind start: `cst_start_at` validates its target through the
+    // tombstone wall first, so this field is untouched since the append and the demoted slot
+    // is byte-identical to a never-spent `cst_mark` tombstone. The one shape that used to
+    // reach this assert with a live pointer — a retro-wrapped tombstone demoted with the
+    // reserved kind, which a content-only wall admits — is now refused above in every build,
+    // so this stays a debug canary over an argument the wall has already proved.
+    debug_assert!(
+      forward_parent.is_none(),
+      "a real-kind StartNode carries a forward_parent: only cst_start_at writes that field \
+       and its target must be a tombstone"
+    );
+    *k = TOMBSTONE;
   }
 
   fn cst_mark(&mut self) -> EventMark

--- a/tokora/src/cst/sink.rs
+++ b/tokora/src/cst/sink.rs
@@ -771,6 +771,17 @@ where
   /// Every check but that scan runs in every build, identity first, for the reason
   /// [`validate_mark`](Self::validate_mark) gives: the positional and era halves are only
   /// meaningful against the issuing sink's own history.
+  ///
+  /// # Who can reach the stale arm
+  ///
+  /// Raw callers, and only raw callers: staling a start mark requires a rewind below the
+  /// bracket's own `cst_start`, and the safe combinator surface cannot express one mid-frame —
+  /// a session settle needs a `SessionPointId` whose invariant `'closure` brand cannot enter a
+  /// universally quantified parser frame, so `node()`'s failing exit always spends a live mark.
+  /// That is a type-system guarantee with **no runtime backstop**: the settle scan is
+  /// newest-first, so a point opened before the bracket would pass it. See *A rollback below the
+  /// start cannot happen mid-frame* in the [`node` module docs](crate::parser::node) for the
+  /// theorem and the compile-fail cases that pin it.
   fn validate_start_mark(&self, mark: &EventMark, kind: u16) {
     assert!(
       mark.sink() == self.witness,

--- a/tokora/src/cst/sink/finish.rs
+++ b/tokora/src/cst/sink/finish.rs
@@ -93,10 +93,16 @@ pub enum FinishError {
   },
 
   /// A `Demote`'s target is not a live, un-demoted `StartNode` — out of bounds, a slot
-  /// holding some other event, a `cst_mark` tombstone, or a slot a **prior** `Demote` already
-  /// claimed.
+  /// holding some other event, a `cst_mark` tombstone, a slot a **prior** `Demote` already
+  /// claimed, or a slot at or **above** the `Demote`'s own index.
   ///
-  /// The last of those is the one a caller can actually reach: `cst_demote` appends rather
+  /// That last shape is raw-injected only: a `Demote` must name a slot strictly below itself,
+  /// and the emission wall derives `target` from a validated live slot below the appended
+  /// event, so no legal stream can carry one. Left unrefused it would tombstone a start the
+  /// walk has not reached yet, erasing that node from a buffer that stays balanced — the
+  /// silent class, so it is refused positionally before the slot is even read.
+  ///
+  /// The double demote is the one a caller can actually reach: `cst_demote` appends rather
   /// than rewrites, so the slot cannot witness an earlier demote of itself and the emission
   /// wall cannot refuse a **double demote** in a release build. It is refused here instead,
   /// by the canonicalization pass — the release half of the two-tier calibration whose
@@ -508,15 +514,23 @@ where
 ///
 /// # What it refuses
 ///
-/// A `Demote` whose target is not a live, un-demoted `StartNode`. Through the validated
-/// emission surface exactly one shape reaches that: a **double demote**, whose second event
-/// finds the slot its predecessor already tombstoned. `cst_demote` cannot refuse it in a
-/// release build — appending leaves the slot unchanged, so the emission wall has nothing to
-/// read — so this is the release half of that misuse's two-tier calibration (the debug half is
-/// `cst_demote`'s own suffix scan, where the prior `Demote`'s −1 dips the running sum). Every
-/// other shape — an out-of-range target, a target holding a token, a `cst_mark` tombstone, a
-/// real-kind start carrying a `forward_parent` — is unreachable through the emission walls and
-/// refused here as the backstop for the raw in-crate injection hook.
+/// A `Demote` whose target is not a live, un-demoted `StartNode`, **or does not sit strictly
+/// below the `Demote` itself**. Through the validated emission surface exactly one shape
+/// reaches that: a **double demote**, whose second event finds the slot its predecessor
+/// already tombstoned. `cst_demote` cannot refuse it in a release build — appending leaves the
+/// slot unchanged, so the emission wall has nothing to read — so this is the release half of
+/// that misuse's two-tier calibration (the debug half is `cst_demote`'s own suffix scan, where
+/// the prior `Demote`'s −1 dips the running sum). Every other shape — an out-of-range target,
+/// a target holding a token, a `cst_mark` tombstone, a real-kind start carrying a
+/// `forward_parent`, **a target at or above the `Demote`'s own index** — is unreachable
+/// through the emission walls and refused here as the backstop for the raw in-crate injection
+/// hook.
+///
+/// The positional shape is worth naming separately, because it is the only one whose residue
+/// is *balanced*. A future target tombstones a start the walk has not opened yet, so the node
+/// simply vanishes and no downstream check has anything to fire on; the others all leave a
+/// stream that reads wrong somewhere. It is checked first, before the slot read, so the
+/// narrowing to `usize` can never alias a distant target onto a nearby slot.
 ///
 /// # Cost
 ///
@@ -531,6 +545,24 @@ fn canonicalize_demotes<S>(events: &mut [Event<S>]) -> Result<(), FinishError> {
     let Event::Demote { target } = events[index] else {
       continue;
     };
+    // The **positional** half of the documented invariant — `target` is strictly below the
+    // `Demote`'s own index — mirroring the `StartAt` replay arm's `*target < index` term. The
+    // content check below cannot stand in for it: a slot ahead of this event holds whatever the
+    // stream put there, so a future-target demote would tombstone a start the walk has not
+    // reached yet and erase its node silently, with a balanced buffer downstream and nothing
+    // left to notice. Only raw injection can build that shape — the emission wall derives
+    // `target` from a validated live slot strictly below the appended event — so no legal
+    // stream is affected.
+    //
+    // Compared in `u64` space, ahead of the `as usize` narrowing below: on a 32-bit target that
+    // cast truncates, so a `target` of, say, `2^32` would otherwise alias slot 0 and be
+    // *accepted*. This compare refuses every such target before the narrowing can happen.
+    if target >= index as u64 {
+      return Err(FinishError::StaleDemote {
+        index: index as u64,
+        target,
+      });
+    }
     // A `forward_parent` on the target is refused with the rest: only `cst_start_at` writes
     // that field and its wall demands a tombstone, so a real-kind start can never carry one —
     // and a tombstoned target that does is a slot this demote does not own.

--- a/tokora/src/cst/sink/finish.rs
+++ b/tokora/src/cst/sink/finish.rs
@@ -92,6 +92,28 @@ pub enum FinishError {
     target: u64,
   },
 
+  /// A `Demote`'s target is not a live, un-demoted `StartNode` — out of bounds, a slot
+  /// holding some other event, a `cst_mark` tombstone, or a slot a **prior** `Demote` already
+  /// claimed.
+  ///
+  /// The last of those is the one a caller can actually reach: `cst_demote` appends rather
+  /// than rewrites, so the slot cannot witness an earlier demote of itself and the emission
+  /// wall cannot refuse a **double demote** in a release build. It is refused here instead,
+  /// by the canonicalization pass — the release half of the two-tier calibration whose
+  /// at-cause half is `cst_demote`'s debug suffix scan (the prior `Demote`'s −1 dips the
+  /// running sum). Both materialization doors refuse: canonicalization runs before the walk,
+  /// and `finish_partial` tolerates incompleteness, not a corrupt stream.
+  #[error(
+    "demote event at index {index} targets {target}, which is not a live open node start (a \
+     double demote, or a target that is not this bracket's own start)"
+  )]
+  StaleDemote {
+    /// The buffer index of the `Demote` event.
+    index: u64,
+    /// The target it names.
+    target: u64,
+  },
+
   /// A tombstone's `forward_parent` pointer does not name a `StartAt` targeting it — the
   /// dangling-pointer shape of an abandoned wrap that escaped the undo journal. With the
   /// journal reverse-replayed on every rewind this is unreachable; it is checked anyway,
@@ -426,12 +448,30 @@ where
       );
     }
 
-    let events = self.events;
+    let mut events = self.events;
+    let has_demotes = self.demotes;
     let profile = self.profile;
     let inner = self.inner;
     // TriviaPolicy::AsEmitted is the only variant today: the replay below IS that policy
     // (tokens land in whichever node is open at their buffer position).
     let TriviaPolicy::AsEmitted = self.trivia;
+
+    // The canonicalization pass, and the one place an interior kind write is unconditionally
+    // safe: the sink has been consumed, so no `EventMark` and no checkpoint row can still be
+    // live, and nothing can observe the buffer between here and the walk.
+    //
+    // The latch keeps the pass off a parse that never took a failing bracket exit — which is
+    // EVERY parse of a predictive grammar, and is measured rather than assumed. The latch can
+    // only ever be over-set (see `Sink::demotes`), so skipping here provably skips a pass with
+    // nothing to do; the assert holds that direction rather than trusting it.
+    debug_assert!(
+      has_demotes || !events.iter().any(|ev| matches!(ev, Event::Demote { .. })),
+      "the demote latch was clear over a buffer holding a Demote: canonicalization would be \
+       skipped and an abandoned node would materialize"
+    );
+    if has_demotes && let Err(err) = canonicalize_demotes(&mut events) {
+      return (Err(err), inner);
+    }
 
     // The source is the one the sink was constructed with, so the spans and the text they
     // slice can never come from different buffers. A byte-backed source validates here, once,
@@ -451,6 +491,63 @@ where
     };
     (result, inner)
   }
+}
+
+/// Applies every surviving [`Event::Demote`] to its target, turning the abandoned node's
+/// `StartNode` into the inert tombstone an unspent `cst_mark` would have left — the one pass
+/// that makes the failing exit's *appended* event equivalent to the eager rewrite it replaced.
+///
+/// # Why here, and why it is not the banned interior write
+///
+/// The law forbids rewriting an earlier slot **during the parse**, because a truncation that
+/// erases the deciding branch does not erase the slot the decision was written on. This pass
+/// runs on the buffer `materialize` **owns**: the sink is consumed, every `EventMark` is
+/// unspendable, every checkpoint row is gone, and no rewind can follow. It is the same bucket
+/// the hole wrap's floored splice sits in — "provably beyond every live mark" — made absolute
+/// rather than argued.
+///
+/// # What it refuses
+///
+/// A `Demote` whose target is not a live, un-demoted `StartNode`. Through the validated
+/// emission surface exactly one shape reaches that: a **double demote**, whose second event
+/// finds the slot its predecessor already tombstoned. `cst_demote` cannot refuse it in a
+/// release build — appending leaves the slot unchanged, so the emission wall has nothing to
+/// read — so this is the release half of that misuse's two-tier calibration (the debug half is
+/// `cst_demote`'s own suffix scan, where the prior `Demote`'s −1 dips the running sum). Every
+/// other shape — an out-of-range target, a target holding a token, a `cst_mark` tombstone, a
+/// real-kind start carrying a `forward_parent` — is unreachable through the emission walls and
+/// refused here as the backstop for the raw in-crate injection hook.
+///
+/// # Cost
+///
+/// One linear pass over the owned buffer with a single well-predicted branch per event, ahead
+/// of a walk that reads the same events again. It is deliberately **not** ticked into the
+/// [`W`](w) instrument: `W`'s obligation is over [`replay`] and its helpers, and folding an
+/// out-of-walk pass into that counter would move its bounds for a reason unrelated to the
+/// walk's own shape. It is linear by construction and stated here instead.
+fn canonicalize_demotes<S>(events: &mut [Event<S>]) -> Result<(), FinishError> {
+  for index in 0..events.len() {
+    // `target` is a `Copy` scalar, so this read releases its borrow before the write below.
+    let Event::Demote { target } = events[index] else {
+      continue;
+    };
+    // A `forward_parent` on the target is refused with the rest: only `cst_start_at` writes
+    // that field and its wall demands a tombstone, so a real-kind start can never carry one —
+    // and a tombstoned target that does is a slot this demote does not own.
+    match events.get_mut(target as usize) {
+      Some(Event::StartNode {
+        kind,
+        forward_parent: None,
+      }) if *kind != TOMBSTONE => *kind = TOMBSTONE,
+      _ => {
+        return Err(FinishError::StaleDemote {
+          index: index as u64,
+          target,
+        });
+      }
+    }
+  }
+  Ok(())
 }
 
 /// Converts one span endpoint, mapping failures to the event's typed error.
@@ -952,6 +1049,14 @@ where
           return Err(FinishError::DanglingForwardParent { index: *target });
         }
       }
+      // Structural silence, exactly like an unwrapped tombstone or a `StartAt` declaration:
+      // canonicalization has already applied this event to its target (and refused it if the
+      // target was not the demote's own live start), so the slot it names is a tombstone the
+      // walk will skip or has already skipped. It deliberately does NOT force a pending gap
+      // tile — it touches the builder not at all, so the run still belongs to the node the
+      // trailing token settled in, which is the placement the eager in-place demote produced
+      // by emitting no event whatsoever. That equality is what keeps the corpus hashes exact.
+      Event::Demote { .. } => {}
       Event::Diag {
         error_span: Some(span),
       } => {

--- a/tokora/src/cst/sink/tests.rs
+++ b/tokora/src/cst/sink/tests.rs
@@ -399,6 +399,395 @@ fn mark_survives_rewinds_strictly_above_it() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
+// The up-front bracket — `cst_start`'s handback and `cst_demote`'s wall
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// `node(kind, p)` as a `ParseInput` names the node's kind at entry and closes on both exits:
+// `cst_finish` on success, `cst_demote` on failure. The demote is the crate's ONE unjournaled
+// interior write, lawful because its author is the frame that appended the slot (the law
+// amendment lives in `cst/event.rs`). These cells hold the three properties that make it so:
+// the demoted slot is inert and indistinguishable from an unspent `cst_mark` tombstone, the
+// write survives exactly the truncations that keep its slot, and every misuse of the handback
+// panics in every build rather than rewriting an unrelated index.
+
+/// The demote is an **in-place** kind rewrite: no extra event, no journal entry, and the slot
+/// materializes into nothing — the abandoned node leaves no trace at all.
+#[test]
+fn demote_materialises_as_inert() {
+  let mut sink = verbose_sink("a");
+  let mark = sink.cst_start(K_NODE);
+  assert_eq!(mark.index(), 0, "the handback names the slot just appended");
+  sink.record_token(&MiniTok(b'a'), &span(0, 1));
+  sink.cst_demote(mark, K_NODE);
+
+  assert_eq!(
+    sink.events(),
+    &[
+      Event::StartNode {
+        kind: TOMBSTONE,
+        forward_parent: None
+      },
+      Event::Token {
+        kind: K_TOK,
+        span: span(0, 1)
+      },
+    ],
+    "the slot reverts in place — the buffer neither grows nor shifts"
+  );
+  assert_eq!(
+    sink.journal_len(),
+    0,
+    "the demote is structurally unjournaled: a truncation that would want it undone erases \
+     the slot it was made on"
+  );
+
+  let (green, _emitter) = sink.finish(K_ROOT);
+  let green = green.expect("a demoted start leaves a balanced buffer");
+  assert_eq!(text(green.clone()), "a");
+  let root = tree(green);
+  assert_eq!(
+    root.children().count(),
+    0,
+    "the abandoned node materializes into nothing"
+  );
+  assert_eq!(root.children_with_tokens().count(), 1, "the token is loose");
+}
+
+/// **Why the four-corpora byte-identity gate can hold at all.** The two brackets' failing
+/// exits converge on the *same buffer*: the retro bracket leaves a `cst_mark` tombstone
+/// unspent, the up-front bracket demotes its own start back to one, and nothing — not the
+/// events, not the journal — separates the two. So converting `ParseInput for Node` changes
+/// the successful path's encoding only, and leaves the error path bit-for-bit alone.
+#[test]
+fn a_demoted_start_and_an_unspent_mark_leave_the_identical_buffer() {
+  let mut up_front = verbose_sink("a");
+  let mark = up_front.cst_start(K_NODE);
+  up_front.record_token(&MiniTok(b'a'), &span(0, 1));
+  up_front.cst_demote(mark, K_NODE);
+
+  let mut retro = verbose_sink("a");
+  let _unspent = retro.cst_mark();
+  retro.record_token(&MiniTok(b'a'), &span(0, 1));
+
+  assert_eq!(
+    up_front.events(),
+    retro.events(),
+    "the up-front bracket's Err exit is the retro bracket's Err exit, byte for byte"
+  );
+  assert_eq!(
+    up_front.journal_len(),
+    retro.journal_len(),
+    "both journal 0"
+  );
+}
+
+/// A truncation **strictly above** the demoted slot leaves the demotion standing. That is the
+/// direction the law argues for: the bracket already exited with an error, no rewind re-runs an
+/// exited frame, so un-demoting would resurrect a dangling open node whose finish never fires.
+#[test]
+fn demote_survives_a_truncation_strictly_above_it() {
+  let mut sink = verbose_sink("ab");
+  let mark = sink.cst_start(K_NODE);
+  sink.record_token(&MiniTok(b'a'), &span(0, 1));
+  sink.cst_demote(mark, K_NODE);
+  let ckp = Emitter::<MiniLexer<'_>>::checkpoint(&sink);
+  sink.record_token(&MiniTok(b'b'), &span(1, 2));
+  rewind(&mut sink, ckp);
+
+  assert_eq!(
+    sink.events(),
+    &[
+      Event::StartNode {
+        kind: TOMBSTONE,
+        forward_parent: None
+      },
+      Event::Token {
+        kind: K_TOK,
+        span: span(0, 1)
+      },
+    ],
+    "the rewind dropped the events above the mark and left the demotion in place"
+  );
+  // Balance is checked before the gap latch is consumed, so the only complaint being the
+  // rewound `b`'s uncovered byte IS the still-balanced proof: an un-demote on rewind would
+  // have reopened a node with no finish and answered `UnclosedNodes` first.
+  let (green, _emitter) = sink.finish(K_ROOT);
+  assert_eq!(
+    green.expect_err("the rewound token leaves byte 1 uncovered"),
+    FinishError::UncoveredGap { start: 1, end: 2 }
+  );
+}
+
+/// A truncation **at or below** the slot erases the slot itself — which is precisely why the
+/// write needs no journal entry: there is nothing left for a reverse-replay to restore onto.
+#[test]
+fn demote_dies_with_a_truncation_at_or_below_it() {
+  let mut sink = verbose_sink("a");
+  let ckp = Emitter::<MiniLexer<'_>>::checkpoint(&sink);
+  let mark = sink.cst_start(K_NODE);
+  sink.record_token(&MiniTok(b'a'), &span(0, 1));
+  sink.cst_demote(mark, K_NODE);
+  rewind(&mut sink, ckp);
+
+  assert!(
+    sink.events().is_empty(),
+    "the truncation erased the very slot the write was made on"
+  );
+  assert_eq!(sink.journal_len(), 0);
+}
+
+/// The sharpest staleness alias, the demote twin of
+/// `stale_mark_panics_even_over_a_regrown_tombstone`: the regrown event at the mark's index is
+/// another `StartNode` of the *same kind*, so the positional and kind checks alone would both
+/// validate — only the era separates the histories.
+#[test]
+#[should_panic(expected = "cst_demote on a mark")]
+fn stale_demote_panics_even_over_a_regrown_start_of_the_same_kind() {
+  let mut sink = verbose_sink("");
+  let ckp = Emitter::<MiniLexer<'_>>::checkpoint(&sink);
+  let dead = sink.cst_start(K_NODE);
+  rewind(&mut sink, ckp);
+  let live = sink.cst_start(K_NODE);
+  assert_eq!(live.index(), dead.index());
+  sink.cst_demote(dead, K_NODE);
+}
+
+/// A mark minted by one sink must not demote on another, even at the exact `(index: 0, era: 0)`
+/// collision two fresh sinks mint — the identity half of the wall, unconditional in every build.
+#[test]
+#[should_panic(expected = "different sink")]
+fn foreign_sink_demote_panics() {
+  let mut a = verbose_sink("");
+  let mut b = verbose_sink("");
+  let mark_a = a.cst_start(K_NODE);
+  let mark_b = b.cst_start(K_NODE);
+  assert_eq!(mark_a.index(), mark_b.index());
+  assert_eq!(mark_a.era(), mark_b.era());
+  b.cst_demote(mark_a, K_NODE);
+}
+
+/// An inert mark (a diagnostics-only emitter's defaulted `cst_start`) can never demote on a
+/// recording sink: its reserved witness names no sink.
+#[test]
+#[should_panic(expected = "different sink")]
+fn inert_mark_demote_panics() {
+  let mut fatal = Fatal::<TestErr>::new();
+  let inert = CstEmitter::<MiniLexer<'_>>::cst_start(&mut fatal, K_NODE);
+  let mut sink = verbose_sink("");
+  sink.cst_demote(inert, K_NODE);
+}
+
+/// The kind is checked, not merely carried: demoting with the wrong kind is the leaked-finish
+/// shape moved to the emit site, and the mark names the exact slot to check, so it is caught
+/// here rather than deferred to materialization.
+#[test]
+#[should_panic(expected = "cst_demote on a mark")]
+fn wrong_kind_demote_panics() {
+  let mut sink = verbose_sink("");
+  let mark = sink.cst_start(K_NODE);
+  sink.cst_demote(mark, K_LIST);
+}
+
+/// The two mark provenances do not cross in this direction either: a `cst_mark` tombstone is
+/// spent by `cst_start_at` and is never demotable. This is the half the slot-content check
+/// answers on its own — a real-kind argument against a `TOMBSTONE` slot. The other half, a
+/// `TOMBSTONE` **argument**, is not a content question at all and is refused separately; see
+/// `demote_with_the_tombstone_kind_panics`.
+#[test]
+#[should_panic(expected = "cst_demote on a mark")]
+fn demote_of_a_cst_mark_tombstone_panics() {
+  let mut sink = verbose_sink("");
+  let mark = sink.cst_mark();
+  sink.cst_demote(mark, K_NODE);
+}
+
+/// The reserved kind is refused as an **argument**, before the slot is read at all — the check
+/// that makes "the spend verbs do not cross" true rather than almost-true.
+///
+/// A content-only wall compares the slot's kind against the caller's, so `TOMBSTONE` against a
+/// live tombstone *matches*, and the demote then writes `TOMBSTONE` over `TOMBSTONE`. In a
+/// release build that is a silent no-op on a slot the caller never opened. The sharper shape it
+/// also retires is a **retro-wrapped** tombstone, whose `forward_parent` is live: the same
+/// content-only wall waves that through too, and only `cst_demote`'s debug `forward_parent`
+/// canary would have caught it, far from the mistake. One compare against an immediate closes
+/// both, in every build.
+#[test]
+#[should_panic(expected = "reserved TOMBSTONE kind")]
+fn demote_with_the_tombstone_kind_panics() {
+  let mut sink = verbose_sink("");
+  let mark = sink.cst_mark();
+  sink.cst_demote(mark, TOMBSTONE);
+}
+
+/// Single-use falls out of the same check: the first demote leaves a tombstone behind, so a
+/// second one finds no start of the expected kind.
+#[test]
+#[should_panic(expected = "cst_demote on a mark")]
+fn a_second_demote_of_one_mark_panics() {
+  let mut sink = verbose_sink("");
+  let mark = sink.cst_start(K_NODE);
+  sink.cst_demote(mark, K_NODE);
+  sink.cst_demote(mark, K_NODE);
+}
+
+/// **The one misuse the slot cannot witness**, caught at cause — in a debug build. `cst_finish`
+/// is appended *above* the mark's slot, so after it the slot still holds a live `StartNode` of
+/// exactly the demoted kind: identity, bounds, era and content all pass. Only a recount of the
+/// events above the mark sees the close, and that recount is `cfg(debug_assertions)`-only
+/// because the release backstop is a typed refusal rather than a wrong tree — pinned by
+/// `the_finished_then_demoted_residue_is_refused_typed_through_both_doors` below.
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "already closed")]
+fn demote_of_a_finished_start_panics_in_debug() {
+  let mut sink = verbose_sink("a");
+  let mark = sink.cst_start(K_NODE);
+  sink.record_token(&MiniTok(b'a'), &span(0, 1));
+  sink.cst_finish(K_NODE);
+  sink.cst_demote(mark, K_NODE);
+}
+
+/// **What a release build does with the residue instead** — and it is what the `cst_demote` docs
+/// now stake, so it is pinned here rather than argued.
+///
+/// The buffer is built *directly*, not by committing the misuse, and that is what lets the cell
+/// run in **every** build: in a debug build the misuse is refused at cause by the cell above and
+/// never reaches materialization at all. Byte for byte, this is what
+/// `cst_start(K_NODE); token; cst_finish(K_NODE); cst_demote(mark, K_NODE)` leaves behind.
+///
+/// The counting argument the docs make: demoting a finished start removes one frame **push**
+/// (the start's `depth_delta` drops from 1 to 0) and removes no **pop**, so pops exceed pushes
+/// and the replay walk must underflow. `finish` and `finish_partial` are one walk over that
+/// buffer — `close_open_nodes` relaxes end-of-stream opens and gap tiling, never balance — so
+/// **both** doors refuse, typed. There is no door through which this residue becomes a tree.
+#[test]
+fn the_finished_then_demoted_residue_is_refused_typed_through_both_doors() {
+  fn residue(src: &str) -> VerboseSink<'_> {
+    let mut sink = verbose_sink(src);
+    // The demoted slot: byte-identical to a `cst_start` whose kind was rewritten back.
+    let _demoted = sink.cst_mark();
+    sink.record_token(&MiniTok(b'a'), &span(0, 1));
+    // The finish the demote left behind. Raw, because `cst_finish`'s own debug wall refuses to
+    // append a close with nothing open — which is the very imbalance this cell is about.
+    sink.push_raw_event_for_tests(Event::FinishNode { kind: K_NODE });
+    sink
+  }
+
+  assert_eq!(
+    residue("a").events(),
+    &[
+      Event::StartNode {
+        kind: TOMBSTONE,
+        forward_parent: None
+      },
+      Event::Token {
+        kind: K_TOK,
+        span: span(0, 1)
+      },
+      Event::FinishNode { kind: K_NODE },
+    ],
+    "the residue is the post-misuse buffer exactly: demoted slot, token, surviving finish"
+  );
+
+  let (green, _emitter) = residue("a").finish(K_ROOT);
+  assert_eq!(
+    green.expect_err("the strict door refuses the surplus finish"),
+    FinishError::OrphanFinish { index: 2 }
+  );
+
+  let (green, _emitter) = residue("a").finish_partial(K_ROOT);
+  assert_eq!(
+    green.expect_err("and so does the tooling door — one walk, one balance check"),
+    FinishError::OrphanFinish { index: 2 },
+    "close_open_nodes relaxes end-of-stream opens, not a pop with nothing to pop"
+  );
+}
+
+/// **The #98-class guard on the debug scan.** A predicate that fires on a legal history is worse
+/// than no predicate at all, and this repo has shipped that mistake once: the old `cst_finish`
+/// assert compared depth against a *frozen* baseline and panicked on a legal cross-checkpoint
+/// close. The new scan carries no baseline — it recounts the live suffix — and this cell is the
+/// busiest legal frame that recount has to admit.
+///
+/// Every shape here puts a `FinishNode` above the mark's slot without closing the marked node: a
+/// completed child (+1 then −1, never dipping), an unspent `cst_mark` tombstone (0 outright),
+/// and a completed retro wrap whose `StartAt` sits above the mark in **emission** order whatever
+/// it hoists to, so its +1 still precedes its −1 there. The demote must be silent, and the
+/// buffer must still materialize.
+#[test]
+fn demote_scan_admits_a_busy_legal_frame() {
+  let mut sink = verbose_sink("abc");
+  let outer = sink.cst_start(K_NODE);
+
+  // A completed child node.
+  sink.cst_start(K_LIST);
+  sink.record_token(&MiniTok(b'a'), &span(0, 1));
+  sink.cst_finish(K_LIST);
+
+  // An unspent tombstone, left to materialize into nothing.
+  let _unspent = sink.cst_mark();
+  sink.record_token(&MiniTok(b'b'), &span(1, 2));
+
+  // A completed retro wrap, hoisted below its own `StartAt` at materialization.
+  let anchor = sink.cst_mark();
+  sink.record_token(&MiniTok(b'c'), &span(2, 3));
+  sink.cst_start_at(anchor, K_WRAP);
+  sink.cst_finish(K_WRAP);
+
+  // The demote under test: legal, and the scan must not fire on any of the above.
+  sink.cst_demote(outer, K_NODE);
+
+  let (green, _emitter) = sink.finish(K_ROOT);
+  let green = green.expect("a legal demote over a busy frame still materializes");
+  assert_eq!(text(green.clone()), "abc", "losslessness holds");
+  assert_eq!(
+    shape(&green),
+    "Root[List[Tok\"a\"] Tok\"b\" Wrap[Tok\"c\"]]",
+    "the demoted outer node vanishes; every completed structure above it survives"
+  );
+}
+
+/// …and the mirror wall, which is what keeps the shared `EventMark` type honest: an up-front
+/// start mark is refused by `cst_start_at`. `validate_mark` demands a live **tombstone**, and a
+/// real-kind `StartNode` is not one — retro-wrapping an already-open node would nest it inside
+/// a wrap of itself.
+#[test]
+#[should_panic(expected = "came from `cst_start`")]
+fn start_at_on_an_up_front_start_mark_panics() {
+  let mut sink = verbose_sink("a");
+  let mark = sink.cst_start(K_NODE);
+  sink.record_token(&MiniTok(b'a'), &span(0, 1));
+  sink.cst_start_at(mark, K_WRAP);
+}
+
+/// **The panic residue, pinned.** A panic that escapes *every* guard is the one exit the
+/// up-front bracket does not close — no `catch_unwind` is involved, so there is no mechanism to
+/// test, only the residue it leaves: an open node. This cell says what that residue costs, and
+/// it costs nothing new — it is the pre-existing fatal-abort shape, already walled two ways.
+/// (A guard-mediated unwind never reaches here: the guard's rewind truncates the start away,
+/// which `demote_dies_with_a_truncation_at_or_below_it` above holds.)
+#[test]
+fn a_start_left_open_by_an_escaping_panic_is_refused_by_finish_and_closed_by_finish_partial() {
+  let mut sink = verbose_sink("a");
+  let _never_closed = sink.cst_start(K_NODE);
+  sink.record_token(&MiniTok(b'a'), &span(0, 1));
+  let (green, _emitter) = sink.finish(K_ROOT);
+  assert_eq!(
+    green.expect_err("the success door refuses a leftover open node, typed"),
+    FinishError::UnclosedNodes { open: 1 }
+  );
+
+  let mut sink = verbose_sink("a");
+  let _never_closed = sink.cst_start(K_NODE);
+  sink.record_token(&MiniTok(b'a'), &span(0, 1));
+  let (green, _emitter) = sink.finish_partial(K_ROOT);
+  let green = green.expect("the tooling door closes it per its existing contract");
+  assert_eq!(text(green.clone()), "a", "losslessness holds either way");
+  let root = tree(green);
+  assert_eq!(root.first_child().expect("Root[Node]").kind(), K_NODE);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
 // F-A2 / F-A3 — the forward_parent write dies to journal + era
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -1256,7 +1645,7 @@ fn cst_forward_census_one_helper_carries_every_channel() {
 fn cst_composition_census_every_family_method_is_overridden() {
   let src = include_str!("../sink.rs");
 
-  // (a) The 29-method inventory: 13 core Emitter + 4 CstEmitter + 12 capability emit_*.
+  // (a) The 30-method inventory: 13 core Emitter + 5 CstEmitter + 12 capability emit_*.
   // Each must appear as an `fn <name>` impl in the sink; a missing one is a severed channel.
   let overridden = [
     // 13 core Emitter
@@ -1278,9 +1667,13 @@ fn cst_composition_census_every_family_method_is_overridden() {
     // The sink is the one emitter in the crate that binds a source, so it is the one that
     // must answer this rather than inherit the `None` default.
     "bound_source",
-    // 4 CstEmitter
+    // 5 CstEmitter
     "cst_start",
     "cst_finish",
+    // The up-front bracket's failing exit. It is the one CstEmitter method whose default is
+    // not merely "record nothing" but "un-record something", so a defaulted inherit here would
+    // leave a wrapped inner carrying a dangling open node for every `Err` a `node()` sees.
+    "cst_demote",
     "cst_mark",
     "cst_start_at",
     // 12 capability emit_*
@@ -1304,8 +1697,8 @@ fn cst_composition_census_every_family_method_is_overridden() {
   ];
   assert_eq!(
     overridden.len(),
-    29,
-    "the family inventory is 13 core + 4 CstEmitter + 12 capability = 29"
+    30,
+    "the family inventory is 13 core + 5 CstEmitter + 12 capability = 30"
   );
 
   // DERIVED, and at the TYPE level rather than by string matching — the half a hand-written
@@ -1356,7 +1749,7 @@ fn cst_composition_census_every_family_method_is_overridden() {
   let cst_body = &cst[cst.find("pub trait CstEmitter<").unwrap()..cst.find("for &mut U").unwrap()];
   assert_eq!(
     count(cst_body, "  fn "),
-    4,
+    5,
     "CstEmitter method count drifted"
   );
   // The capability surface, DERIVED on both sides — no constant, because a hard-coded total is
@@ -2329,7 +2722,9 @@ fn placement_drive(
   let mut sink = verbose_sink(src);
   for op in ops {
     match *op {
-      PlacementOp::Start(kind) => sink.cst_start(kind),
+      PlacementOp::Start(kind) => {
+        let _up_front = sink.cst_start(kind);
+      }
       PlacementOp::Finish(kind) => sink.cst_finish(kind),
       PlacementOp::Tok(byte, lo, hi) => sink.record_token(&MiniTok(byte), &span(lo, hi)),
       PlacementOp::Diag(lo, hi) => {
@@ -5727,12 +6122,16 @@ impl<'inp> crate::Emitter<'inp, MiniLexer<'inp>> for NonForwardingWrapper<'_, 'i
 /// combinators), so the realistic adversary is a wrapper that forwards everything a tree needs
 /// and still hides the binding. Pin 5 is the shape that needs it.
 impl<'inp> CstEmitter<'inp, MiniLexer<'inp>> for NonForwardingWrapper<'_, 'inp> {
-  fn cst_start(&mut self, kind: u16) {
-    self.0.cst_start(kind);
+  fn cst_start(&mut self, kind: u16) -> EventMark {
+    self.0.cst_start(kind)
   }
 
   fn cst_finish(&mut self, kind: u16) {
     self.0.cst_finish(kind);
+  }
+
+  fn cst_demote(&mut self, mark: EventMark, kind: u16) {
+    self.0.cst_demote(mark, kind);
   }
 
   fn cst_mark(&mut self) -> EventMark {
@@ -6593,12 +6992,16 @@ impl<'inp> crate::Emitter<'inp, MiniLexer<'inp>> for HalfForward<'_, 'inp> {
 }
 
 impl<'inp> CstEmitter<'inp, MiniLexer<'inp>> for HalfForward<'_, 'inp> {
-  fn cst_start(&mut self, kind: u16) {
-    self.0.cst_start(kind);
+  fn cst_start(&mut self, kind: u16) -> EventMark {
+    self.0.cst_start(kind)
   }
 
   fn cst_finish(&mut self, kind: u16) {
     self.0.cst_finish(kind);
+  }
+
+  fn cst_demote(&mut self, mark: EventMark, kind: u16) {
+    self.0.cst_demote(mark, kind);
   }
 
   fn cst_mark(&mut self) -> EventMark {
@@ -6684,12 +7087,16 @@ impl<'inp> crate::Emitter<'inp, MiniLexer<'inp>> for HalfForwardPartial<'_, 'inp
 }
 
 impl<'inp> CstEmitter<'inp, MiniLexer<'inp>> for HalfForwardPartial<'_, 'inp> {
-  fn cst_start(&mut self, kind: u16) {
-    self.inner.cst_start(kind);
+  fn cst_start(&mut self, kind: u16) -> EventMark {
+    self.inner.cst_start(kind)
   }
 
   fn cst_finish(&mut self, kind: u16) {
     self.inner.cst_finish(kind);
+  }
+
+  fn cst_demote(&mut self, mark: EventMark, kind: u16) {
+    self.inner.cst_demote(mark, kind);
   }
 
   fn cst_mark(&mut self) -> EventMark {

--- a/tokora/src/cst/sink/tests.rs
+++ b/tokora/src/cst/sink/tests.rs
@@ -6601,6 +6601,14 @@ impl<'inp> crate::Emitter<'inp, MiniLexer<'inp>> for NonForwardingWrapper<'_, 'i
 /// could not carry a CST parse at all (`CstEmitter` is a bound, not a default, on the `node()`
 /// combinators), so the realistic adversary is a wrapper that forwards everything a tree needs
 /// and still hides the binding. Pin 5 is the shape that needs it.
+///
+/// One of the five is no longer forwarded voluntarily: as of 0.9.0 `cst_demote` is a **required**
+/// method, so rustc refuses this impl unless the line below is present. That is the whole reach of
+/// that change and it is worth stating here, next to the residue it does *not* touch — this type's
+/// omission is `Emitter::bound_source`, which is defaulted on the **core** trait and stays that
+/// way, so what the three cells below pin is unchanged. What is gone is the *silent* half of the
+/// same shape on the CST surface: a wrapper can still discard the failing exit, but only by
+/// writing the discard where its own reviewer reads it.
 impl<'inp> CstEmitter<'inp, MiniLexer<'inp>> for NonForwardingWrapper<'_, 'inp> {
   fn cst_start(&mut self, kind: u16) -> EventMark {
     self.0.cst_start(kind)
@@ -7059,6 +7067,17 @@ fn conformance_emitter_kit_refuses_a_non_forwarding_wrapper() {
 /// published bypasses is the `## Panics` fiction this release deleted nine of, in a different
 /// medium.
 ///
+/// **What 0.9.0 narrowed, and what it left alone.** The cell used to state the general form as
+/// "a wrapper writing `impl CstEmitter for W {}` satisfies every CST bound while inheriting every
+/// default". That sentence is now stale in the good direction and is reworded below: `cst_demote`
+/// — the node bracket's failing exit — is a **required** method, so the empty impl no longer
+/// compiles and the one default whose inheritance produced a *silently wrong tree* cannot be
+/// inherited at all. The residue this cell pins is untouched by that, and the reason is worth
+/// keeping next to it: `bound_source` lives on the **core** `Emitter` trait, where the defaults
+/// are the promise diagnostics-only emitters were made, and its inheritance fails toward an
+/// *absence* (the check does not run) rather than toward a wrong tree. Same grading, opposite
+/// answer — see `CstEmitter::cst_demote`'s *Required, not defaulted*.
+///
 /// **The handle no longer hands out the sink; a callback parameter still does.** Wrapping a
 /// sink needs a `Sink` value or a `&mut Sink`, and the *handle* routes are shut — `Sink::new`,
 /// `InputRef::emitter` and `Input::emitter`/`into_emitter` are crate-private,
@@ -7091,7 +7110,8 @@ fn a_non_forwarding_wrapper_is_not_caught() {
     "XY",
     "the residue: an emitter wrapper that does not forward `bound_source` gives up the \
      guarantee for whatever it wraps, and no bound can see the omission — a wrapper writing \
-     `impl CstEmitter for W {{}}` satisfies every CST bound while inheriting every default"
+     `impl CstEmitter for W {{ fn cst_demote(..) {{}} }}`, the smallest impl that still \
+     compiles, satisfies every CST bound while inheriting every default it is still allowed to"
   );
 }
 

--- a/tokora/src/cst/sink/tests.rs
+++ b/tokora/src/cst/sink/tests.rs
@@ -759,6 +759,90 @@ fn canonicalization_refuses_a_demote_that_names_no_live_start() {
   );
 }
 
+/// **The positional half of the wall, and the one demote shape whose residue is balanced.**
+///
+/// A `Demote` naming a slot *ahead* of itself is the only stale shape that leaves nothing
+/// downstream to notice: canonicalization tombstones a start the walk has not opened yet, so
+/// the node vanishes, the buffer stays balanced, pops still match pushes, and the tree
+/// materializes one node short of what the stream said. Every other stale target leaves a
+/// stream that reads wrong somewhere — the surplus finish, the unclosed node — and is caught
+/// by a later law.
+///
+/// The stream below is that shape at its smallest: a demote at slot 0 naming slot 1, the start
+/// it names, and a token inside it. Before the positional term existed this **materialized**,
+/// returning `<root><tok/></root>` with the `K_NODE` silently erased. It is raw-injectable
+/// only — `cst_demote` derives its target from a live slot strictly below the event it appends
+/// — which is exactly why the release backstop has to carry the term the emission wall
+/// guarantees.
+#[test]
+fn canonicalization_refuses_a_demote_naming_a_slot_above_itself() {
+  fn future_target(src: &str) -> VerboseSink<'_> {
+    let mut sink = verbose_sink(src);
+    // The demote lands FIRST, naming the start that follows it.
+    sink.push_raw_event_for_tests(Event::Demote { target: 1 });
+    sink.push_raw_event_for_tests(Event::StartNode {
+      kind: K_NODE,
+      forward_parent: None,
+    });
+    sink.record_token(&MiniTok(b'a'), &span(0, 1));
+    sink
+  }
+
+  let (green, _emitter) = future_target("a").finish(K_ROOT);
+  assert_eq!(
+    green.expect_err("a demote may only name a slot strictly below itself"),
+    FinishError::StaleDemote {
+      index: 0,
+      target: 1
+    },
+    "without the positional term this materializes a tree with the future start erased, and \
+     nothing downstream can tell it apart from a stream that never opened the node"
+  );
+
+  let (green, _emitter) = future_target("a").finish_partial(K_ROOT);
+  assert_eq!(
+    green.expect_err("and the tooling door, which tolerates incompleteness, not corruption"),
+    FinishError::StaleDemote {
+      index: 0,
+      target: 1
+    }
+  );
+}
+
+/// The boundary of the same term: `>=`, not `>`. A demote naming **its own** index is refused
+/// through both doors.
+///
+/// Its outcome does not depend on the positional term — a slot holding a `Demote` is not a
+/// `StartNode`, so the content match refuses a self-target anyway — and that is the point of
+/// pinning it. The two arms must agree on the boundary, so that a future rewrite of either one
+/// cannot open a gap between them.
+#[test]
+fn canonicalization_refuses_a_demote_naming_its_own_slot() {
+  fn self_target(src: &str) -> VerboseSink<'_> {
+    let mut sink = verbose_sink(src);
+    sink.push_raw_event_for_tests(Event::Demote { target: 0 });
+    sink
+  }
+
+  let (green, _emitter) = self_target("").finish(K_ROOT);
+  assert_eq!(
+    green.expect_err("a demote cannot un-open itself"),
+    FinishError::StaleDemote {
+      index: 0,
+      target: 0
+    }
+  );
+
+  let (green, _emitter) = self_target("").finish_partial(K_ROOT);
+  assert_eq!(
+    green.expect_err("through the tooling door too"),
+    FinishError::StaleDemote {
+      index: 0,
+      target: 0
+    }
+  );
+}
+
 /// **The interleaved-exit shape, and what release actually does with it.** Two brackets whose
 /// closings cross — the enclosing start demoted while the inner one is still open — is the third
 /// route that dips `cst_demote`'s debug suffix recount, and the only one of the three that is

--- a/tokora/src/cst/sink/tests.rs
+++ b/tokora/src/cst/sink/tests.rs
@@ -403,15 +403,17 @@ fn mark_survives_rewinds_strictly_above_it() {
 // ═══════════════════════════════════════════════════════════════════════════════
 //
 // `node(kind, p)` as a `ParseInput` names the node's kind at entry and closes on both exits:
-// `cst_finish` on success, `cst_demote` on failure. The demote is the crate's ONE unjournaled
-// interior write, lawful because its author is the frame that appended the slot (the law
-// amendment lives in `cst/event.rs`). These cells hold the three properties that make it so:
-// the demoted slot is inert and indistinguishable from an unspent `cst_mark` tombstone, the
-// write survives exactly the truncations that keep its slot, and every misuse of the handback
-// panics in every build rather than rewriting an unrelated index.
+// `cst_finish` on success, `cst_demote` on failure. BOTH exits are appends — the failing one
+// appends an `Event::Demote` naming its own start, and materialization's canonicalization pass
+// applies it — so the bracket obeys ONE rollback law whichever exit it took (the law lives in
+// `cst/event.rs`). These cells hold the properties that make it so: the abandoned node
+// materializes into nothing, the demote survives exactly the truncations that keep it and dies
+// with the ones that do not, a rollback into the bracket's own window reopens the node on
+// either exit, and every misuse of the handback is refused — in every build at the wall, or at
+// the two calibrated tiers for the two the slot cannot witness.
 
-/// The demote is an **in-place** kind rewrite: no extra event, no journal entry, and the slot
-/// materializes into nothing — the abandoned node leaves no trace at all.
+/// The demote leaves the buffer **balanced and append-only**: one extra event, no journal
+/// entry, no interior write, and the abandoned node materializes into nothing.
 #[test]
 fn demote_materialises_as_inert() {
   let mut sink = verbose_sink("a");
@@ -424,21 +426,22 @@ fn demote_materialises_as_inert() {
     sink.events(),
     &[
       Event::StartNode {
-        kind: TOMBSTONE,
+        kind: K_NODE,
         forward_parent: None
       },
       Event::Token {
         kind: K_TOK,
         span: span(0, 1)
       },
+      Event::Demote { target: 0 },
     ],
-    "the slot reverts in place — the buffer neither grows nor shifts"
+    "the demote APPENDS: the slot keeps its real kind for the whole parse, and the decision \
+     rides an event that a rollback can truncate"
   );
   assert_eq!(
     sink.journal_len(),
     0,
-    "the demote is structurally unjournaled: a truncation that would want it undone erases \
-     the slot it was made on"
+    "an appended event needs no undo entry — the truncation IS the undo"
   );
 
   let (green, _emitter) = sink.finish(K_ROOT);
@@ -448,18 +451,19 @@ fn demote_materialises_as_inert() {
   assert_eq!(
     root.children().count(),
     0,
-    "the abandoned node materializes into nothing"
+    "canonicalization tombstones the slot; the abandoned node materializes into nothing"
   );
   assert_eq!(root.children_with_tokens().count(), 1, "the token is loose");
 }
 
-/// **Why the four-corpora byte-identity gate can hold at all.** The two brackets' failing
-/// exits converge on the *same buffer*: the retro bracket leaves a `cst_mark` tombstone
-/// unspent, the up-front bracket demotes its own start back to one, and nothing — not the
-/// events, not the journal — separates the two. So converting `ParseInput for Node` changes
-/// the successful path's encoding only, and leaves the error path bit-for-bit alone.
+/// **Why the four-corpora byte-identity gate can hold at all.** The two brackets' failing exits
+/// converge — at *materialization*, not in the buffer. The retro bracket leaves a `cst_mark`
+/// tombstone unspent; the up-front bracket leaves a real-kind start plus the `Demote` that
+/// names it, which canonicalization turns into exactly that tombstone before the walk begins.
+/// So converting `ParseInput for Node` leaves every tree the error path produces bit-for-bit
+/// alone, which is what the corpus hashes measure.
 #[test]
-fn a_demoted_start_and_an_unspent_mark_leave_the_identical_buffer() {
+fn a_demoted_start_and_an_unspent_mark_materialize_identically() {
   let mut up_front = verbose_sink("a");
   let mark = up_front.cst_start(K_NODE);
   up_front.record_token(&MiniTok(b'a'), &span(0, 1));
@@ -469,21 +473,29 @@ fn a_demoted_start_and_an_unspent_mark_leave_the_identical_buffer() {
   let _unspent = retro.cst_mark();
   retro.record_token(&MiniTok(b'a'), &span(0, 1));
 
-  assert_eq!(
+  assert_ne!(
     up_front.events(),
     retro.events(),
-    "the up-front bracket's Err exit is the retro bracket's Err exit, byte for byte"
+    "the buffers deliberately differ: the demote is an event, not a rewrite"
   );
   assert_eq!(
     up_front.journal_len(),
     retro.journal_len(),
     "both journal 0"
   );
+
+  let (up_front_green, _emitter) = up_front.finish(K_ROOT);
+  let (retro_green, _emitter) = retro.finish(K_ROOT);
+  assert_eq!(
+    up_front_green.expect("balanced"),
+    retro_green.expect("balanced"),
+    "the up-front bracket's Err exit materializes the retro bracket's Err exit, byte for byte"
+  );
 }
 
-/// A truncation **strictly above** the demoted slot leaves the demotion standing. That is the
-/// direction the law argues for: the bracket already exited with an error, no rewind re-runs an
-/// exited frame, so un-demoting would resurrect a dangling open node whose finish never fires.
+/// A truncation **strictly above** the `Demote` event leaves the demotion standing — the
+/// ordinary direction: the bracket exited with an error and nothing rewound into its window,
+/// so the abandoned node stays abandoned.
 #[test]
 fn demote_survives_a_truncation_strictly_above_it() {
   let mut sink = verbose_sink("ab");
@@ -498,19 +510,20 @@ fn demote_survives_a_truncation_strictly_above_it() {
     sink.events(),
     &[
       Event::StartNode {
-        kind: TOMBSTONE,
+        kind: K_NODE,
         forward_parent: None
       },
       Event::Token {
         kind: K_TOK,
         span: span(0, 1)
       },
+      Event::Demote { target: 0 },
     ],
-    "the rewind dropped the events above the mark and left the demotion in place"
+    "the rewind dropped the events above the mark and left the demote event standing"
   );
   // Balance is checked before the gap latch is consumed, so the only complaint being the
-  // rewound `b`'s uncovered byte IS the still-balanced proof: an un-demote on rewind would
-  // have reopened a node with no finish and answered `UnclosedNodes` first.
+  // rewound `b`'s uncovered byte IS the still-balanced proof: a surviving Start with no
+  // surviving Demote would have answered `UnclosedNodes` first.
   let (green, _emitter) = sink.finish(K_ROOT);
   assert_eq!(
     green.expect_err("the rewound token leaves byte 1 uncovered"),
@@ -619,26 +632,208 @@ fn demote_with_the_tombstone_kind_panics() {
   sink.cst_demote(mark, TOMBSTONE);
 }
 
-/// Single-use falls out of the same check: the first demote leaves a tombstone behind, so a
-/// second one finds no start of the expected kind.
+/// **Single-use, at the two tiers the appended encoding leaves available.** A demote no longer
+/// rewrites the slot, so the slot cannot witness that it was already demoted and the
+/// every-build content wall has nothing to read — the same reason it cannot see a finish. The
+/// debug tier catches it at cause: the prior `Demote` is a −1 above the mark, so the exact
+/// suffix recount dips.
+///
+/// That is a *narrowing* of the every-build refusal this bracket shipped with, taken
+/// deliberately in exchange for one rollback law across both exits, and the release tier below
+/// is what keeps it out of the silent class.
 #[test]
-#[should_panic(expected = "cst_demote on a mark")]
-fn a_second_demote_of_one_mark_panics() {
+#[cfg(debug_assertions)]
+#[should_panic(expected = "a DOUBLE demote")]
+fn a_second_demote_of_one_mark_panics_in_debug() {
   let mut sink = verbose_sink("");
   let mark = sink.cst_start(K_NODE);
   sink.cst_demote(mark, K_NODE);
   sink.cst_demote(mark, K_NODE);
 }
 
-/// **The one misuse the slot cannot witness**, caught at cause — in a debug build. `cst_finish`
-/// is appended *above* the mark's slot, so after it the slot still holds a live `StartNode` of
-/// exactly the demoted kind: identity, bounds, era and content all pass. Only a recount of the
-/// events above the mark sees the close, and that recount is `cfg(debug_assertions)`-only
-/// because the release backstop is a typed refusal rather than a wrong tree — pinned by
+/// **…and what a release build does with the double-demote residue instead**: canonicalization
+/// refuses it, typed, through both doors. The buffer is built *directly* so the cell runs in
+/// every build — in a debug build the misuse is refused at cause by the cell above and never
+/// reaches materialization at all — and byte for byte it is what
+/// `cst_start(K_NODE); cst_demote(mark, K_NODE); cst_demote(mark, K_NODE)` leaves behind.
+///
+/// The second pass over one target finds the slot its predecessor already tombstoned; there is
+/// no reading of that buffer under which two brackets closed, so it is corruption rather than
+/// incompleteness and `finish_partial` refuses it too.
+#[test]
+fn the_double_demote_residue_is_refused_typed_through_both_doors() {
+  fn residue(src: &str) -> VerboseSink<'_> {
+    let mut sink = verbose_sink(src);
+    sink.push_raw_event_for_tests(Event::StartNode {
+      kind: K_NODE,
+      forward_parent: None,
+    });
+    sink.record_token(&MiniTok(b'a'), &span(0, 1));
+    // Raw, because in a debug build `cst_demote`'s own suffix scan refuses the second one —
+    // which is the very misuse this cell is about.
+    sink.push_raw_event_for_tests(Event::Demote { target: 0 });
+    sink.push_raw_event_for_tests(Event::Demote { target: 0 });
+    sink
+  }
+
+  let (green, _emitter) = residue("a").finish(K_ROOT);
+  assert_eq!(
+    green.expect_err("the strict door refuses the second demote"),
+    FinishError::StaleDemote {
+      index: 3,
+      target: 0
+    }
+  );
+
+  let (green, _emitter) = residue("a").finish_partial(K_ROOT);
+  assert_eq!(
+    green.expect_err("and so does the tooling door — one canonicalization, one verdict"),
+    FinishError::StaleDemote {
+      index: 3,
+      target: 0
+    },
+    "close_open_nodes relaxes end-of-stream opens, not a stream that closed one node twice"
+  );
+}
+
+/// The canonicalization wall is positional, so it also backstops every shape the emission walls
+/// already refuse in every build but the raw injection hook can still construct: a `Demote`
+/// naming a `cst_mark` tombstone, and one naming a slot that is not a node start at all.
+#[test]
+fn canonicalization_refuses_a_demote_that_names_no_live_start() {
+  let mut sink = verbose_sink("a");
+  let _tomb = sink.cst_mark();
+  sink.record_token(&MiniTok(b'a'), &span(0, 1));
+  sink.push_raw_event_for_tests(Event::Demote { target: 0 });
+  let (green, _emitter) = sink.finish(K_ROOT);
+  assert_eq!(
+    green.expect_err("a cst_mark tombstone is spent by cst_start_at, never demoted"),
+    FinishError::StaleDemote {
+      index: 2,
+      target: 0
+    }
+  );
+
+  let mut sink = verbose_sink("a");
+  sink.record_token(&MiniTok(b'a'), &span(0, 1));
+  sink.push_raw_event_for_tests(Event::Demote { target: 0 });
+  let (green, _emitter) = sink.finish(K_ROOT);
+  assert_eq!(
+    green.expect_err("the target holds a token, not a start"),
+    FinishError::StaleDemote {
+      index: 1,
+      target: 0
+    }
+  );
+
+  let mut sink = verbose_sink("a");
+  sink.record_token(&MiniTok(b'a'), &span(0, 1));
+  sink.push_raw_event_for_tests(Event::Demote { target: 99 });
+  let (green, _emitter) = sink.finish(K_ROOT);
+  assert_eq!(
+    green.expect_err("out of bounds"),
+    FinishError::StaleDemote {
+      index: 1,
+      target: 99
+    }
+  );
+
+  // …and the `forward_parent: None` half of the same predicate, which the emission walls make
+  // unreachable (only `cst_start_at` writes that field, and its wall demands a tombstone) and
+  // which is therefore raw-injectable only. It is a typed refusal rather than the debug
+  // `forward_parent` canary the eager encoding carried: the demote does not own that slot.
+  let mut sink = verbose_sink("a");
+  sink.push_raw_event_for_tests(Event::StartNode {
+    kind: K_NODE,
+    forward_parent: NonZeroU32::new(1),
+  });
+  sink.record_token(&MiniTok(b'a'), &span(0, 1));
+  sink.push_raw_event_for_tests(Event::Demote { target: 0 });
+  let (green, _emitter) = sink.finish(K_ROOT);
+  assert_eq!(
+    green.expect_err("a real-kind start carrying a forward_parent is not this demote's own"),
+    FinishError::StaleDemote {
+      index: 2,
+      target: 0
+    }
+  );
+}
+
+/// **The interleaved-exit shape, and what release actually does with it.** Two brackets whose
+/// closings cross — the enclosing start demoted while the inner one is still open — is the third
+/// route that dips `cst_demote`'s debug suffix recount, and the only one of the three that is
+/// *not* a misuse. Canonicalization is positional and order-blind, so it tombstones both slots
+/// whichever order the two `Demote`s arrive in, and the two buffers materialize the **same
+/// tree**.
+///
+/// That is the fact the debug assert's message stakes, so it is pinned rather than asserted.
+/// Both buffers are built raw, because in a debug build the interleaved order is refused at the
+/// emit site (`raw_interleaved_bracket_exits_panic_in_debug`, in `tests/parser_node.rs`) and
+/// would never reach materialization at all.
+#[test]
+fn interleaved_and_innermost_first_demotes_materialize_the_same_tree() {
+  fn built(src: &str, first: u64, second: u64) -> VerboseSink<'_> {
+    let mut sink = verbose_sink(src);
+    sink.push_raw_event_for_tests(Event::StartNode {
+      kind: K_NODE,
+      forward_parent: None,
+    });
+    sink.push_raw_event_for_tests(Event::StartNode {
+      kind: K_LIST,
+      forward_parent: None,
+    });
+    sink.record_token(&MiniTok(b'a'), &span(0, 1));
+    sink.push_raw_event_for_tests(Event::Demote { target: first });
+    sink.push_raw_event_for_tests(Event::Demote { target: second });
+    sink.record_token(&MiniTok(b'b'), &span(1, 2));
+    sink
+  }
+
+  // Interleaved: the ENCLOSING start (slot 0) closes first, while slot 1 is still open.
+  let (interleaved, _emitter) = built("ab", 0, 1).finish(K_ROOT);
+  // Innermost-first: the order the blessed bracket produces structurally.
+  let (innermost_first, _emitter) = built("ab", 1, 0).finish(K_ROOT);
+
+  let interleaved = interleaved.expect("release admits the interleaved order");
+  let innermost_first = innermost_first.expect("and the innermost-first order, as always");
+  assert_eq!(
+    shape(&interleaved),
+    "Root[Tok\"a\" Tok\"b\"]",
+    "both brackets abandoned: no node at all, and losslessness holds"
+  );
+  assert_eq!(
+    interleaved, innermost_first,
+    "the two closing orders are byte-identical after canonicalization — the debug refusal of \
+     the interleaved order is a strictness choice on the raw surface, not early detection of a \
+     release defect"
+  );
+}
+
+/// The traded-away affordance, pinned rather than left to be discovered: a **demoted** start
+/// mark is not a retro-wrap anchor. The slot keeps its real kind for the whole parse now, so
+/// `cst_start_at`'s tombstone wall refuses it exactly as it refuses an un-demoted start mark
+/// (`start_at_on_an_up_front_start_mark_panics` below). Recovery tooling that wants to wrap an
+/// abandoned region mints its own `cst_mark`.
+#[test]
+#[should_panic(expected = "came from `cst_start`")]
+fn start_at_on_a_demoted_start_mark_panics() {
+  let mut sink = verbose_sink("a");
+  let mark = sink.cst_start(K_NODE);
+  sink.record_token(&MiniTok(b'a'), &span(0, 1));
+  sink.cst_demote(mark, K_NODE);
+  sink.cst_start_at(mark, K_WRAP);
+}
+
+/// **The first misuse the slot cannot witness**, caught at cause — in a debug build. Nothing
+/// ever rewrites the slot: `cst_finish` is appended *above* it, so afterwards the slot still
+/// holds a live `StartNode` of exactly the demoted kind and identity, bounds, era and content
+/// all pass. Only a recount of the events above the mark sees the close, and that recount is
+/// `cfg(debug_assertions)`-only because the release backstop is a typed refusal rather than a
+/// wrong tree — pinned by
 /// `the_finished_then_demoted_residue_is_refused_typed_through_both_doors` below.
 #[test]
 #[cfg(debug_assertions)]
-#[should_panic(expected = "already closed")]
+#[should_panic(expected = "already took its SUCCESS exit")]
 fn demote_of_a_finished_start_panics_in_debug() {
   let mut sink = verbose_sink("a");
   let mark = sink.cst_start(K_NODE);
@@ -653,23 +848,28 @@ fn demote_of_a_finished_start_panics_in_debug() {
 /// The buffer is built *directly*, not by committing the misuse, and that is what lets the cell
 /// run in **every** build: in a debug build the misuse is refused at cause by the cell above and
 /// never reaches materialization at all. Byte for byte, this is what
-/// `cst_start(K_NODE); token; cst_finish(K_NODE); cst_demote(mark, K_NODE)` leaves behind.
+/// `cst_start(K_NODE); token; cst_finish(K_NODE); cst_demote(mark, K_NODE)` leaves behind — the
+/// real start, its finish, and the appended demote naming it.
 ///
-/// The counting argument the docs make: demoting a finished start removes one frame **push**
-/// (the start's `depth_delta` drops from 1 to 0) and removes no **pop**, so pops exceed pushes
-/// and the replay walk must underflow. `finish` and `finish_partial` are one walk over that
-/// buffer — `close_open_nodes` relaxes end-of-stream opens and gap tiling, never balance — so
-/// **both** doors refuse, typed. There is no door through which this residue becomes a tree.
+/// The counting argument the docs make: canonicalization applies the demote, so the start's
+/// `depth_delta` drops from 1 to 0 — one frame **push** removed and no **pop** — and pops
+/// therefore exceed pushes and the replay walk must underflow. `finish` and `finish_partial`
+/// are one walk over that canonicalized buffer — `close_open_nodes` relaxes end-of-stream opens
+/// and gap tiling, never balance — so **both** doors refuse, typed. There is no door through
+/// which this residue becomes a tree.
 #[test]
 fn the_finished_then_demoted_residue_is_refused_typed_through_both_doors() {
   fn residue(src: &str) -> VerboseSink<'_> {
     let mut sink = verbose_sink(src);
-    // The demoted slot: byte-identical to a `cst_start` whose kind was rewritten back.
-    let _demoted = sink.cst_mark();
+    sink.push_raw_event_for_tests(Event::StartNode {
+      kind: K_NODE,
+      forward_parent: None,
+    });
     sink.record_token(&MiniTok(b'a'), &span(0, 1));
-    // The finish the demote left behind. Raw, because `cst_finish`'s own debug wall refuses to
-    // append a close with nothing open — which is the very imbalance this cell is about.
+    // The finish the demote left behind. Raw throughout, because the misuse is refused at cause
+    // in a debug build — which is the very imbalance this cell is about.
     sink.push_raw_event_for_tests(Event::FinishNode { kind: K_NODE });
+    sink.push_raw_event_for_tests(Event::Demote { target: 0 });
     sink
   }
 
@@ -677,7 +877,7 @@ fn the_finished_then_demoted_residue_is_refused_typed_through_both_doors() {
     residue("a").events(),
     &[
       Event::StartNode {
-        kind: TOMBSTONE,
+        kind: K_NODE,
         forward_parent: None
       },
       Event::Token {
@@ -685,8 +885,10 @@ fn the_finished_then_demoted_residue_is_refused_typed_through_both_doors() {
         span: span(0, 1)
       },
       Event::FinishNode { kind: K_NODE },
+      Event::Demote { target: 0 },
     ],
-    "the residue is the post-misuse buffer exactly: demoted slot, token, surviving finish"
+    "the residue is the post-misuse buffer exactly: the start, its token, the finish that \
+     closed it, and the demote that came after"
   );
 
   let (green, _emitter) = residue("a").finish(K_ROOT);
@@ -709,14 +911,16 @@ fn the_finished_then_demoted_residue_is_refused_typed_through_both_doors() {
 /// close. The new scan carries no baseline — it recounts the live suffix — and this cell is the
 /// busiest legal frame that recount has to admit.
 ///
-/// Every shape here puts a `FinishNode` above the mark's slot without closing the marked node: a
+/// Every shape here puts a −1 above the mark's slot without closing the marked node: a
 /// completed child (+1 then −1, never dipping), an unspent `cst_mark` tombstone (0 outright),
-/// and a completed retro wrap whose `StartAt` sits above the mark in **emission** order whatever
-/// it hoists to, so its +1 still precedes its −1 there. The demote must be silent, and the
-/// buffer must still materialize.
+/// a completed retro wrap whose `StartAt` sits above the mark in **emission** order whatever it
+/// hoists to (so its +1 still precedes its −1 there), and — the shape the appended encoding
+/// adds — a **nested bracket that took its own failing exit**, which is a `Start(+1)` followed
+/// by its own `Demote(−1)` and nets zero exactly like the completed child. The outer demote
+/// must be silent, and the buffer must still materialize.
 #[test]
 fn demote_scan_admits_a_busy_legal_frame() {
-  let mut sink = verbose_sink("abc");
+  let mut sink = verbose_sink("abcd");
   let outer = sink.cst_start(K_NODE);
 
   // A completed child node.
@@ -724,13 +928,18 @@ fn demote_scan_admits_a_busy_legal_frame() {
   sink.record_token(&MiniTok(b'a'), &span(0, 1));
   sink.cst_finish(K_LIST);
 
+  // A nested bracket that FAILED: its own Start/Demote pair nets zero above the outer mark.
+  let inner = sink.cst_start(K_LIST);
+  sink.record_token(&MiniTok(b'b'), &span(1, 2));
+  sink.cst_demote(inner, K_LIST);
+
   // An unspent tombstone, left to materialize into nothing.
   let _unspent = sink.cst_mark();
-  sink.record_token(&MiniTok(b'b'), &span(1, 2));
+  sink.record_token(&MiniTok(b'c'), &span(2, 3));
 
   // A completed retro wrap, hoisted below its own `StartAt` at materialization.
   let anchor = sink.cst_mark();
-  sink.record_token(&MiniTok(b'c'), &span(2, 3));
+  sink.record_token(&MiniTok(b'd'), &span(3, 4));
   sink.cst_start_at(anchor, K_WRAP);
   sink.cst_finish(K_WRAP);
 
@@ -739,11 +948,11 @@ fn demote_scan_admits_a_busy_legal_frame() {
 
   let (green, _emitter) = sink.finish(K_ROOT);
   let green = green.expect("a legal demote over a busy frame still materializes");
-  assert_eq!(text(green.clone()), "abc", "losslessness holds");
+  assert_eq!(text(green.clone()), "abcd", "losslessness holds");
   assert_eq!(
     shape(&green),
-    "Root[List[Tok\"a\"] Tok\"b\" Wrap[Tok\"c\"]]",
-    "the demoted outer node vanishes; every completed structure above it survives"
+    "Root[List[Tok\"a\"] Tok\"b\" Tok\"c\" Wrap[Tok\"d\"]]",
+    "both demoted nodes vanish; every completed structure above them survives"
   );
 }
 
@@ -785,6 +994,193 @@ fn a_start_left_open_by_an_escaping_panic_is_refused_by_finish_and_closed_by_fin
   assert_eq!(text(green.clone()), "a", "losslessness holds either way");
   let root = tree(green);
   assert_eq!(root.first_child().expect("Root[Node]").kind(), K_NODE);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ONE BRACKET, TWO EXITS, ONE ROLLBACK LAW
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// These five cells are the adversarial-review evidence that decided the appended encoding,
+// kept as pins. The finding they were built to demonstrate — a rollback whose target lands
+// BETWEEN a `cst_start` and its failing exit — is what an in-place kind rewrite got wrong: the
+// truncation kept the slot and kept the rewrite, so `finish` succeeded with the node silently
+// gone where the restore contract promised it open again. The success exit never had that
+// problem, because its `FinishNode` is an append the truncation removes.
+//
+// With both exits appended the two are the same law, and the first two cells below are the
+// former defect stated as its correct outcome.
+
+/// **The finding, inverted.** A checkpoint captured between `cst_start` and `cst_demote`
+/// promised a buffer whose slot holds a live `StartNode(K_NODE)`. The rollback truncates the
+/// `Demote` and delivers exactly that: the node is open again, and a `finish` that follows is
+/// answered with the typed refusal the restore contract implies.
+///
+/// Under the eager in-place rewrite this cell read the other way — the tombstone survived the
+/// rollback, the retry re-balanced the buffer, and `finish` returned a tree with the node
+/// silently omitted. Nothing downstream could detect that; this is the whole reason the
+/// demotion moved onto an event.
+#[test]
+fn a_rollback_into_the_demote_window_reopens_the_node() {
+  let mut sink = verbose_sink("ab");
+  let m = sink.cst_start(K_NODE); // slot 0
+  let ckp = Emitter::<MiniLexer<'_>>::checkpoint(&sink); // len 1: [StartNode(K_NODE)]
+  sink.record_token(&MiniTok(b'a'), &span(0, 1)); // len 2
+  sink.cst_demote(m, K_NODE); // len 3 — an APPEND above the checkpoint
+  rewind(&mut sink, ckp); // truncate to len 1
+
+  assert_eq!(
+    sink.events(),
+    &[Event::StartNode {
+      kind: K_NODE,
+      forward_parent: None
+    }],
+    "exact: the rollback restored the buffer the capture promised, demote and all"
+  );
+
+  // The retry that does not re-close. Under the eager rewrite this buffer was BALANCED and
+  // `finish` handed back a tree; now the open node is still open and the refusal is typed.
+  sink.record_token(&MiniTok(b'a'), &span(0, 1));
+  sink.record_token(&MiniTok(b'b'), &span(1, 2));
+  let (green, _emitter) = sink.finish(K_ROOT);
+  assert_eq!(
+    green.expect_err("the reopened node is correctly reported open"),
+    FinishError::UnclosedNodes { open: 1 }
+  );
+}
+
+/// **The boundary case that killed the journal remedy, dissolved by construction.** A
+/// write-time-length journal cannot fix an in-place demote, because the eager demote appended
+/// *nothing*: capture-at-L → demote-at-L → rewind-to-L is a lawful rewind-to-current, a total
+/// no-op that runs no truncation and no journal replay, so no length-keyed entry can tell a
+/// capture taken before the demote from one taken after it. That is also the MOST common
+/// failure shape (the inner parser fails before consuming, with a point opened at entry).
+///
+/// An appended demote ticks the length clock, so the two captures are no longer at the same
+/// length and no rewind can straddle the demote invisibly.
+#[test]
+fn a_demote_ticks_the_length_clock_so_no_rewind_can_straddle_it() {
+  let mut sink = verbose_sink("ab");
+  let m = sink.cst_start(K_NODE); // slot 0
+  let ckp = Emitter::<MiniLexer<'_>>::checkpoint(&sink); // len 1
+  sink.cst_demote(m, K_NODE); // len 2 — the clock ticked
+  assert_eq!(
+    sink.events().len(),
+    2,
+    "the failing exit is an event, so the capture at len 1 is strictly below it"
+  );
+  rewind(&mut sink, ckp); // a real truncation, not a rewind-to-current
+
+  assert_eq!(
+    sink.events(),
+    &[Event::StartNode {
+      kind: K_NODE,
+      forward_parent: None
+    }],
+    "the capture promised StartNode(K_NODE) and got it back"
+  );
+}
+
+/// The **success exit** under the same drive, unchanged — the precedent the failing exit now
+/// matches rather than contradicts. The finish is an append, the rollback into the window
+/// truncates it, the open node returns, and the resumed window may lawfully re-close (the
+/// `#98` cross-checkpoint-close clause).
+#[test]
+fn the_success_exit_rollback_into_the_window_is_exact_and_reclosable() {
+  let mut sink = verbose_sink("ab");
+  let _m = sink.cst_start(K_NODE);
+  let ckp = Emitter::<MiniLexer<'_>>::checkpoint(&sink);
+  sink.record_token(&MiniTok(b'a'), &span(0, 1));
+  sink.cst_finish(K_NODE); // success exit: an append
+  rewind(&mut sink, ckp); // rollback into the window
+  assert_eq!(
+    sink.events(),
+    &[Event::StartNode {
+      kind: K_NODE,
+      forward_parent: None
+    }],
+    "exact: the open node is back"
+  );
+  sink.record_token(&MiniTok(b'a'), &span(0, 1));
+  sink.record_token(&MiniTok(b'b'), &span(1, 2));
+  sink.cst_finish(K_NODE); // the reopened frame re-closes — legal per #98
+  let (green, _emitter) = sink.finish(K_ROOT);
+  let root = tree(green.expect("balanced"));
+  assert_eq!(
+    root.first_child().expect("Root[Node]").kind(),
+    K_NODE,
+    "same drive, success exit: the node survives the window rollback"
+  );
+}
+
+/// …and the failing exit's twin of that re-close, which under the eager rewrite was a **misuse
+/// caught by a debug wall**: a continuation that trusted the restore law and re-closed the
+/// promised node was closing a node the buffer no longer had open. It is now simply correct —
+/// the node really is open again, the finish really does close it, and the tree is the one the
+/// restore contract described.
+#[test]
+fn a_reclose_after_a_rollback_into_the_demote_window_is_legal() {
+  let mut sink = verbose_sink("ab");
+  let m = sink.cst_start(K_NODE);
+  let ckp = Emitter::<MiniLexer<'_>>::checkpoint(&sink);
+  sink.record_token(&MiniTok(b'a'), &span(0, 1));
+  sink.cst_demote(m, K_NODE);
+  rewind(&mut sink, ckp);
+
+  sink.record_token(&MiniTok(b'a'), &span(0, 1));
+  sink.record_token(&MiniTok(b'b'), &span(1, 2));
+  sink.cst_finish(K_NODE); // trusts the promise — and the promise is now true
+  let (green, _emitter) = sink.finish(K_ROOT);
+  let green = green.expect("balanced");
+  assert_eq!(text(green.clone()), "ab", "losslessness holds");
+  assert_eq!(
+    shape(&green),
+    "Root[Node[Tok\"a\" Tok\"b\"]]",
+    "the resumed window re-closed the node the rollback reopened"
+  );
+}
+
+/// **E4, healed as a corollary.** A live row between the slot and the exit freezes a depth over
+/// the prefix below it, and the eager rewrite falsified that frozen fact in place: the row went
+/// on claiming depth 1 over a prefix whose start had become a tombstone, which masked
+/// `cst_finish`'s debug underflow wall and cost the at-cause tier.
+///
+/// With the demotion on an event, a frozen depth stays true because both the `+1` start and the
+/// `−1` demote are *events* — nothing below a live row can change under it. The row here
+/// survives the rollback, still reads 1, and the finish it governs is correctly admitted.
+#[test]
+fn a_frozen_row_depth_stays_true_across_a_demote_and_its_rollback() {
+  let mut sink = verbose_sink("ab");
+  let m = sink.cst_start(K_NODE); // slot 0
+  let _outer = Emitter::<MiniLexer<'_>>::checkpoint(&sink); // row(mark 1, depth 1) — stays live
+  sink.record_token(&MiniTok(b'a'), &span(0, 1)); // len 2
+  let ckp = Emitter::<MiniLexer<'_>>::checkpoint(&sink); // row(mark 2, depth 1)
+  sink.record_token(&MiniTok(b'b'), &span(1, 2)); // len 3
+  sink.cst_demote(m, K_NODE); // len 4 — appended, ABOVE both rows
+  rewind(&mut sink, ckp); // spends row(mark 2), keeps row(mark 1)
+
+  assert_eq!(
+    sink.events(),
+    &[
+      Event::StartNode {
+        kind: K_NODE,
+        forward_parent: None
+      },
+      Event::Token {
+        kind: K_TOK,
+        span: span(0, 1)
+      },
+    ],
+    "the demote went with the rollback; the surviving row's prefix is untouched"
+  );
+
+  // The surviving row froze depth 1 over `[StartNode(K_NODE)]`, and that is still the truth,
+  // so this finish is admitted rather than masked — the debug wall it consults is exact.
+  sink.record_token(&MiniTok(b'b'), &span(1, 2));
+  sink.cst_finish(K_NODE);
+  let (green, _emitter) = sink.finish(K_ROOT);
+  let green = green.expect("balanced");
+  assert_eq!(text(green.clone()), "ab");
+  assert_eq!(shape(&green), "Root[Node[Tok\"a\" Tok\"b\"]]");
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/tokora/src/emitter/cst.rs
+++ b/tokora/src/emitter/cst.rs
@@ -62,7 +62,11 @@ use super::*;
 /// Two shapes are worth naming:
 ///
 /// - a **decline or error-unwind** between a start and its finish is safe *when the pair is
-///   emitted by a both-exits bracket* (the `labelled` precedent); raw callers own that duty;
+///   emitted by a both-exits bracket* (the `labelled` precedent); raw callers own that duty.
+///   A start has **two** closing exits, and the bracket owes exactly one of them:
+///   [`cst_finish`](Self::cst_finish) on success, [`cst_demote`](Self::cst_demote) on
+///   failure — the latter spending the mark `cst_start` handed back, which is why it hands
+///   one back at all;
 /// - a **session point rolled back across a finished node** truncates the finish but not the
 ///   start — legal, and reported by materialization as a leftover open, per the
 ///   `begin_point` settle-your-points clause.
@@ -85,16 +89,41 @@ use super::*;
 /// minted at each node open and consumed at its finish — which costs a mark-like allocation
 /// per node open on the hot emit path. The kind is the cheap 90%; the brand is not paid for.
 pub trait CstEmitter<'a, L, Lang: ?Sized = ()>: Emitter<'a, L, Lang> {
-  /// Opens a node of `kind`; the matching [`cst_finish`](Self::cst_finish) closes it.
+  /// Opens a node of `kind`, returning the [`EventMark`] naming the slot it appended; the
+  /// matching [`cst_finish`](Self::cst_finish) closes it, and
+  /// [`cst_demote`](Self::cst_demote) un-opens it on a failing exit.
   ///
   /// `kind` is a dialect u16 from the unified kind space; the [`TOMBSTONE`](crate::cst::event::TOMBSTONE)
   /// value is reserved and rejected by recording sinks.
+  ///
+  /// # The handback, and who needs it
+  ///
+  /// The returned mark exists for the **both-exits bracket**: `node(kind, p)` names the kind
+  /// up front and, when `p` returns `Err`, spends the mark on `cst_demote` so the opened slot
+  /// reverts to an inert tombstone. A caller that never fails — or that closes with
+  /// `cst_finish` on every path — may discard it; an unspent start mark costs nothing beyond
+  /// the open node it names, which the stream must still balance.
+  ///
+  /// It is deliberately the **same** [`EventMark`] type [`cst_mark`](Self::cst_mark) hands
+  /// out, not a second position handle: one positional-mark surface, one staleness rule, one
+  /// validation wall. The two provenances are still distinguishable at a recording sink, and
+  /// the spend verbs do not cross — [`cst_start_at`](Self::cst_start_at) refuses a start mark
+  /// at its tombstone wall, and `cst_demote` refuses a `cst_mark` tombstone at its kind check
+  /// *and* refuses the reserved tombstone kind as an argument, so neither verb can be talked
+  /// into the other's slot.
+  ///
+  /// The default returns an **inert** mark (no event channel to name): the same value
+  /// [`cst_mark`](Self::cst_mark) defaults to, and just as unspendable on a recording sink.
+  /// An emitter with no event channel of its own should not override this method at all; a
+  /// **wrapper** emitter must forward the inner's return value unchanged, because that value
+  /// is the inner's own slot name and nothing else can stand in for it.
   #[inline(always)]
-  fn cst_start(&mut self, kind: u16)
+  fn cst_start(&mut self, kind: u16) -> EventMark
   where
     L: Lexer<'a>,
   {
     let _ = kind;
+    EventMark::inert()
   }
 
   // There is deliberately **no** `cst_token` here. Tokens reach the event stream through
@@ -119,6 +148,55 @@ pub trait CstEmitter<'a, L, Lang: ?Sized = ()>: Emitter<'a, L, Lang> {
     L: Lexer<'a>,
   {
     let _ = kind;
+  }
+
+  /// Un-opens the node [`cst_start`](Self::cst_start) appended at `mark`: the **failing
+  /// exit** of an up-front bracket, which reverts the slot to an inert tombstone so the
+  /// stream carries no dangling open node.
+  ///
+  /// `kind` is the kind the matching `cst_start` was given — the same identity-by-kind
+  /// argument [`cst_finish`](Self::cst_finish) takes, checked here at the emit site rather
+  /// than at materialization because the mark names the exact slot to check.
+  ///
+  /// A demoted slot is indistinguishable from a never-spent [`cst_mark`](Self::cst_mark)
+  /// tombstone — the error path of the up-front bracket produces the byte-identical event
+  /// buffer the retro bracket's error path produces — so it materializes into nothing and
+  /// pairs with no finish. Indistinguishable is meant literally, and it cuts both ways: the
+  /// mark is *not* inert afterwards. It still names a live tombstone, so
+  /// [`cst_start_at`](Self::cst_start_at) will accept it, and that is coherent rather than a
+  /// gap — retro-wrapping the abandoned region under an error kind is exactly what recovery
+  /// tooling wants a failed bracket to leave behind. What the mark can no longer do is demote
+  /// again: the slot no longer holds a start of its kind.
+  ///
+  /// # Panics
+  ///
+  /// A recording sink validates the mark in **every** build — issued by this sink, in
+  /// bounds, era not invalidated by a later truncation, `kind` not the reserved
+  /// [`TOMBSTONE`](crate::cst::event::TOMBSTONE), and the slot still holding a `StartNode` of
+  /// exactly `kind` — and panics otherwise. This is the savepoint posture
+  /// [`cst_start_at`](Self::cst_start_at) already takes: a stale, foreign, wrong-kind or
+  /// already-**demoted** spend is a parser bug, and rewriting whatever else sits at that index
+  /// is the wrong-tree class nothing downstream can detect. The kind check is what makes a
+  /// `cst_mark` tombstone unspendable here, the mirror of `cst_start_at`'s tombstone wall
+  /// refusing a start mark; the reserved-kind check keeps that true even when the demote
+  /// *names* the tombstone kind, which no `cst_start` could ever have opened.
+  ///
+  /// One misuse is deliberately **not** an every-build panic: demoting a start whose node was
+  /// already **finished**. The slot cannot witness its own close — the finish is appended above
+  /// it — so proving it at the wall would put a scan on the failure path of every grammar. It
+  /// is caught at the two tiers this crate calibrates such checks to instead. A **debug** build
+  /// panics here, at the misuse site, on an exact recount of the events above the mark. A
+  /// **release** build refuses at materialization, typed: the demote removes one frame push and
+  /// no pop, so the replay walk underflows and answers `cst::FinishError::OrphanFinish` — or
+  /// `MismatchedFinish`, when kinds misalign first — through `Cst::finish` **and**
+  /// `Cst::finish_partial` alike, because they are one walk and the partial door relaxes
+  /// end-of-stream opens rather than balance. A silently wrong tree is not among the outcomes.
+  #[inline(always)]
+  fn cst_demote(&mut self, mark: EventMark, kind: u16)
+  where
+    L: Lexer<'a>,
+  {
+    let _ = (mark, kind);
   }
 
   /// Appends an inert tombstone and returns the [`EventMark`] naming it — the anchor for a
@@ -164,7 +242,7 @@ where
   U: CstEmitter<'a, L, Lang>,
 {
   #[inline(always)]
-  fn cst_start(&mut self, kind: u16)
+  fn cst_start(&mut self, kind: u16) -> EventMark
   where
     L: Lexer<'a>,
   {
@@ -177,6 +255,14 @@ where
     L: Lexer<'a>,
   {
     (**self).cst_finish(kind)
+  }
+
+  #[inline(always)]
+  fn cst_demote(&mut self, mark: EventMark, kind: u16)
+  where
+    L: Lexer<'a>,
+  {
+    (**self).cst_demote(mark, kind)
   }
 
   #[inline(always)]

--- a/tokora/src/emitter/cst.rs
+++ b/tokora/src/emitter/cst.rs
@@ -67,9 +67,10 @@ use super::*;
 ///   [`cst_finish`](Self::cst_finish) on success, [`cst_demote`](Self::cst_demote) on
 ///   failure — the latter spending the mark `cst_start` handed back, which is why it hands
 ///   one back at all;
-/// - a **session point rolled back across a finished node** truncates the finish but not the
-///   start — legal, and reported by materialization as a leftover open, per the
-///   `begin_point` settle-your-points clause.
+/// - a **session point rolled back across a closed node** truncates the closing event but not
+///   the start — legal, and reported by materialization as a leftover open, per the
+///   `begin_point` settle-your-points clause. Both exits are appends, so this reads the same
+///   whichever one the bracket took: the rollback truncates it and the node is open again.
 ///
 /// # Identity by kind: what [`cst_finish`](Self::cst_finish)'s argument catches
 ///
@@ -99,8 +100,8 @@ pub trait CstEmitter<'a, L, Lang: ?Sized = ()>: Emitter<'a, L, Lang> {
   /// # The handback, and who needs it
   ///
   /// The returned mark exists for the **both-exits bracket**: `node(kind, p)` names the kind
-  /// up front and, when `p` returns `Err`, spends the mark on `cst_demote` so the opened slot
-  /// reverts to an inert tombstone. A caller that never fails — or that closes with
+  /// up front and, when `p` returns `Err`, spends the mark on `cst_demote`, which appends the
+  /// event that un-opens the slot. A caller that never fails — or that closes with
   /// `cst_finish` on every path — may discard it; an unspent start mark costs nothing beyond
   /// the open node it names, which the stream must still balance.
   ///
@@ -151,22 +152,31 @@ pub trait CstEmitter<'a, L, Lang: ?Sized = ()>: Emitter<'a, L, Lang> {
   }
 
   /// Un-opens the node [`cst_start`](Self::cst_start) appended at `mark`: the **failing
-  /// exit** of an up-front bracket, which reverts the slot to an inert tombstone so the
-  /// stream carries no dangling open node.
+  /// exit** of an up-front bracket, so the stream carries no dangling open node.
   ///
   /// `kind` is the kind the matching `cst_start` was given — the same identity-by-kind
-  /// argument [`cst_finish`](Self::cst_finish) takes, checked here at the emit site rather
-  /// than at materialization because the mark names the exact slot to check.
+  /// argument [`cst_finish`](Self::cst_finish) takes, checked here at the emit site because
+  /// the mark names the exact slot to check.
   ///
-  /// A demoted slot is indistinguishable from a never-spent [`cst_mark`](Self::cst_mark)
-  /// tombstone — the error path of the up-front bracket produces the byte-identical event
-  /// buffer the retro bracket's error path produces — so it materializes into nothing and
-  /// pairs with no finish. Indistinguishable is meant literally, and it cuts both ways: the
-  /// mark is *not* inert afterwards. It still names a live tombstone, so
-  /// [`cst_start_at`](Self::cst_start_at) will accept it, and that is coherent rather than a
-  /// gap — retro-wrapping the abandoned region under an error kind is exactly what recovery
-  /// tooling wants a failed bracket to leave behind. What the mark can no longer do is demote
-  /// again: the slot no longer holds a start of its kind.
+  /// # Append-only, like every other structural decision
+  ///
+  /// A recording sink **appends** an event naming the slot; it does not rewrite the slot. That
+  /// is what gives the bracket's two exits *one* rollback law. Both exits are appends, so a
+  /// rollback whose target lands between the start and the exit truncates the exit and the
+  /// open node returns — the truncate-and-reopen semantics the *session point rolled back
+  /// across a finished node* clause already blesses for `cst_finish`, now equally true of the
+  /// failing exit. An in-place rewrite would not truncate: the rollback would keep the slot
+  /// *and* the rewrite, and the node the restore contract promised was open again would be
+  /// silently gone from the tree.
+  ///
+  /// Materialization applies the demotion, so the abandoned node **materializes identically**
+  /// to a never-spent [`cst_mark`](Self::cst_mark) tombstone: into nothing, pairing with no
+  /// finish. The error paths of the two brackets converge there rather than in the buffer.
+  /// During the parse the slot still holds its real-kind `StartNode`, which has one visible
+  /// consequence: the mark is **not** a retro-wrap anchor afterwards —
+  /// [`cst_start_at`](Self::cst_start_at) refuses it at the tombstone wall, as it refuses any
+  /// start mark. Recovery tooling that wants to wrap an abandoned region takes its own
+  /// `cst_mark` (or the retro bracket) rather than reusing a spent start mark.
   ///
   /// # Panics
   ///
@@ -174,23 +184,37 @@ pub trait CstEmitter<'a, L, Lang: ?Sized = ()>: Emitter<'a, L, Lang> {
   /// bounds, era not invalidated by a later truncation, `kind` not the reserved
   /// [`TOMBSTONE`](crate::cst::event::TOMBSTONE), and the slot still holding a `StartNode` of
   /// exactly `kind` — and panics otherwise. This is the savepoint posture
-  /// [`cst_start_at`](Self::cst_start_at) already takes: a stale, foreign, wrong-kind or
-  /// already-**demoted** spend is a parser bug, and rewriting whatever else sits at that index
-  /// is the wrong-tree class nothing downstream can detect. The kind check is what makes a
-  /// `cst_mark` tombstone unspendable here, the mirror of `cst_start_at`'s tombstone wall
-  /// refusing a start mark; the reserved-kind check keeps that true even when the demote
-  /// *names* the tombstone kind, which no `cst_start` could ever have opened.
+  /// [`cst_start_at`](Self::cst_start_at) already takes: a stale, foreign or wrong-kind spend
+  /// is a parser bug, and naming whatever else sits at that index is the wrong-tree class
+  /// nothing downstream can detect. The kind check is what makes a `cst_mark` tombstone
+  /// unspendable here, the mirror of `cst_start_at`'s tombstone wall refusing a start mark;
+  /// the reserved-kind check keeps that true even when the demote *names* the tombstone kind,
+  /// which no `cst_start` could ever have opened.
   ///
-  /// One misuse is deliberately **not** an every-build panic: demoting a start whose node was
-  /// already **finished**. The slot cannot witness its own close — the finish is appended above
-  /// it — so proving it at the wall would put a scan on the failure path of every grammar. It
-  /// is caught at the two tiers this crate calibrates such checks to instead. A **debug** build
-  /// panics here, at the misuse site, on an exact recount of the events above the mark. A
-  /// **release** build refuses at materialization, typed: the demote removes one frame push and
-  /// no pop, so the replay walk underflows and answers `cst::FinishError::OrphanFinish` — or
-  /// `MismatchedFinish`, when kinds misalign first — through `Cst::finish` **and**
-  /// `Cst::finish_partial` alike, because they are one walk and the partial door relaxes
-  /// end-of-stream opens rather than balance. A silently wrong tree is not among the outcomes.
+  /// Two misuses are deliberately **not** every-build panics, and for one reason: the slot is
+  /// unchanged by a demote, so it cannot witness that it has already been closed. Demoting a
+  /// start whose node was already **finished**, and demoting the same start **twice**, both
+  /// pass the wall in a release build; proving either at the wall would put a scan on the
+  /// failure path of every grammar. They are caught at the two tiers this crate calibrates such
+  /// checks to. A **debug** build panics here, at the misuse site, on an exact recount of the
+  /// events above the mark — a surviving finish and a prior demote are both `−1` there. A
+  /// **release** build refuses at materialization, typed, through `Cst::finish` **and**
+  /// `Cst::finish_partial` alike: `cst::FinishError::OrphanFinish` (or `MismatchedFinish`, when
+  /// kinds misalign first) for the finished-then-demoted residue, whose pops exceed its pushes;
+  /// `cst::FinishError::StaleDemote` for the double demote, refused by the canonicalization
+  /// pass when the second event finds a target the first already tombstoned. A silently wrong
+  /// tree is not among the outcomes.
+  ///
+  /// That debug recount is positional, so it fires on a **third** shape too, and this one is
+  /// not a misuse: demoting a start while a `Demote` of an **enclosing** start already sits
+  /// above it — two brackets whose exits **interleave** instead of nesting. Release admits that
+  /// order and materialises exactly the tree the innermost-first order builds, because
+  /// canonicalization tombstones both slots either way. So the debug tier is deliberately
+  /// **stricter** than the contract: **debug enforces innermost-first closings on this raw
+  /// surface; release admits the out-of-order shape and materialises the same tree.** A grammar
+  /// cannot trip it — `node(kind, p)` mints and spends its mark inside one call frame, so
+  /// nested brackets close last-in-first-out structurally — and a raw caller that hits it
+  /// should emit the two closings innermost-first.
   #[inline(always)]
   fn cst_demote(&mut self, mark: EventMark, kind: u16)
   where

--- a/tokora/src/emitter/cst.rs
+++ b/tokora/src/emitter/cst.rs
@@ -191,6 +191,13 @@ pub trait CstEmitter<'a, L, Lang: ?Sized = ()>: Emitter<'a, L, Lang> {
   /// the reserved-kind check keeps that true even when the demote *names* the tombstone kind,
   /// which no `cst_start` could ever have opened.
   ///
+  /// **Scope: those panics are reachable from the raw surface only.** The blessed
+  /// [`node`](crate::parser::node) bracket cannot reach the stale arm, because staling its mark
+  /// needs a rewind below its own `cst_start`, and the only public verbs that rewind that far
+  /// take a `SessionPointId` whose invariant `'closure` brand cannot cross into a parser frame
+  /// — see *A rollback below the start cannot happen mid-frame* in the
+  /// [`node` module docs](crate::parser::node), which names the compile-fail cases that pin it.
+  ///
   /// Two misuses are deliberately **not** every-build panics, and for one reason: the slot is
   /// unchanged by a demote, so it cannot witness that it has already been closed. Demoting a
   /// start whose node was already **finished**, and demoting the same start **twice**, both

--- a/tokora/src/emitter/cst.rs
+++ b/tokora/src/emitter/cst.rs
@@ -27,22 +27,29 @@ use super::*;
 /// gap-tiled tree. A wrapper must forward
 /// [`Emitter::commit_token`] alongside these methods.
 ///
-/// # Defaulted no-ops: diagnostics-only emitters opt in trivially
+/// # Four defaulted no-ops, one required method: what a diagnostics-only emitter writes
 ///
-/// Every method has an empty (or inert-value) default, so an emitter with no event channel
+/// Four of the five event methods have an empty (or inert-value) default, so an emitter with
+/// no event channel opts in with an `impl` whose entire body is the fifth
 #[cfg_attr(
   any(feature = "std", feature = "alloc"),
-  doc = " opts in with an empty `impl` — the crate does exactly that for [`Fatal`], [`Verbose`],"
+  doc = " — the crate does exactly that for [`Fatal`], [`Verbose`],"
 )]
 #[cfg_attr(
   not(any(feature = "std", feature = "alloc")),
-  doc = " opts in with an empty `impl` — the crate does exactly that for [`Fatal`], `Verbose`,"
+  doc = " — the crate does exactly that for [`Fatal`], `Verbose`,"
 )]
 /// [`Silent`], and [`Ignored`](crate::utils::marker::Ignored). That is what makes *one*
 /// parser assembly serve both configurations: over a plain diagnostics emitter the event
 /// calls compile to nothing (reference-taking signatures, empty inlined bodies — the
 /// zero-cost bar is byte-identical machine code, held by the `__text`-hash standard); over a
 /// recording sink the same calls buffer the tree.
+///
+/// The fifth, [`cst_demote`](Self::cst_demote), is **required**: an implementor writes the
+/// one-line discard itself rather than inheriting it. The asymmetry is a rule, not an
+/// oversight — see *Required, not defaulted* on that method for the failure-direction test
+/// it is the only member of this trait to fail, and for what that test asks of any CST
+/// method added later.
 ///
 /// The recording implementation is the `rowan`-gated `Sink`, which buffers events under
 /// the one emitter checkpoint/rewind mark so backtracking rewinds the tree exactly as it
@@ -158,6 +165,40 @@ pub trait CstEmitter<'a, L, Lang: ?Sized = ()>: Emitter<'a, L, Lang> {
   /// argument [`cst_finish`](Self::cst_finish) takes, checked here at the emit site because
   /// the mark names the exact slot to check.
   ///
+  /// # Required, not defaulted
+  ///
+  /// This is the one method on this trait with **no default body**, so every implementor
+  /// writes it: a diagnostics-only emitter with a one-line discard, a wrapper by forwarding to
+  /// its inner. The other four keep their defaults. The difference is not this method's
+  /// importance — it is the **direction its absence fails in**, and that direction is the rule
+  /// this trait applies to defaults.
+  ///
+  /// Inherit any of the other four alone, over an otherwise-forwarded channel, and the first
+  /// consequence is an **absence**, announced loudly, on a path every test walks: a finish or a
+  /// demote arriving unopened is `cst::FinishError::OrphanFinish` (or `MismatchedFinish`), a
+  /// node nothing ever closes is `UnclosedNodes` on the *first successful* parse, an inert mark
+  /// spent on a recording sink is the identity-wall panic in every build, a swallowed
+  /// retro-wrap lands its paired finish elsewhere as a `MismatchedFinish`. Inherit **this** one
+  /// and the first consequence is a **presence**, silent, on error paths only: nothing happens
+  /// at all until a [`node`](crate::parser::node) fails, and then the channel below keeps a
+  /// `StartNode` open. That stream is byte-identical to the one an escaped panic leaves, so
+  /// `Cst::finish` refuses a grammar that did everything right (`UnclosedNodes`, misattributed)
+  /// and `Cst::finish_partial` materializes the very node the grammar retracted. The same
+  /// byte-identity is why no sink-side check could recover the difference: a sink cannot tell a
+  /// swallowed demote from a legal panic residue, so there is no backstop to fall back on.
+  ///
+  /// [`Emitter::commit_token`] keeps *its* default under this rule rather than in spite of it —
+  /// its inheritance fails toward absence and it has typed finish-time backstops
+  /// (`cst::FinishError::StructureWithoutTokens`, `UncoveredGap`). So: **a method whose default
+  /// cannot be backstopped and whose absence fails toward a silently wrong tree does not get a
+  /// default.** That governs growth as well as today's surface — a CST method added after this
+  /// one either passes the failure-direction test or ships behind a new bound, never as a
+  /// default on this trait.
+  ///
+  /// The cost to an emitter with no event channel is one line, and the line is not noise: such
+  /// an emitter genuinely does discard the failing exit, and now says so where its own reviewer
+  /// can read it, instead of inheriting the decision from a trait it never opened.
+  ///
   /// # Append-only, like every other structural decision
   ///
   /// A recording sink **appends** an event naming the slot; it does not rewrite the slot. That
@@ -222,13 +263,9 @@ pub trait CstEmitter<'a, L, Lang: ?Sized = ()>: Emitter<'a, L, Lang> {
   /// cannot trip it — `node(kind, p)` mints and spends its mark inside one call frame, so
   /// nested brackets close last-in-first-out structurally — and a raw caller that hits it
   /// should emit the two closings innermost-first.
-  #[inline(always)]
   fn cst_demote(&mut self, mark: EventMark, kind: u16)
   where
-    L: Lexer<'a>,
-  {
-    let _ = (mark, kind);
-  }
+    L: Lexer<'a>;
 
   /// Appends an inert tombstone and returns the [`EventMark`] naming it — the anchor for a
   /// later retro-wrap ([`cst_start_at`](Self::cst_start_at)). An unspent mark costs
@@ -313,27 +350,74 @@ where
   }
 }
 
-// The shipped diagnostics-only emitters opt into the event channel with the defaulted
-// no-ops: one parser assembly can then bound `Ctx::Emitter: CstEmitter` and run tree-less
-// (today's behavior, zero cost) or tree-building (a `Sink`) by configuration alone. The
-// wrapper-emitter trap this trait exists to close is untouched: a *wrapper* type gets no
-// blanket opt-in and must implement (and forward) the trait deliberately.
+// The shipped diagnostics-only emitters opt into the event channel with the four defaulted
+// no-ops plus the one body below: one parser assembly can then bound
+// `Ctx::Emitter: CstEmitter` and run tree-less (today's behavior, zero cost) or tree-building
+// (a `Sink`) by configuration alone. The wrapper-emitter trap this trait exists to close is
+// untouched: a *wrapper* type gets no blanket opt-in and must implement (and forward) the
+// trait deliberately.
+//
+// THE DISCARD, WRITTEN OUT FOUR TIMES, AND WHY IT IS NOT DEFAULTED ONCE. These four have no
+// event channel, so the failing exit of a node bracket has nothing to un-open and the right
+// body is empty. A default would spell the same thing in one place — and would then be
+// *inheritable*, which is precisely the property that must not exist: a wrapper emitter over a
+// recording sink inherits it too, and on `node()`'s failing exit its inner keeps a `StartNode`
+// open with no diagnostic anywhere and no possible sink-side backstop (a swallowed demote and
+// a legal escaped-panic residue leave byte-identical streams). Requiring the method costs
+// these four one line each and buys `E0046` at the one place that can tell the two intents
+// apart: the implementor's own impl block. See `CstEmitter::cst_demote`'s *Required, not
+// defaulted* for the failure-direction rule this is an application of.
 
-impl<'a, L, E, Lang: ?Sized> CstEmitter<'a, L, Lang> for Fatal<E, Lang> where
-  Self: Emitter<'a, L, Lang>
+impl<'a, L, E, Lang: ?Sized> CstEmitter<'a, L, Lang> for Fatal<E, Lang>
+where
+  Self: Emitter<'a, L, Lang>,
 {
+  #[inline(always)]
+  fn cst_demote(&mut self, mark: EventMark, kind: u16)
+  where
+    L: Lexer<'a>,
+  {
+    let _ = (mark, kind);
+  }
 }
 
-impl<'a, L, E, Lang: ?Sized> CstEmitter<'a, L, Lang> for Silent<E, Lang> where
-  Self: Emitter<'a, L, Lang>
+impl<'a, L, E, Lang: ?Sized> CstEmitter<'a, L, Lang> for Silent<E, Lang>
+where
+  Self: Emitter<'a, L, Lang>,
 {
+  #[inline(always)]
+  fn cst_demote(&mut self, mark: EventMark, kind: u16)
+  where
+    L: Lexer<'a>,
+  {
+    let _ = (mark, kind);
+  }
 }
 
-impl<'a, L, Lang: ?Sized> CstEmitter<'a, L, Lang> for Ignored where Self: Emitter<'a, L, Lang> {}
+impl<'a, L, Lang: ?Sized> CstEmitter<'a, L, Lang> for Ignored
+where
+  Self: Emitter<'a, L, Lang>,
+{
+  #[inline(always)]
+  fn cst_demote(&mut self, mark: EventMark, kind: u16)
+  where
+    L: Lexer<'a>,
+  {
+    let _ = (mark, kind);
+  }
+}
 
 #[cfg(any(feature = "std", feature = "alloc"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "std", feature = "alloc"))))]
-impl<'a, L, Error, S, Lang: ?Sized> CstEmitter<'a, L, Lang> for Verbose<Error, S, Lang> where
-  Self: Emitter<'a, L, Lang>
+impl<'a, L, Error, S, Lang: ?Sized> CstEmitter<'a, L, Lang> for Verbose<Error, S, Lang>
+where
+  Self: Emitter<'a, L, Lang>,
 {
+  #[inline(always)]
+  fn cst_demote(&mut self, mark: EventMark, kind: u16)
+  where
+    L: Lexer<'a>,
+  {
+    let _ = (mark, kind);
+  }
 }

--- a/tokora/src/emitter/impl_/verbose/record_census.rs
+++ b/tokora/src/emitter/impl_/verbose/record_census.rs
@@ -37,9 +37,10 @@
 //! # Scope
 //!
 //! This census covers `impl_/verbose/**`. One `impl … for Verbose` lives outside it —
-//! `emitter/cst.rs`'s empty `CstEmitter` impl — which carries no diagnostic payload and could
-//! not record if it wanted to (`Verbose::record` is private to this subtree). It is asserted
-//! to contain no emit channel at all, so the scope statement is a test rather than a claim.
+//! `emitter/cst.rs`'s `CstEmitter` impl, whose whole body is the required `cst_demote`
+//! discard — which carries no diagnostic payload and could not record if it wanted to
+//! (`Verbose::record` is private to this subtree). It is asserted to contain no emit channel
+//! at all, so the scope statement is a test rather than a claim.
 //!
 //! Counting is line-based and skips `//`-prefixed lines, so doc references to these names do
 //! not count; only code does. Keep code mentions of the counted names off comment-trailing

--- a/tokora/src/emitter/view.rs
+++ b/tokora/src/emitter/view.rs
@@ -302,13 +302,14 @@ where
   /// Opens a CST node of `kind` — [`CstEmitter::cst_start`], forwarded.
   ///
   /// Raw transport: pair it with [`cst_finish`](Self::cst_finish) through a both-exits bracket, or
-  /// use the `node`-shaped combinators.
+  /// use the `node`-shaped combinators. The returned mark is the failing exit's handle — spend
+  /// it on [`cst_demote`](Self::cst_demote).
   #[inline(always)]
-  pub fn cst_start(&mut self, kind: u16)
+  pub fn cst_start(&mut self, kind: u16) -> EventMark
   where
     E: CstEmitter<'inp, L, Lang>,
   {
-    self.emitter.cst_start(kind);
+    self.emitter.cst_start(kind)
   }
 
   /// Closes the innermost open CST node — [`CstEmitter::cst_finish`], forwarded.
@@ -318,6 +319,15 @@ where
     E: CstEmitter<'inp, L, Lang>,
   {
     self.emitter.cst_finish(kind);
+  }
+
+  /// Un-opens the node started at `mark` — [`CstEmitter::cst_demote`], forwarded.
+  #[inline(always)]
+  pub fn cst_demote(&mut self, mark: EventMark, kind: u16)
+  where
+    E: CstEmitter<'inp, L, Lang>,
+  {
+    self.emitter.cst_demote(mark, kind);
   }
 
   /// Appends a retro-wrap anchor — [`CstEmitter::cst_mark`], forwarded.

--- a/tokora/src/fuzz/fixtures.rs
+++ b/tokora/src/fuzz/fixtures.rs
@@ -419,8 +419,19 @@ impl crate::emitter::ValueKeyedEmitter for CountEmitter {}
 /// scripts satisfy the `Ctx::Emitter: CstEmitter` bound. The recording twin — the same
 /// ops over a real `Sink` with the tree-equality oracle — is the `rowan`-gated
 /// `fuzz::cst` case kind.
-impl<'a, L, Lang: ?Sized> crate::emitter::CstEmitter<'a, L, Lang> for CountEmitter where L: Lexer<'a>
-{}
+///
+/// One member is not defaulted and so is written out: `cst_demote`, the node bracket's failing
+/// exit, is discarded here because there is no event channel to un-open — the deliberate
+/// counterpart of a wrapper, which must forward it (see `CstEmitter::cst_demote`).
+impl<'a, L, Lang: ?Sized> crate::emitter::CstEmitter<'a, L, Lang> for CountEmitter
+where
+  L: Lexer<'a>,
+{
+  #[inline(always)]
+  fn cst_demote(&mut self, mark: crate::cst::event::EventMark, kind: u16) {
+    let _ = (mark, kind);
+  }
+}
 
 // ── Context wiring ───────────────────────────────────────────────────────────────────────────────
 

--- a/tokora/src/guide/arch_atomic_emitter.md
+++ b/tokora/src/guide/arch_atomic_emitter.md
@@ -153,10 +153,15 @@ of them regardless.
 ### The one capability that binds rather than defaults
 
 [`CstEmitter`](crate::emitter::CstEmitter) is the exception worth naming, because it inverts the
-default's purpose. Its methods (`cst_start` / `cst_finish`, and the retro-wrap pair
-`cst_mark` / `cst_start_at`) all have no-op defaults, so `Fatal` / `Verbose` / `Silent` /
-[`Ignored`](crate::emitter::Ignored) are `CstEmitter` for free and a tree-less parse compiles the
-event calls to nothing. But a tree-*producing* parse path bounds `Ctx::Emitter: CstEmitter` anyway —
+default's purpose. Four of its five methods (`cst_start` / `cst_finish`, and the retro-wrap pair
+`cst_mark` / `cst_start_at`) have no-op defaults, so `Fatal` / `Verbose` / `Silent` /
+[`Ignored`](crate::emitter::Ignored) are `CstEmitter` for one written line and a tree-less parse
+compiles the event calls to nothing. That line is the fifth method,
+[`cst_demote`](crate::emitter::CstEmitter::cst_demote) — the node bracket's failing exit, and
+**required** for the same reason [`rewind`](crate::Emitter::rewind) is (the next section): an
+inherited no-op there is not an absence someone would notice on the first parse but a *presence*
+nothing can detect — a node the grammar retracted, left open in whatever channel sits below, on
+error paths only. But a tree-*producing* parse path bounds `Ctx::Emitter: CstEmitter` anyway —
 not to reach a method the default already provides, but to make the bound itself load-bearing: a
 wrapper emitter that forwarded the diagnostic surface and forgot the structure surface would produce
 a parse whose diagnostics flow perfectly and whose tree is *silently empty*. On every other
@@ -165,7 +170,7 @@ is the one place the design binds instead of trusting a default. The recording i
 `rowan`-gated `cst::Sink`, the subject of the event-stream CST chapter (its
 vocabulary lives in [`crate::cst`]).
 
-## The one method the design refuses to default
+## The core trait's one method the design refuses to default
 
 Everything past the three emit verbs is defaulted — with a single, deliberate exception:
 [`rewind`](crate::Emitter::rewind) has no default body. Every emitter must write it, and that is a
@@ -182,6 +187,12 @@ and [`Ignored`](crate::emitter::Ignored) each write one — but the compiler mak
 the question is never skipped by accident. `checkpoint` defaults to `0` and `release` defaults to a
 no-op precisely because a stateless emitter genuinely has nothing to mark or reclaim; `rewind` is
 the one place where silence would be a correctness bug, so silence is not allowed to be the default.
+
+[`CstEmitter::cst_demote`](crate::emitter::CstEmitter::cst_demote) is the same decision taken again
+on the capability trait, and the test is the same one stated generally: a default is allowed when
+inheriting it fails toward an *absence* something downstream reports, and refused when inheriting it
+fails toward a *presence* nothing can. `rewind` is a phantom diagnostic; `cst_demote` is a phantom
+node. Every other method on both traits keeps its default because its absence announces itself.
 
 ## checkpoint / rewind / release: the emitter's transactional surface
 

--- a/tokora/src/input/input_ref/emit.rs
+++ b/tokora/src/input/input_ref/emit.rs
@@ -243,13 +243,14 @@ where
   /// Opens a CST node of `kind` — [`CstEmitter::cst_start`], forwarded.
   ///
   /// Raw transport: pair it with [`cst_finish`](Self::cst_finish) through a both-exits
-  /// bracket, or use the `node`-shaped combinators.
+  /// bracket, or use the `node`-shaped combinators. The returned mark is the failing exit's
+  /// handle — spend it on [`cst_demote`](Self::cst_demote).
   #[inline(always)]
-  pub fn cst_start(&mut self, kind: u16)
+  pub fn cst_start(&mut self, kind: u16) -> EventMark
   where
     Ctx::Emitter: CstEmitter<'inp, L, Lang>,
   {
-    self.emitter_view().cst_start(kind);
+    self.emitter_view().cst_start(kind)
   }
 
   /// Closes the innermost open CST node — [`CstEmitter::cst_finish`], forwarded.
@@ -259,6 +260,15 @@ where
     Ctx::Emitter: CstEmitter<'inp, L, Lang>,
   {
     self.emitter_view().cst_finish(kind);
+  }
+
+  /// Un-opens the node started at `mark` — [`CstEmitter::cst_demote`], forwarded.
+  #[inline(always)]
+  pub fn cst_demote(&mut self, mark: EventMark, kind: u16)
+  where
+    Ctx::Emitter: CstEmitter<'inp, L, Lang>,
+  {
+    self.emitter_view().cst_demote(mark, kind);
   }
 
   /// Appends a retro-wrap anchor — [`CstEmitter::cst_mark`], forwarded.

--- a/tokora/src/input/input_ref/mod.rs
+++ b/tokora/src/input/input_ref/mod.rs
@@ -1951,6 +1951,13 @@ where
   /// happens either way is the third outcome: a point left on the stack describing a lineage the
   /// rewind destroyed.
   ///
+  /// One thing a point deliberately **cannot** reach is the interior of a
+  /// [`node`](crate::parser::node) bracket a caller is already inside: settling a point from an
+  /// enclosing frame there would rewind below that bracket's start and stale the mark its failing
+  /// exit must spend, so the invariant `'closure` brand on the id refuses it at compile time —
+  /// the wall is the brand, not a runtime check. See *A rollback below the start cannot happen
+  /// mid-frame* in the [`node` module docs](crate::parser::node).
+  ///
   /// # Contract: a point is scoped to *this handle*, and never outlives it
   ///
   /// A session point is non-lexical — it outlives the *call* that opened it — but it is **not**

--- a/tokora/src/parse_state/mod.rs
+++ b/tokora/src/parse_state/mod.rs
@@ -193,11 +193,11 @@ where
   /// Opens a CST node of `kind` —
   /// [`CstEmitter::cst_start`](crate::emitter::CstEmitter::cst_start), forwarded.
   #[inline(always)]
-  pub fn cst_start(&mut self, kind: u16)
+  pub fn cst_start(&mut self, kind: u16) -> crate::cst::event::EventMark
   where
     Ctx::Emitter: crate::emitter::CstEmitter<'inp, L, Lang>,
   {
-    self.inp.cst_start(kind);
+    self.inp.cst_start(kind)
   }
 
   /// Closes the innermost open CST node —
@@ -208,6 +208,16 @@ where
     Ctx::Emitter: crate::emitter::CstEmitter<'inp, L, Lang>,
   {
     self.inp.cst_finish(kind);
+  }
+
+  /// Un-opens the node started at `mark` —
+  /// [`CstEmitter::cst_demote`](crate::emitter::CstEmitter::cst_demote), forwarded.
+  #[inline(always)]
+  pub fn cst_demote(&mut self, mark: crate::cst::event::EventMark, kind: u16)
+  where
+    Ctx::Emitter: crate::emitter::CstEmitter<'inp, L, Lang>,
+  {
+    self.inp.cst_demote(mark, kind);
   }
 
   /// Appends a retro-wrap anchor —

--- a/tokora/src/parser/node.rs
+++ b/tokora/src/parser/node.rs
@@ -135,13 +135,22 @@
 //!
 //! Every combinator here bounds `Ctx::Emitter:`[`CstEmitter`] — the one user-ruled gate of
 //! the CST design. A diagnostics-only parse (over [`Fatal`](crate::emitter::Fatal),
-//! [`Verbose`](crate::emitter::Verbose), …) satisfies the bound through the defaulted no-op
-//! event methods, so one parser assembly serves both configurations: tree-less at zero cost
-//! (every mark is inert, the start/finish/wrap/demote calls inline to nothing and the
-//! handback is a dead `Copy` constant), or tree-building over a recording sink — by emitter
-//! choice alone. A wrapper emitter that does not implement (and forward)
-//! [`CstEmitter`] cannot drive a `node`-bearing parser at all: a **compile error**, never a
-//! silently empty tree.
+//! [`Verbose`](crate::emitter::Verbose), …) satisfies the bound through four defaulted no-op
+//! event methods plus a one-line discard for the fifth, so one parser assembly serves both
+//! configurations: tree-less at zero cost (every mark is inert, the start/finish/wrap/demote
+//! calls inline to nothing and the handback is a dead `Copy` constant), or tree-building over
+//! a recording sink — by emitter choice alone. A wrapper emitter that does not implement (and
+//! forward) [`CstEmitter`] cannot drive a `node`-bearing parser at all: a **compile error**,
+//! never a silently empty tree.
+//!
+//! The bound guarantees the structuring surface **exists**; that
+//! [`cst_demote`](crate::emitter::CstEmitter::cst_demote) is a **required** method is what
+//! guarantees a wrapper cannot **half-carry** it. Forward `cst_start` and inherit the failing
+//! exit — which is what a 0.8-era wrapper does after applying the one compiler diagnostic its
+//! rebase produces — and the `Err` arm below would dispatch into a vacuous body, leaving the
+//! channel underneath holding a `StartNode` no exit ever closes, on error paths only and
+//! indistinguishable downstream from an escaped panic. `E0046` now stands where that silence
+//! was, and `tests/ui/cst_demote_cannot_be_inherited.rs` pins both it and the re-defaulting.
 //!
 //! # Marks are LIFO by construction
 //!

--- a/tokora/src/parser/node.rs
+++ b/tokora/src/parser/node.rs
@@ -1,21 +1,75 @@
 //! The [`node`] combinators — the blessed CST bracketing over the event sink.
 //!
 //! Wrapping a parser in [`node`] records everything the sub-parse commits — tokens, trivia,
-//! nested nodes — as the children of one syntax node of the given kind. The bracketing is
-//! **append-only**: entry mints an inert tombstone mark
-//! ([`cst_mark`](crate::emitter::CstEmitter::cst_mark)), and only a *successful* exit spends
-//! it as a retro-wrap ([`cst_start_at`](crate::emitter::CstEmitter::cst_start_at) +
-//! [`cst_finish`](crate::emitter::CstEmitter::cst_finish)). There is therefore **never an
-//! open node between entry and exit** — the `labelled` finish-on-both-exits discipline,
-//! made structural rather than dutiful:
+//! nested nodes — as the children of one syntax node of the given kind. Every combinator here
+//! is a **both-exits bracket**; they differ only in *when the node's kind is named*, and that
+//! split is measured rather than stylistic.
+//!
+//! # Two brackets, one contract
+//!
+//! **Up front — [`Node`] as a [`ParseInput`].** This impl cannot decline, so the kind is known
+//! at entry: it emits [`cst_start`](crate::emitter::CstEmitter::cst_start) immediately and
+//! closes on both exits — [`cst_finish`](crate::emitter::CstEmitter::cst_finish) on success,
+//! [`cst_demote`](crate::emitter::CstEmitter::cst_demote) (spending the mark `cst_start` handed
+//! back) on failure. An open node therefore exists **only inside the frame**, and both exits
+//! close it. Two events per node instead of three, and no tombstone whose only purpose is to be
+//! named later.
+//!
+//! **Retro — every other impl.** [`Node`] as a [`TryParseInput`], [`node_at`] in both shapes,
+//! and [`node_opt`] mint an inert tombstone mark
+//! ([`cst_mark`](crate::emitter::CstEmitter::cst_mark)) and spend it as a retro-wrap
+//! ([`cst_start_at`](crate::emitter::CstEmitter::cst_start_at) + `cst_finish`) only on a
+//! successful exit, so **no node is ever open between entry and exit**. That is not a leftover:
+//! a declining parser's kind is not knowable at entry (a decline must leave *nothing*, and an
+//! up-front start would have to be demoted on a path that also has to consume nothing), and
+//! [`node_at`]'s whole purpose is a kind decided after its first child was parsed. The
+//! retro path is also what the pratt driver runs on, where the kind is a function of an
+//! operator not yet read.
+//!
+//! Both shapes are the `labelled` finish-on-both-exits discipline made structural rather than
+//! dutiful, and on every non-success **return** — a decline or an `Err` — the two shapes leave
+//! the identical event buffer:
 //!
 //! - a **decline** leaves the tombstone unspent — no node, not even an empty one (the
 //!   optional-`Description` shape wants exactly this: see [`node_opt`]);
-//! - an **error-path unwind** (`?`-propagation out of the sub-parser, or a panic caught by
-//!   an enclosing guard) leaves the tombstone unspent — no dangling `Start` for a later
-//!   finish to mispair with; the enclosing rollback, if any, truncates the tombstone with
-//!   the rest of the abandoned branch;
-//! - a **success** wraps precisely the region recorded since entry.
+//! - an **error-path unwind** (`?`-propagation out of the sub-parser) leaves an inert
+//!   tombstone — the retro bracket by never spending its mark, the up-front bracket by
+//!   demoting its start back to one — so there is no dangling `Start` for a later finish to
+//!   mispair with; the enclosing rollback, if any, truncates that slot with the rest of the
+//!   abandoned branch;
+//! - a **success** wraps precisely the region recorded since entry. The buffers differ here
+//!   and always did — three events for the retro shape, two for the up-front one — and
+//!   converge only at materialization, which hoists a retro-wrap to its target and builds the
+//!   same tree from either;
+//! - a **panic** is the one non-success exit outside this equivalence, and the only one where
+//!   the two shapes' residues genuinely differ. See *The panic residue* below.
+//!
+//! # The panic residue
+//!
+//! A panic is the one exit the up-front bracket does not close, and it is deliberately left to
+//! the machinery that already handles it rather than given a mechanism here:
+//!
+//! - a panic caught by an **enclosing guard** unwinds through that guard's rewind, which
+//!   truncates the buffer to a mark at or below the `cst_start` — the node goes with the
+//!   branch, exactly as the tombstone does today (the rewind-mid-unwind clause);
+//! - a panic escaping **every** guard leaves the node open. Nothing observes that until
+//!   materialization, which refuses the leftover in the typed way it already refuses any
+//!   imbalance (`cst::FinishError::UnclosedNodes`), while
+//!   [`finish_partial`](crate::cst::Cst::finish_partial) closes it per its existing contract.
+//!   A wrong tree is not reachable through this door; a typed refusal is.
+//!
+//! The delta versus the retro shape, stated plainly rather than left to be inferred, because
+//! this is a **behaviour change** and not merely a documented residue. Under the retro bracket
+//! an escaped panic left an unspent tombstone: `finish()` could return a tree that silently
+//! omitted the interrupted frame whenever byte coverage happened to be complete (and
+//! `UncoveredGap` when it was not), and `finish_partial` produced no node for it either. Under
+//! the up-front bracket `finish()` **refuses** — `UnclosedNodes`, always, for any interrupted
+//! frame — and `finish_partial` materialises the interrupted frame's node containing everything
+//! recorded up to the panic, which is that door's published closes-open-nodes contract answering
+//! exactly what a host that caught a panic and asked for a partial tree requested. The strict
+//! door therefore got *stricter*, not looser. Both halves are pinned by
+//! `a_start_left_open_by_an_escaping_panic_is_refused_by_finish_and_closed_by_finish_partial`
+//! in the sink suite.
 //!
 //! # The structural gate
 //!
@@ -23,27 +77,38 @@
 //! the CST design. A diagnostics-only parse (over [`Fatal`](crate::emitter::Fatal),
 //! [`Verbose`](crate::emitter::Verbose), …) satisfies the bound through the defaulted no-op
 //! event methods, so one parser assembly serves both configurations: tree-less at zero cost
-//! (the mark is inert, the wrap calls inline to nothing), or tree-building over a recording
-//! sink — by emitter choice alone. A wrapper emitter that does not implement (and forward)
+//! (every mark is inert, the start/finish/wrap/demote calls inline to nothing and the
+//! handback is a dead `Copy` constant), or tree-building over a recording sink — by emitter
+//! choice alone. A wrapper emitter that does not implement (and forward)
 //! [`CstEmitter`] cannot drive a `node`-bearing parser at all: a **compile error**, never a
 //! silently empty tree.
 //!
 //! # Marks are LIFO by construction
 //!
 //! [`node`] and [`node_opt`] mint their mark and spend it inside one call frame, so nested
-//! nodes nest their wraps last-in-first-out structurally — no discipline is asked of the
-//! caller. [`node_at`] spends a caller-held mark (the retro-wrap shape: mark, parse a
+//! nodes nest last-in-first-out structurally — no discipline is asked of the caller.
+//! [`node_at`] spends a caller-held mark (the retro-wrap shape: mark, parse a
 //! prefix, *then* decide it was the start of something bigger); the recording sink
 //! validates every spend — stale marks (a mark whose branch was rolled back) **panic in
 //! every build**, and a wrap that would cross another node's boundary is a typed
-//! materialization error, never a silently wrong tree.
+//! materialization error, never a silently wrong tree. The up-front bracket's handback is
+//! validated on the same wall: a demote of a stale, foreign, already-**demoted** or
+//! wrong-kind mark panics in every build too, as does a demote naming the reserved tombstone
+//! kind. The one misuse that wall cannot see is a demote of a start whose node was already
+//! finished — the slot cannot witness a finish appended above it — and that one is caught at
+//! the misuse site in debug builds and refused at materialization in release, typed and
+//! through both doors; see
+//! [`cst_demote`](crate::emitter::CstEmitter::cst_demote) for why it can never be a silently
+//! wrong tree.
 //!
 //! # Trivia lands inside
 //!
 //! Committed tokens auto-flow to the sink at their settle, so whatever the sub-parser
 //! consumes — including trivia skipped by [`padded`](crate::parser::Padded)-style wrappers
-//! *inside* it — is recorded between the mark and the wrap and materializes inside the
-//! node (the innermost-open-node-at-commit placement).
+//! *inside* it — is recorded between the bracket's two events and materializes inside the
+//! node (the innermost-open-node-at-commit placement). The two brackets place trivia
+//! identically: materialization hoists a retro-wrap to its target, so the node opens at the
+//! mark's slot either way.
 
 use crate::{
   Emitter, InputRef, Lexer, ParseContext, ParseInput, TryParseInput, cst::event::EventMark,
@@ -109,10 +174,14 @@ pub const fn node_opt<P>(kind: u16, parser: P) -> NodeOpt<P> {
 
 /// The parser wrapper produced by [`node`].
 ///
-/// Delegates to the inner parser between an entry [`cst_mark`] and — on success only — the
-/// retro-wrap spend ([`cst_start_at`] + [`cst_finish`]); the module-level docs hold the
+/// Delegates to the inner parser inside a both-exits bracket whose shape depends on which
+/// trait drives it — the up-front [`cst_start`] / [`cst_finish`] | [`cst_demote`] pair as a
+/// [`ParseInput`], the retro [`cst_mark`] / [`cst_start_at`] pair as a [`TryParseInput`],
+/// because a declining parser's kind is not knowable at entry. The module-level docs hold the
 /// full contract.
 ///
+/// [`cst_start`]: crate::emitter::CstEmitter::cst_start
+/// [`cst_demote`]: crate::emitter::CstEmitter::cst_demote
 /// [`cst_mark`]: crate::emitter::CstEmitter::cst_mark
 /// [`cst_start_at`]: crate::emitter::CstEmitter::cst_start_at
 /// [`cst_finish`]: crate::emitter::CstEmitter::cst_finish
@@ -174,10 +243,14 @@ where
     &mut self,
     input: &mut InputRef<'inp, '_, L, Ctx, Lang>,
   ) -> Result<O, <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error> {
-    let mark = input.emitter().cst_mark();
+    // The UP-FRONT bracket: this impl cannot decline, so the node's kind is knowable at
+    // entry and the retro-wrap's third event — the tombstone that exists only to be named
+    // later — is not needed. See the module docs for why the *other* three impls keep it.
+    let mark = input.emitter().cst_start(self.kind);
     let res = self.parser.parse_input(input);
-    if res.is_ok() {
-      wrap(input, mark, self.kind);
+    match &res {
+      Ok(_) => input.emitter().cst_finish(self.kind),
+      Err(_) => input.emitter().cst_demote(mark, self.kind),
     }
     res
   }

--- a/tokora/src/parser/node.rs
+++ b/tokora/src/parser/node.rs
@@ -80,6 +80,57 @@
 //! `a_start_left_open_by_an_escaping_panic_is_refused_by_finish_and_closed_by_finish_partial`
 //! in the sink suite.
 //!
+//! # A rollback below the start cannot happen mid-frame
+//!
+//! The up-front bracket's failing exit spends the mark `cst_start` handed back, and a recording
+//! sink's [`cst_demote`](crate::emitter::CstEmitter::cst_demote) asserts **in every build** that
+//! the mark still names a live open node. A rewind whose target lands *below* the bracket's own
+//! start would truncate the slot away and stale that mark — so the assert would fire from inside
+//! a blessed combinator, in a release build, on code that broke no documented rule.
+//!
+//! It cannot, and the reason is worth stating as a theorem rather than left implicit, because it
+//! is a **type-system** fact with no runtime backstop under it. Three legs:
+//!
+//! 1. **The bracket's own rewinds are one-frame.** `cst_start` mints the mark and one of the two
+//!    exits spends it, both inside `parse_input`'s single call frame. Nothing else holds the
+//!    mark, so no rewind the bracket itself performs can outlive the window.
+//! 2. **Both exits append.** Neither rewrites the slot, so a rollback *into* the window
+//!    `(start, exit]` truncates the exit and leaves the node open again — the one rollback law
+//!    both exits share, pinned by `raw_bracket_{failing,success}_exit_below_a_point_is_exactly_restored_by_the_rollback`
+//!    in `tests/parser_node.rs`. That is the *inside* case, and it is legal.
+//! 3. **No external rollback can enter the window.** The only public verbs that rewind below a
+//!    point an enclosing frame opened are the session settles
+//!    ([`rollback_point`](crate::InputRef::rollback_point) and friends), and each takes a
+//!    [`SessionPointId`](crate::SessionPointId) branded with the *minting* handle's `'closure`
+//!    lifetime — **invariantly**, via an `fn(&'closure ()) -> &'closure ()` marker chosen
+//!    precisely so it cannot be coerced. A parser reaches its input through
+//!    [`ParseInput::parse_input`], whose handle lifetime is universally quantified (a fresh
+//!    region per call). An invariant token branded with one concrete region cannot be passed
+//!    into a frame that demands every region, in either direction. So an id minted outside the
+//!    bracket cannot be settled inside it, and an id minted inside sits **above** the slot, where
+//!    a rollback stops short of the start.
+//!
+//! Leg 3 is the load-bearing one and the only one a future change can quietly remove, so it is
+//! pinned as two compile-fail cases — `tests/ui/session_point_cannot_cross_into_a_bracket.rs`
+//! (the closure form a grammar would write) and its `_impl` companion (a hand-written
+//! `ParseInput`, which closes the "that is merely closure inference" reading). Registered in
+//! `BOUND_CASES` in `tests/diagnostics.rs`, so the census test refuses to let either go
+//! unregistered.
+//!
+//! **There is no second wall.** The runtime settle scan is not one: `take_point` checks
+//! newest-first, and a point opened *before* the bracket has no younger open above it, so the
+//! scan would accept it and the sink would panic. Whoever adds a new session-verb surface —
+//! on [`ParseState`](crate::ParseState), or any other handle a parser can reach — **must
+//! re-prove this theorem for it**, and add the corresponding compile-fail case. A verb that
+//! takes an unbranded id, or one branded covariantly, reopens a release panic inside `node()`.
+//!
+//! What the assert itself does on the raw surface, where the shape *is* reachable and *is* the
+//! published contract, is pinned by `raw_demote_after_a_rollback_below_the_start_panics`; the
+//! legal mirror is `a_point_opened_inside_the_bracket_and_rolled_back_inside_keeps_the_demote_valid`;
+//! and `retro_node_at_over_a_mark_staled_by_the_same_rollback_panics_too` records that the retro
+//! encoding is no refuge — under the same drive it panics on its *success* exit, on the older
+//! [`node_at`] wall.
+//!
 //! # The structural gate
 //!
 //! Every combinator here bounds `Ctx::Emitter:`[`CstEmitter`] — the one user-ruled gate of

--- a/tokora/src/parser/node.rs
+++ b/tokora/src/parser/node.rs
@@ -12,8 +12,9 @@
 //! closes on both exits — [`cst_finish`](crate::emitter::CstEmitter::cst_finish) on success,
 //! [`cst_demote`](crate::emitter::CstEmitter::cst_demote) (spending the mark `cst_start` handed
 //! back) on failure. An open node therefore exists **only inside the frame**, and both exits
-//! close it. Two events per node instead of three, and no tombstone whose only purpose is to be
-//! named later.
+//! close it, both by appending. **Two events per successful node instead of three**, and no
+//! tombstone whose only purpose is to be named later; the failing exit costs one event more
+//! than the retro shape's unspent mark, on the path that is about to be discarded or refused.
 //!
 //! **Retro — every other impl.** [`Node`] as a [`TryParseInput`], [`node_at`] in both shapes,
 //! and [`node_opt`] mint an inert tombstone mark
@@ -27,22 +28,30 @@
 //! operator not yet read.
 //!
 //! Both shapes are the `labelled` finish-on-both-exits discipline made structural rather than
-//! dutiful, and on every non-success **return** — a decline or an `Err` — the two shapes leave
-//! the identical event buffer:
+//! dutiful, and on every non-success **return** — a decline or an `Err` — the two shapes
+//! **materialize identically**:
 //!
 //! - a **decline** leaves the tombstone unspent — no node, not even an empty one (the
 //!   optional-`Description` shape wants exactly this: see [`node_opt`]);
-//! - an **error-path unwind** (`?`-propagation out of the sub-parser) leaves an inert
-//!   tombstone — the retro bracket by never spending its mark, the up-front bracket by
-//!   demoting its start back to one — so there is no dangling `Start` for a later finish to
-//!   mispair with; the enclosing rollback, if any, truncates that slot with the rest of the
-//!   abandoned branch;
+//! - an **error-path unwind** (`?`-propagation out of the sub-parser) leaves nothing the tree
+//!   can see — the retro bracket by never spending its mark, the up-front bracket by appending
+//!   a demote event that materialization applies to its own start — so there is no dangling
+//!   `Start` for a later finish to mispair with; the enclosing rollback, if any, truncates
+//!   both the demote and the slot with the rest of the abandoned branch. The two buffers are
+//!   not byte-identical here (the up-front shape carries the demote event) and converge at
+//!   materialization, where the demoted slot becomes exactly the inert tombstone the retro
+//!   shape left;
 //! - a **success** wraps precisely the region recorded since entry. The buffers differ here
 //!   and always did — three events for the retro shape, two for the up-front one — and
 //!   converge only at materialization, which hoists a retro-wrap to its target and builds the
 //!   same tree from either;
 //! - a **panic** is the one non-success exit outside this equivalence, and the only one where
 //!   the two shapes' residues genuinely differ. See *The panic residue* below.
+//!
+//! Both of the up-front bracket's exits are **appends**, which is what makes the bracket
+//! answer a rollback the same way whichever exit it took: a session point rolled back into the
+//! window between `cst_start` and the exit truncates that exit and the node is open again,
+//! success and failure alike. One bracket, two exits, one rollback law.
 //!
 //! # The panic residue
 //!
@@ -92,14 +101,23 @@
 //! validates every spend — stale marks (a mark whose branch was rolled back) **panic in
 //! every build**, and a wrap that would cross another node's boundary is a typed
 //! materialization error, never a silently wrong tree. The up-front bracket's handback is
-//! validated on the same wall: a demote of a stale, foreign, already-**demoted** or
-//! wrong-kind mark panics in every build too, as does a demote naming the reserved tombstone
-//! kind. The one misuse that wall cannot see is a demote of a start whose node was already
-//! finished — the slot cannot witness a finish appended above it — and that one is caught at
-//! the misuse site in debug builds and refused at materialization in release, typed and
-//! through both doors; see
-//! [`cst_demote`](crate::emitter::CstEmitter::cst_demote) for why it can never be a silently
+//! validated on the same wall: a demote of a stale, foreign or wrong-kind mark panics in every
+//! build too, as does a demote naming the reserved tombstone kind. The misuses that wall
+//! cannot see are the two the *slot* cannot witness — a demote of a start already finished,
+//! and a second demote of one start, both of which sit above the slot as appended events —
+//! and both are caught at the misuse site in debug builds and refused at materialization in
+//! release, typed and through both doors; see
+//! [`cst_demote`](crate::emitter::CstEmitter::cst_demote) for why neither can be a silently
 //! wrong tree.
+//!
+//! The debug recount behind those two is *positional*, so it also fires on a third shape that
+//! is **not** a misuse: two raw brackets whose exits **interleave** — an enclosing start
+//! demoted while an inner one is still open. Release admits that order and materialises exactly
+//! the tree the innermost-first order builds, so **debug enforces innermost-first closings on
+//! the raw surface while release admits the out-of-order shape**. The heading above is why no
+//! grammar meets it: `node` and `node_opt` close inside their own frame, so their exits nest by
+//! construction and cannot interleave. It is reachable only by hand-rolling `cst_start` /
+//! `cst_demote` pairs, and there the fix is to emit the closings innermost-first.
 //!
 //! # Trivia lands inside
 //!

--- a/tokora/tests/diagnostics.rs
+++ b/tokora/tests/diagnostics.rs
@@ -169,11 +169,26 @@ fn every_ui_case_file_is_registered() {
 /// the pinned one. That file also carries the runtime half: this attribute catches **one** of the
 /// five ways a caller can release the level early, and the recommended shape,
 /// `InputRef::descending`, cannot express any of them.
+///
+/// The two `session_point_cannot_cross_into_a_bracket*` cases pin a **reachability wall**, which
+/// is a different kind of subject again: nothing in the crate reads them, and their whole value
+/// is that the code inside them does not compile. `node()`'s up-front bracket spends its start
+/// mark on the failing exit through an assert that fires in **every** build, and the only thing
+/// keeping that assert unreachable from safe code is that a `SessionPointId` cannot be carried
+/// across the bracket boundary — an invariant brand meeting `ParseInput`'s universally
+/// quantified handle lifetime. The runtime settle scan is *not* a second wall: `take_point`'s
+/// newest-first check would accept a pre-bracket point, because no younger point is open above
+/// it. So the type system is the whole defence, and an untested type-system guarantee is one
+/// signature change away from silently ceasing to hold. The closure case is the shape a grammar
+/// would actually write; the `_impl` case closes the "that is just closure inference" reading by
+/// attacking the trait boundary directly.
 const BOUND_CASES: &[&str] = &[
   "tests/ui/session_sink.rs",
   "tests/ui/bundle1_policy.rs",
   "tests/ui/node_brand_mismatch.rs",
   "tests/ui/descent_dropped_early.rs",
+  "tests/ui/session_point_cannot_cross_into_a_bracket.rs",
+  "tests/ui/session_point_cannot_cross_into_a_bracket_impl.rs",
 ];
 
 /// Per case: the ui file, the curated headline its trait's attribute must produce, and

--- a/tokora/tests/diagnostics.rs
+++ b/tokora/tests/diagnostics.rs
@@ -182,6 +182,17 @@ fn every_ui_case_file_is_registered() {
 /// signature change away from silently ceasing to hold. The closure case is the shape a grammar
 /// would actually write; the `_impl` case closes the "that is just closure inference" reading by
 /// attacking the trait boundary directly.
+///
+/// `cst_demote_cannot_be_inherited` pins a **missing default**, which is a subject with no runtime
+/// shadow at all: `CstEmitter::cst_demote` has no default body, so a wrapper that forwards the four
+/// 0.8 CST methods and stops fails with `E0046` instead of inheriting an empty failing exit. The
+/// case's teeth point forward rather than back — the day someone re-adds that default "for
+/// convenience", this file starts compiling and a `compile_fail` case that compiles is a failing
+/// test. That is the *only* signal there would be: an inherited demote is silent on every success
+/// path, byte-perfect in the buffer, and its error-path residue is byte-identical to an escaped
+/// panic's, so no sink-side check and no other gate can see it. Same reason the two session-point
+/// cases exist — the guarantee lives entirely in the type system, so it needs a test that compiles
+/// nothing.
 const BOUND_CASES: &[&str] = &[
   "tests/ui/session_sink.rs",
   "tests/ui/bundle1_policy.rs",
@@ -189,6 +200,7 @@ const BOUND_CASES: &[&str] = &[
   "tests/ui/descent_dropped_early.rs",
   "tests/ui/session_point_cannot_cross_into_a_bracket.rs",
   "tests/ui/session_point_cannot_cross_into_a_bracket_impl.rs",
+  "tests/ui/cst_demote_cannot_be_inherited.rs",
 ];
 
 /// Per case: the ui file, the curated headline its trait's attribute must produce, and

--- a/tokora/tests/forwarding_discrimination.rs
+++ b/tokora/tests/forwarding_discrimination.rs
@@ -8,7 +8,7 @@
 //! # The defect this suite exists to catch
 //!
 //! Three receivers carry a thin forwarding surface onto the emitter's operations:
-//! [`EmitterView`] (27 public methods), [`InputRef`]'s `emit.rs` (25) and [`ParseState`] (17).
+//! [`EmitterView`] (28 public methods), [`InputRef`]'s `emit.rs` (26) and [`ParseState`] (18).
 //! They were written by copy-and-adjust, which is the shape where a wrong delegation target is
 //! easiest to introduce and hardest to see. An `emit_warning` whose body calls `emit_error`
 //! compiles, propagates nothing, and every other test in the crate still passes — the defect
@@ -254,6 +254,7 @@ enum Call {
   // `CstEmitter`
   CstStart(u16),
   CstFinish(u16),
+  CstDemote(EventMark, u16),
   CstMark,
   CstStartAt(EventMark, u16),
   // The capability channels
@@ -443,12 +444,17 @@ impl<'inp> Emitter<'inp, TestLexer<'inp>> for Ledger {
 }
 
 impl<'inp> CstEmitter<'inp, TestLexer<'inp>> for Ledger {
-  fn cst_start(&mut self, kind: u16) {
+  fn cst_start(&mut self, kind: u16) -> EventMark {
     self.note(Call::CstStart(kind));
+    inert_mark()
   }
 
   fn cst_finish(&mut self, kind: u16) {
     self.note(Call::CstFinish(kind));
+  }
+
+  fn cst_demote(&mut self, mark: EventMark, kind: u16) {
+    self.note(Call::CstDemote(mark, kind));
   }
 
   fn cst_mark(&mut self) -> EventMark {
@@ -625,6 +631,7 @@ fn sp(start: usize, end: usize) -> SimpleSpan {
 const KIND_START: u16 = 0x0151;
 const KIND_FINISH: u16 = 0x0152;
 const KIND_START_AT: u16 = 0x0153;
+const KIND_DEMOTE: u16 = 0x0154;
 const LABEL: &str = "ledger-label";
 
 // ── The assertion ─────────────────────────────────────────────────────────────
@@ -644,7 +651,7 @@ fn landed(receiver: &str, method: &str, got: &[Call], want: &[Call]) {
 }
 
 // ══════════════════════════════════════════════════════════════════════════════
-// `EmitterView` — 27 public methods
+// `EmitterView` — 28 public methods
 // ══════════════════════════════════════════════════════════════════════════════
 //
 // The lowest layer, and the only one reachable without a parse: `EmitterView::new` is public
@@ -822,7 +829,11 @@ view_case!(
   view_cst_start,
   "cst_start",
   |v| {
-    v.cst_start(KIND_START);
+    assert_eq!(
+      v.cst_start(KIND_START),
+      inert_mark(),
+      "`EmitterView::cst_start` did not hand back the mark the emitter minted"
+    );
   },
   [Call::CstStart(KIND_START)]
 );
@@ -834,6 +845,15 @@ view_case!(
     v.cst_finish(KIND_FINISH);
   },
   [Call::CstFinish(KIND_FINISH)]
+);
+
+view_case!(
+  view_cst_demote,
+  "cst_demote",
+  |v| {
+    v.cst_demote(inert_mark(), KIND_DEMOTE);
+  },
+  [Call::CstDemote(inert_mark(), KIND_DEMOTE)]
 );
 
 view_case!(
@@ -1001,7 +1021,7 @@ view_case!(
 );
 
 // ══════════════════════════════════════════════════════════════════════════════
-// `InputRef` — 25 public methods
+// `InputRef` — 26 public methods
 // ══════════════════════════════════════════════════════════════════════════════
 //
 // Reached through a real parse: the handle's emitter accessor is crate-private, so the subject
@@ -1162,7 +1182,11 @@ handle_case!(
   handle_cst_start,
   "cst_start",
   |h| {
-    h.cst_start(KIND_START);
+    assert_eq!(
+      h.cst_start(KIND_START),
+      inert_mark(),
+      "`InputRef::cst_start` did not hand back the mark the emitter minted"
+    );
   },
   [Call::CstStart(KIND_START)]
 );
@@ -1174,6 +1198,15 @@ handle_case!(
     h.cst_finish(KIND_FINISH);
   },
   [Call::CstFinish(KIND_FINISH)]
+);
+
+handle_case!(
+  handle_cst_demote,
+  "cst_demote",
+  |h| {
+    h.cst_demote(inert_mark(), KIND_DEMOTE);
+  },
+  [Call::CstDemote(inert_mark(), KIND_DEMOTE)]
 );
 
 handle_case!(
@@ -1341,7 +1374,7 @@ handle_case!(
 );
 
 // ══════════════════════════════════════════════════════════════════════════════
-// `ParseState` — 17 public methods
+// `ParseState` — 18 public methods
 // ══════════════════════════════════════════════════════════════════════════════
 //
 // `ParseState::new` is `pub(super)`, so the subject is **reached**, not constructed: a real
@@ -1519,7 +1552,11 @@ state_case!(
   state_cst_start,
   "cst_start",
   |st| {
-    st.cst_start(KIND_START);
+    assert_eq!(
+      st.cst_start(KIND_START),
+      inert_mark(),
+      "`ParseState::cst_start` did not hand back the mark the emitter minted"
+    );
   },
   [Call::CstStart(KIND_START)]
 );
@@ -1532,6 +1569,16 @@ state_case!(
     st.cst_finish(KIND_FINISH);
   },
   [Call::CstFinish(KIND_FINISH)]
+);
+
+#[cfg(feature = "map")]
+state_case!(
+  state_cst_demote,
+  "cst_demote",
+  |st| {
+    st.cst_demote(inert_mark(), KIND_DEMOTE);
+  },
+  [Call::CstDemote(inert_mark(), KIND_DEMOTE)]
 );
 
 #[cfg(feature = "map")]
@@ -1785,6 +1832,7 @@ const VIEW_COVERED: &[&str] = &[
   "bound_source",
   "cst_start",
   "cst_finish",
+  "cst_demote",
   "cst_mark",
   "cst_start_at",
   "emit_too_few",
@@ -1815,6 +1863,7 @@ const HANDLE_COVERED: &[&str] = &[
   "emitter_bound_source",
   "cst_start",
   "cst_finish",
+  "cst_demote",
   "cst_mark",
   "cst_start_at",
   "emit_too_few",
@@ -1846,6 +1895,7 @@ const STATE_COVERED: &[&str] = &[
   "emitter_bound_source",
   "cst_start",
   "cst_finish",
+  "cst_demote",
   "cst_mark",
   "cst_start_at",
   "state",
@@ -1911,7 +1961,7 @@ fn census(receiver: &str, src: &str, covered: &[&str], expected: usize) {
 #[cfg(feature = "pratt")]
 #[test]
 fn forwarding_census_every_public_forward_is_covered() {
-  census("EmitterView", VIEW_SOURCE, VIEW_COVERED, 27);
-  census("InputRef", HANDLE_SOURCE, HANDLE_COVERED, 25);
-  census("ParseState", STATE_SOURCE, STATE_COVERED, 17);
+  census("EmitterView", VIEW_SOURCE, VIEW_COVERED, 28);
+  census("InputRef", HANDLE_SOURCE, HANDLE_COVERED, 26);
+  census("ParseState", STATE_SOURCE, STATE_COVERED, 18);
 }

--- a/tokora/tests/handler_coverage.rs
+++ b/tokora/tests/handler_coverage.rs
@@ -2917,21 +2917,30 @@ fn delimiter_handler_ignored_via_parser() {
 
 use tokora::{cst::event::EventMark, emitter::CstEmitter};
 
+/// No public `EventMark` constructor exists (only a recording sink mints live marks), so the
+/// tracking overrides hand back the defaulted inert mark of a diagnostics-only emitter; the
+/// forwarding proof is the counter, not the value.
+fn inert_mark<'inp>() -> EventMark {
+  <Fatal<E> as CstEmitter<'inp, TestLexer<'inp>>>::cst_mark(&mut Fatal::new())
+}
+
 impl<'inp> CstEmitter<'inp, TestLexer<'inp>> for TrackingEmitter {
-  fn cst_start(&mut self, _: u16) {
+  fn cst_start(&mut self, _: u16) -> EventMark {
     self.cst_events += 1;
+    inert_mark()
   }
 
   fn cst_finish(&mut self, _: u16) {
     self.cst_events += 1;
   }
 
+  fn cst_demote(&mut self, _: EventMark, _: u16) {
+    self.cst_events += 1;
+  }
+
   fn cst_mark(&mut self) -> EventMark {
     self.cst_events += 1;
-    // No public EventMark constructor exists (only a recording sink mints live marks), so
-    // the tracking override hands back the defaulted inert mark of a diagnostics-only
-    // emitter; the forwarding proof is the counter, not the value.
-    <Fatal<E> as CstEmitter<'inp, TestLexer<'inp>>>::cst_mark(&mut Fatal::new())
+    inert_mark()
   }
 
   fn cst_start_at(&mut self, _: EventMark, _: u16) {

--- a/tokora/tests/parser_node.rs
+++ b/tokora/tests/parser_node.rs
@@ -20,7 +20,7 @@ use tokora::{
   emitter::Verbose,
   error::token::UnexpectedToken,
   parser::{
-    PrattFoldOp, PrattInfix, PrattLHS, PrattRHS, Precedenced, node, node_at, node_opt, pratt,
+    Empty, PrattFoldOp, PrattInfix, PrattLHS, PrattRHS, Precedenced, node, node_at, node_opt, pratt,
   },
   try_parse_input::ParseAttempt,
 };
@@ -987,5 +987,204 @@ fn an_orphan_view_wrapper_carries_a_foreign_lexer_error_but_licenses_no_gap() {
     emitter.errors().len(),
     1,
     "the foreign diagnostic still arrived: the channel is forwarded, not severed"
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// The up-front bracket under a session point: one bracket, two exits, one rollback law
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// The sink suite holds these three laws at the event level. Here they are through the PUBLIC
+// surface only, because that is where the adversarial finding lived: `EventMark` is a
+// deliberately unbranded `Copy` POD (a pratt driver holds one across arbitrarily many folds),
+// so the raw bracket — `ParseState::cst_start` / `cst_demote` — composes freely with session
+// points, which are public and non-lexical by design. A driver can therefore roll back INTO a
+// bracket's own window, and both exits have to answer that the same way.
+
+/// **The reachability pin that decided the remedy.** A live emitter row can sit ABOVE an
+/// up-front bracket's slot at demote time, on a fully supported and completely harmless
+/// history: the inner parser opens a session point and `?`-fails out without settling it —
+/// the documented-legal abandonment shape, whose bookkeeping the handle's drop reclaims.
+///
+/// This is why the two cheap remedies were rejected. "Refuse the demote when a live row sits
+/// above the slot" would panic *here*, on code that ends with a correct tree and never rewinds
+/// into the window at all.
+#[test]
+fn a_live_point_above_the_slot_at_demote_time_is_a_legal_and_harmless_history() {
+  let (res, green) = run("ab", |inp| {
+    let r: Result<(), TestErr> = node(K_NODE, |ii: &mut Ir<'_, '_>| {
+      // Supported public API, abandoned by the early return below, exactly as the session
+      // docs bless. Its emitter row is live — and above the bracket's slot — when the Err arm
+      // demotes.
+      let _abandoned = ii.begin_point();
+      take_one(ii)?; // consumes 'a' through the open point (progress: kept)
+      Err(TestErr::Boom)
+    })
+    .parse_input(inp);
+    assert_eq!(r, Err(TestErr::Boom), "the bracket failed and demoted");
+    // No rollback anywhere: the driver accepts the kept progress and parses on.
+    take_one(inp) // consumes 'b'
+  });
+  assert_eq!(res, Ok(()));
+  let green = green.expect("a completely lawful parse: finish succeeds");
+  let root = tree(green);
+  assert_eq!(root.text(), "ab");
+  assert!(
+    root.children().all(|c| c.kind() != K_NODE),
+    "the failed bracket correctly leaves no node"
+  );
+}
+
+/// **The finding, inverted, at the public surface.** The raw bracket takes its FAILING exit
+/// below a session point, and the driver then rolls back into the window. Every documented duty
+/// is upheld — the bracket takes exactly one closing exit, and the point settles newest-first —
+/// so `restore`'s contract ("the buffer as it was when the mark was captured") says the node is
+/// open again and `finish` must refuse `UnclosedNodes`.
+///
+/// It now does. Under the eager in-place rewrite this same drive returned a *tree* with the node
+/// silently gone: the rollback discarded the demote's own evidence but kept its effect, leaving
+/// a balanced buffer with one fewer node than the checkpoint promised, undetectable by anything
+/// downstream.
+#[test]
+fn raw_bracket_failing_exit_below_a_point_is_exactly_restored_by_the_rollback() {
+  let (res, green) = run("ab", |inp| {
+    let m_cell = core::cell::Cell::new(None);
+    // 1. Open the bracket through the public raw surface.
+    Empty::new()
+      .map_with(|_o, mut st| m_cell.set(Some(st.cst_start(K_NODE))))
+      .parse_input(inp)?;
+    // 2. A session point ABOVE the slot.
+    let id = inp.begin_point();
+    // 3. Content.
+    take_one(inp)?; // 'a'
+    // 4. The failing exit, below the point.
+    Empty::new()
+      .map_with(|_o, mut st| st.cst_demote(m_cell.get().expect("stashed"), K_NODE))
+      .parse_input(inp)?;
+    // 5. Roll back INTO the (slot, demote] window.
+    inp.rollback_point(id);
+    // 6. Continue; per the restore law the node is open again.
+    take_one(inp)?; // 'a'
+    take_one(inp) // 'b'
+  });
+  assert_eq!(res, Ok(()));
+  let err = green.expect_err("typed: the reopened node is correctly reported open");
+  assert!(
+    matches!(err, FinishError::UnclosedNodes { .. }),
+    "unexpected refusal shape: {err:?}"
+  );
+}
+
+/// The SUCCESS exit under the IDENTICAL drive — one line differs from the cell above, and the
+/// two now answer identically. This is the precedent the failing exit was made to match: the
+/// finish is an append, the rollback truncates it, the node is open again, and `finish` gives
+/// the typed refusal the law promises.
+#[test]
+fn raw_bracket_success_exit_below_a_point_is_exactly_restored_by_the_rollback() {
+  let (res, green) = run("ab", |inp| {
+    let m_cell = core::cell::Cell::new(None);
+    Empty::new()
+      .map_with(|_o, mut st| m_cell.set(Some(st.cst_start(K_NODE))))
+      .parse_input(inp)?;
+    let id = inp.begin_point();
+    take_one(inp)?; // 'a'
+    // The SUCCESS exit, below the point.
+    Empty::new()
+      .map_with(|_o, mut st| st.cst_finish(K_NODE))
+      .parse_input(inp)?;
+    inp.rollback_point(id);
+    take_one(inp)?; // 'a'
+    take_one(inp) // 'b'
+  });
+  assert_eq!(res, Ok(()));
+  let err = green.expect_err("typed: the reopened node is correctly reported open");
+  assert!(
+    matches!(err, FinishError::UnclosedNodes { .. }),
+    "unexpected refusal shape: {err:?}"
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Two raw brackets: innermost-first closings are the contract, and debug says so
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// `node()` mints and spends its mark inside one call frame, so its exits nest structurally and
+// a grammar can never reach the shape below. The raw surface can: `cst_start` hands back a
+// `Copy` mark, so two brackets' closings can be emitted in either order. These two cells pin
+// which order the surface asks for and what the other one costs.
+
+/// The **interleaved** order — the enclosing start demoted while the inner one is still open —
+/// is refused at the emit site in a debug build. The dip is positional: the ancestor's `Demote`
+/// sits above the inner slot with its paired `+1` *below* it, so the inner node was closed by
+/// nothing.
+///
+/// This is a strictness choice rather than early detection: release admits the same order and
+/// materialises the identical both-abandoned tree, which
+/// `interleaved_and_innermost_first_demotes_materialize_the_same_tree` in the sink suite pins
+/// directly. The cell exists so the *emit-site* half of that statement is checked too, and it
+/// drives the raw surface the way a caller would.
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "closings INTERLEAVE instead of nesting")]
+fn raw_interleaved_bracket_exits_panic_in_debug() {
+  let _ = run("ab", |inp| {
+    let outer = core::cell::Cell::new(None);
+    let inner = core::cell::Cell::new(None);
+    Empty::new()
+      .map_with(|_o, mut st| outer.set(Some(st.cst_start(K_NODE))))
+      .parse_input(inp)?;
+    Empty::new()
+      .map_with(|_o, mut st| inner.set(Some(st.cst_start(K_INNER))))
+      .parse_input(inp)?;
+    take_one(inp)?; // 'a', inside both
+    // The ENCLOSING bracket's failing exit, emitted while the inner node is still open.
+    Empty::new()
+      .map_with(|_o, mut st| st.cst_demote(outer.get().expect("stashed"), K_NODE))
+      .parse_input(inp)?;
+    // …and now the inner one. Its slot is untouched and passes every content check; only the
+    // suffix recount sees that an ancestor already closed out from under it.
+    Empty::new()
+      .map_with(|_o, mut st| st.cst_demote(inner.get().expect("stashed"), K_INNER))
+      .parse_input(inp)?;
+    take_one(inp) // 'b'
+  });
+}
+
+/// The **innermost-first** order under the identical drive — one pair of lines swapped — is
+/// admitted in every build, and both brackets abandon: no node at all, and the two tokens land
+/// loose in the root with losslessness intact.
+#[test]
+fn raw_innermost_first_bracket_exits_are_admitted_and_abandon_both() {
+  let (res, green) = run("ab", |inp| {
+    let outer = core::cell::Cell::new(None);
+    let inner = core::cell::Cell::new(None);
+    Empty::new()
+      .map_with(|_o, mut st| outer.set(Some(st.cst_start(K_NODE))))
+      .parse_input(inp)?;
+    Empty::new()
+      .map_with(|_o, mut st| inner.set(Some(st.cst_start(K_INNER))))
+      .parse_input(inp)?;
+    take_one(inp)?; // 'a', inside both
+    Empty::new()
+      .map_with(|_o, mut st| st.cst_demote(inner.get().expect("stashed"), K_INNER))
+      .parse_input(inp)?;
+    Empty::new()
+      .map_with(|_o, mut st| st.cst_demote(outer.get().expect("stashed"), K_NODE))
+      .parse_input(inp)?;
+    take_one(inp) // 'b'
+  });
+  assert_eq!(res, Ok(()));
+  let green = green.expect("innermost-first closings are the contract, in every build");
+  let root = tree(green);
+  assert_eq!(root.text(), "ab", "losslessness holds");
+  assert_eq!(
+    root.children().count(),
+    0,
+    "both brackets took their failing exit: neither node materializes"
+  );
+  assert_eq!(
+    root.children_with_tokens().count(),
+    2,
+    "the two tokens are loose in the root"
   );
 }

--- a/tokora/tests/parser_node.rs
+++ b/tokora/tests/parser_node.rs
@@ -437,6 +437,82 @@ fn backtrack_equivalence_seed_declined_wrap_vs_straight() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
+// The two brackets — up-front (`ParseInput`) and retro (everything else)
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// `Node` carries an up-front bracket as a `ParseInput` (`cst_start` at entry, `cst_finish` or
+// `cst_demote` at exit) and the retro one as a `TryParseInput` (`cst_mark` at entry, spent as a
+// retro-wrap on acceptance only), because a declining parser's kind is not knowable at entry —
+// a decline must leave *nothing*, on a path that also consumes nothing. The two encodings are
+// observationally equivalent, and these two cells are what keeps them so.
+
+/// **The equivalence.** Same source, same kind, same committed region: the two brackets build
+/// the byte-identical green tree. This is the crate-local half of the four-corpora
+/// byte-identity gate, and unlike that gate it is not blind to the retro path.
+#[test]
+fn the_up_front_and_retro_brackets_build_the_identical_tree() {
+  /// Accepts and consumes two tokens, declining only on an empty input.
+  fn try_two(inp: &mut Ir<'_, '_>) -> Result<ParseAttempt<()>, TestErr> {
+    match inp.try_expect(|t| t.data().0 == b'a')? {
+      Some(_) => {
+        take_one(inp)?;
+        Ok(ParseAttempt::Accept(()))
+      }
+      None => Ok(ParseAttempt::Decline),
+    }
+  }
+
+  let (res, up_front) = run("ab", |inp| node(K_NODE, take_two).parse_input(inp));
+  assert_eq!(res, Ok(()));
+
+  let (res, retro) = run("ab", |inp| {
+    let attempt = node(K_NODE, try_two).try_parse_input(inp)?;
+    assert!(matches!(attempt, ParseAttempt::Accept(())));
+    Ok(())
+  });
+  assert_eq!(res, Ok(()));
+
+  assert_eq!(
+    up_front.expect("the up-front bracket balances"),
+    retro.expect("the retro bracket balances"),
+    "the two bracket encodings must materialize the same tree — a divergence here is a wrong \
+     tree that the GraphQL corpora, which drive only the up-front path, cannot see"
+  );
+}
+
+/// **The decline path stays retro, and stays balanced.** The regression this pins is the
+/// tempting generalisation: converting `TryParseInput for Node` to the up-front bracket too.
+/// A decline would then leave an open `StartNode` that no exit closes — `cst_demote` is the
+/// *failure* exit and a decline is not a failure — and the strict `finish` door would refuse
+/// the whole parse with `UnclosedNodes` even though the grammar behaved perfectly. The cell is
+/// green today and reds on that change, which is exactly its job.
+#[test]
+fn a_decline_leaves_the_buffer_balanced_and_the_strict_finish_door_open() {
+  let (res, green) = run("ab", |inp| {
+    // Declines twice — once bare, once through `node_opt`'s adapter — with a successful
+    // up-front node between them, so a dangling start from either decline is visible.
+    let first = node(K_NODE, try_x).try_parse_input(inp)?;
+    assert!(matches!(first, ParseAttempt::Decline));
+    node(K_INNER, take_one).parse_input(inp)?;
+    assert_eq!(node_opt(K_NODE, try_x).parse_input(inp)?, None);
+    take_one(inp)
+  });
+  assert_eq!(res, Ok(()));
+
+  let root = tree(green.expect(
+    "the strict door: two declines leave nothing open, so `finish` succeeds rather than \
+     reporting UnclosedNodes",
+  ));
+  assert_eq!(root.text().to_string(), "ab");
+  assert_eq!(
+    root.children().count(),
+    1,
+    "only the accepted node exists — a decline records no node, not even an empty one"
+  );
+  assert_eq!(root.first_child().expect("Root[Inner]").kind(), K_INNER);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
 // node_at() / node_opt()
 // ═══════════════════════════════════════════════════════════════════════════════
 

--- a/tokora/tests/parser_node.rs
+++ b/tokora/tests/parser_node.rs
@@ -1188,3 +1188,118 @@ fn raw_innermost_first_bracket_exits_are_admitted_and_abandon_both() {
     "the two tokens are loose in the root"
   );
 }
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// A rollback BELOW an in-progress bracket's start: the sink mechanism, and the wall
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// The session-point block further up asks what happens when a point sits ABOVE a bracket's
+// slot. This block asks the mirror question — a point opened BEFORE the bracket, rolled back
+// BELOW its start — which is the one an external review raised against the blessed combinator.
+//
+// The answer has two halves, and they are pinned separately because they are different kinds
+// of fact:
+//
+// - **At the sink**, the mechanism is real: the rollback truncates the slot away, the mark
+//   stales, and the failing exit's `cst_demote` hits `validate_start_mark`'s every-build
+//   assert. `raw_demote_after_a_rollback_below_the_start_panics` drives exactly that, through
+//   the raw surface, where it is the documented contract.
+// - **Through `node()`, it is unreachable**, and not by a runtime check — `take_point`'s settle
+//   scan is newest-first, and a point opened before the bracket has no younger open above it,
+//   so the scan would accept it. It is unreachable because the *type system* refuses to carry a
+//   `SessionPointId` across the bracket boundary at all. That is the load-bearing fact, and it
+//   is pinned as two compile-fail cases: `tests/ui/session_point_cannot_cross_into_a_bracket.rs`
+//   and its `_impl` companion.
+//
+// The last cell in the block is the asymmetry control: opened inside, rolled back inside, green.
+
+/// **The mechanism, at the raw surface, where it is the published contract.** A session point
+/// opened *below* a raw bracket's `cst_start`, rolled back after the content is recorded: the
+/// truncation takes the slot with it, so the mark is stale and `cst_demote` refuses to spend it
+/// — in **every** build, because naming whatever else lands at that index would be the
+/// wrong-tree class nothing downstream can detect.
+///
+/// Unconditional rather than `#[cfg(debug_assertions)]`: this is the identity/liveness wall, not
+/// the debug suffix recount.
+///
+/// This is precisely what would fire *inside* `node()` if a pre-bracket point could be settled
+/// in its inner parser. It cannot — see the compile-fail cases named above — so this cell is the
+/// raw surface's contract and not a reachable defect of the combinator.
+#[test]
+#[should_panic(expected = "does not name a live open node")]
+fn raw_demote_after_a_rollback_below_the_start_panics() {
+  let _ = run("ab", |inp| {
+    // The emitter row lands BELOW the slot: the point opens before the bracket does.
+    let id = inp.begin_point();
+    let m_cell = core::cell::Cell::new(None);
+    Empty::new()
+      .map_with(|_o, mut st| m_cell.set(Some(st.cst_start(K_NODE))))
+      .parse_input(inp)?;
+    take_one(inp)?; // 'a'
+    // Truncates the slot away and records the truncation era.
+    inp.rollback_point(id);
+    // The failing exit, now spending a mark whose slot is gone.
+    Empty::new()
+      .map_with(|_o, mut st| st.cst_demote(m_cell.get().expect("stashed"), K_NODE))
+      .parse_input(inp)?;
+    take_one(inp)
+  });
+}
+
+/// **And the retro encoding is not a refuge from it.** The same drive, one encoding back: a
+/// `cst_mark` minted above the point, staled by the same rollback, then handed to `node_at` —
+/// which is a *public API argument*, not an internal handback. It panics too, on the
+/// pre-existing `validate_mark` wall, and on the **success** exit rather than the failing one.
+///
+/// The cell exists because the finding framed the panic as a regression the up-front bracket
+/// introduced. It is not: a rollback below a pending wrap's anchor has always been a
+/// spend-time panic, and the retro shape reaches it on the exit a grammar is *more* likely to
+/// take.
+#[test]
+#[should_panic(expected = "stale EventMark")]
+fn retro_node_at_over_a_mark_staled_by_the_same_rollback_panics_too() {
+  let _ = run("ab", |inp| {
+    let id = inp.begin_point();
+    let m_cell = core::cell::Cell::new(None);
+    Empty::new()
+      .map_with(|_o, mut st| m_cell.set(Some(st.cst_mark())))
+      .parse_input(inp)?;
+    take_one(inp)?; // 'a'
+    inp.rollback_point(id); // stales the mark
+    node_at(m_cell.get().expect("stashed"), K_NODE, take_one).parse_input(inp)
+  });
+}
+
+/// **The asymmetry control, and the settled twin of the abandon-shape cell above.** A session
+/// point opened *inside* the blessed bracket's inner parser and rolled back there sits ABOVE the
+/// slot, so the truncation stops short of it: the start survives, the mark stays live, and the
+/// failing exit's demote is valid. A bracket cannot be staled from inside itself.
+///
+/// `a_live_point_above_the_slot_at_demote_time_is_a_legal_and_harmless_history` is the same
+/// geometry with the point *abandoned*; this one **settles** it, which is the stronger claim —
+/// the rollback actually runs, and the demote that follows it still validates.
+#[test]
+fn a_point_opened_inside_the_bracket_and_rolled_back_inside_keeps_the_demote_valid() {
+  let (res, green) = run("ab", |inp| {
+    let r: Result<(), TestErr> = node(K_NODE, |ii: &mut Ir<'_, '_>| {
+      // The row lands ABOVE the slot: the point opens after the bracket's own cst_start.
+      let id = ii.begin_point();
+      take_one(ii)?; // 'a'
+      ii.rollback_point(id); // truncates back to just above the slot
+      Err(TestErr::Boom) // the failing exit, demoting a still-live mark
+    })
+    .parse_input(inp);
+    assert_eq!(r, Err(TestErr::Boom), "the bracket failed and demoted");
+    take_one(inp)?; // 'a' again — the rollback un-consumed it
+    take_one(inp) // 'b'
+  });
+  assert_eq!(res, Ok(()));
+  let green = green.expect("lawful parse: balanced buffer, full coverage");
+  let root = tree(green);
+  assert_eq!(root.text(), "ab", "losslessness holds");
+  assert_eq!(
+    root.children().count(),
+    0,
+    "the failed bracket correctly leaves no node"
+  );
+}

--- a/tokora/tests/ui/cst_demote_cannot_be_inherited.rs
+++ b/tokora/tests/ui/cst_demote_cannot_be_inherited.rs
@@ -1,0 +1,93 @@
+// THE FAILING EXIT CANNOT BE INHERITED. `CstEmitter::cst_demote` is a REQUIRED method, and this
+// case is the wall.
+//
+// The shape below is not hypothetical — it is the exact state the compiler steers a 0.8-era
+// wrapper into. Such a wrapper forwarded the four CST methods that existed when it was written;
+// rebasing it onto 0.9.0 produces exactly one diagnostic, `E0053` on `cst_start`, and rustc's own
+// fix-it writes the migration ("change the output type to match the trait: `-> EventMark`") while
+// mentioning `cst_demote` nowhere. Apply the suggestion and, if the fifth method were defaulted,
+// the impl would compile with zero warnings and be byte-perfect on every success path — and on
+// `node()`'s failing exit the demote would dispatch into the inherited empty body, leaving the
+// inner channel a `StartNode` no exit ever closes. That residue is byte-identical to the one an
+// escaped panic leaves, so no sink-side check can ever tell the two apart: strict `finish` would
+// refuse a grammar that did everything right, and `finish_partial` would materialize the node the
+// grammar retracted. There is no runtime wall to build here, which is why the wall is `E0046`.
+//
+// So this case's subject is the ABSENCE of a default body on one trait method, and its teeth are
+// mostly aimed at the future. Re-add that default "for convenience" and this file starts
+// compiling; a `compile_fail` case that compiles is a failing test, and it is the only signal
+// there would be — every other gate stays green, because the trap is silent by construction.
+// `every_ui_case_file_is_registered` keeps it from being quietly deregistered instead.
+//
+// What it does NOT claim: nothing forces a wrapper to forward. Writing `fn cst_demote(..) {}` here
+// would compile, and that is the whole point of the remedy — discard-by-silence becomes
+// discard-in-writing, in the implementor's own diff, where a reviewer reads it. See
+// `CstEmitter::cst_demote`'s *Required, not defaulted* for the failure-direction rule that makes
+// this method the only one on the trait to be graded this way.
+#![allow(dead_code)]
+
+use tokora::{
+  Emitter, Lexer, Token, cst::event::EventMark, emitter::CstEmitter,
+  error::token::UnexpectedTokenOf, input::Cursor, span::Spanned,
+};
+
+/// A generic forwarding wrapper — the fully-public downstream population. It cannot mint an
+/// `EventMark` of its own (`EventMark::new` and `::inert` are both crate-private), so every
+/// downstream `cst_start` overrider is a forwarder or an instrumentor, and both owe the demote.
+struct Wrapper<E>(E);
+
+impl<'inp, L, E> Emitter<'inp, L> for Wrapper<E>
+where
+  L: Lexer<'inp>,
+  E: Emitter<'inp, L>,
+{
+  type Error = E::Error;
+
+  fn emit_lexer_error(
+    &mut self,
+    err: Spanned<<L::Token as Token<'inp>>::Error, L::Span>,
+  ) -> Result<(), Self::Error> {
+    self.0.emit_lexer_error(err)
+  }
+
+  fn emit_unexpected_token(
+    &mut self,
+    err: UnexpectedTokenOf<'inp, L, ()>,
+  ) -> Result<(), Self::Error> {
+    self.0.emit_unexpected_token(err)
+  }
+
+  fn emit_error(&mut self, err: Spanned<Self::Error, L::Span>) -> Result<(), Self::Error> {
+    self.0.emit_error(err)
+  }
+
+  fn rewind(&mut self, cursor: &Cursor<'inp, '_, L>, checkpoint: u64) {
+    self.0.rewind(cursor, checkpoint);
+  }
+}
+
+// The four methods a 0.8 wrapper knew about, forwarded — including `cst_start` with the return
+// type rustc's fix-it supplies. `cst_demote` is deliberately absent: that omission is the case.
+impl<'inp, L, E> CstEmitter<'inp, L> for Wrapper<E>
+where
+  L: Lexer<'inp>,
+  E: CstEmitter<'inp, L>,
+{
+  fn cst_start(&mut self, kind: u16) -> EventMark {
+    self.0.cst_start(kind)
+  }
+
+  fn cst_finish(&mut self, kind: u16) {
+    self.0.cst_finish(kind);
+  }
+
+  fn cst_mark(&mut self) -> EventMark {
+    self.0.cst_mark()
+  }
+
+  fn cst_start_at(&mut self, mark: EventMark, kind: u16) {
+    self.0.cst_start_at(mark, kind);
+  }
+}
+
+fn main() {}

--- a/tokora/tests/ui/cst_demote_cannot_be_inherited.stderr
+++ b/tokora/tests/ui/cst_demote_cannot_be_inherited.stderr
@@ -1,0 +1,10 @@
+error[E0046]: not all trait items implemented, missing: `cst_demote`
+  --> tests/ui/cst_demote_cannot_be_inherited.rs:71:1
+   |
+71 | / impl<'inp, L, E> CstEmitter<'inp, L> for Wrapper<E>
+72 | | where
+73 | |   L: Lexer<'inp>,
+74 | |   E: CstEmitter<'inp, L>,
+   | |_________________________^ missing `cst_demote` in implementation
+   |
+   = help: implement the missing item: `fn cst_demote(&mut self, _: EventMark, _: u16) { todo!() }`

--- a/tokora/tests/ui/session_point_cannot_cross_into_a_bracket.rs
+++ b/tokora/tests/ui/session_point_cannot_cross_into_a_bracket.rs
@@ -1,0 +1,64 @@
+// THEOREM. A `SessionPointId` minted **outside** a `node()` bracket cannot be settled
+// **inside** it. This case is the load-bearing half of that proof: the closure form.
+//
+// # Why the bracket's correctness rests on this
+//
+// `Node`'s `ParseInput` impl is an up-front bracket — `cst_start` on entry, and on the `Err`
+// exit a `cst_demote` spending the mark that start handed back. `validate_start_mark` asserts,
+// **in every build**, that the mark still names a live open node; a rollback that truncated the
+// buffer *below* the start would stale it and the demote would panic in release.
+//
+// A rollback below an in-progress bracket's start is exactly what settling a point opened
+// before the bracket does. Nothing at runtime stops it: `take_point`'s settle scan is
+// newest-first, and a point opened before the bracket has no younger open above it, so the scan
+// accepts it. **The type system is the only wall**, and it is this:
+//
+// - `SessionPointId<'closure>` is invariant in `'closure` (an `fn(&'closure ()) -> &'closure ()`
+//   brand, deliberately not a covariant reference);
+// - a parser reaches its input through `ParseInput::parse_input`, whose handle lifetime is
+//   universally quantified — `&mut InputRef<'inp, '_, …>`, a fresh region per call;
+// - an invariant token branded with one concrete region cannot be handed to a frame that
+//   demands every region. The two cannot unify in either direction, and rustc says so below.
+//
+// The mirror shape — a point opened *inside* the bracket and rolled back there — is legal,
+// harmless, and green: it sits **above** the slot, so the truncation keeps the start. That
+// asymmetry is pinned at runtime by
+// `a_point_opened_inside_the_bracket_and_rolled_back_inside_keeps_the_demote_valid` in
+// `tests/parser_node.rs`; the panic this case makes unreachable is pinned as a raw-surface
+// contract by `raw_demote_after_a_rollback_below_the_start_panics` beside it.
+//
+// **If this file ever compiles, the wall is gone** and `node()` can panic in a release build.
+// Any new session-verb surface — on `ParseState`, or any other handle a parser can reach — must
+// re-prove this theorem before it ships. See the module docs on `src/parser/node.rs`.
+#![allow(dead_code)]
+
+use tokora::{
+  Emitter, InputRef, Lexer, ParseContext, ParseInput, SessionPointId, emitter::CstEmitter,
+  parser::node,
+};
+
+const K_NODE: u16 = 1;
+
+// Generic over the lexer and the parse context, so the refusal is a property of the bound and
+// not of one fixture's concrete types.
+fn cross_into_the_bracket<'inp, 'closure, L, Ctx>(
+  input: &mut InputRef<'inp, 'closure, L, Ctx, ()>,
+) -> Result<(), <Ctx::Emitter as Emitter<'inp, L, ()>>::Error>
+where
+  L: Lexer<'inp>,
+  L::State: Clone,
+  Ctx: ParseContext<'inp, L, ()>,
+  Ctx::Emitter: CstEmitter<'inp, L, ()>,
+{
+  // Opened BEFORE the bracket: its brand is this frame's concrete `'closure`.
+  let id: SessionPointId<'closure> = input.begin_point();
+  node(K_NODE, move |inner: &mut InputRef<'inp, '_, L, Ctx, ()>| {
+    // The one offending line. The body is otherwise inert and returns `Ok(())`, so nothing
+    // else here can carry the error: settling this id inside the bracket is the whole case.
+    inner.rollback_point(id);
+    Ok(())
+  })
+  .parse_input(input)
+}
+
+fn main() {}

--- a/tokora/tests/ui/session_point_cannot_cross_into_a_bracket.stderr
+++ b/tokora/tests/ui/session_point_cannot_cross_into_a_bracket.stderr
@@ -1,0 +1,27 @@
+error[E0521]: borrowed data escapes outside of closure
+  --> tests/ui/session_point_cannot_cross_into_a_bracket.rs:58:5
+   |
+54 |   let id: SessionPointId<'closure> = input.begin_point();
+   |       -- `id` declared here, outside of the closure body
+55 |   node(K_NODE, move |inner: &mut InputRef<'inp, '_, L, Ctx, ()>| {
+   |                      ----- `inner` is a reference that is only valid in the closure body
+...
+58 |     inner.rollback_point(id);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ `inner` escapes the closure body here
+   |
+   = note: requirement occurs because of the type `SessionPointId<'_>`, which makes the generic argument `'_` invariant
+   = note: the struct `SessionPointId<'closure>` is invariant over the parameter `'closure`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> tests/ui/session_point_cannot_cross_into_a_bracket.rs:58:5
+   |
+44 | fn cross_into_the_bracket<'inp, 'closure, L, Ctx>(
+   |                           ----  -------- lifetime `'closure` defined here
+   |                           |
+   |                           lifetime `'inp` defined here
+...
+58 |     inner.rollback_point(id);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'closure` must outlive `'inp`
+   |
+   = help: consider adding the following bound: `'closure: 'inp`

--- a/tokora/tests/ui/session_point_cannot_cross_into_a_bracket_impl.rs
+++ b/tokora/tests/ui/session_point_cannot_cross_into_a_bracket_impl.rs
@@ -1,0 +1,64 @@
+// THEOREM, second half: the manual-`impl` route is refused too.
+//
+// The companion case (`session_point_cannot_cross_into_a_bracket.rs`) drives a **closure**
+// through the blanket `ParseInput` impl, so a reader could reasonably suspect the refusal is an
+// artifact of closure inference — that spelling the parser out by hand would let a
+// pre-opened `SessionPointId` in through the front door. It does not, and this case is why:
+// the wall is the trait's own quantification, not the closure's.
+//
+// A hand-written implementor may store whatever it likes, including a branded id. But
+// `parse_input`'s handle lifetime is fresh at every call — `&mut InputRef<'inp, '_, …>` — and
+// `SessionPointId<'closure>` is invariant, so a stored id branded with the *struct's* region
+// can be neither shortened nor lengthened into the method's. rustc reports the equality
+// requirement in both directions below, and names the invariance as the cause.
+//
+// Together the two cases say: **no safe surface can settle a point across a `node()`
+// boundary**, which is what makes the bracket's every-build `validate_start_mark` assert
+// unreachable from the blessed combinator, and what a future session verb must re-prove. See
+// the module docs on `src/parser/node.rs`.
+#![allow(dead_code)]
+
+use tokora::{
+  Emitter, InputRef, Lexer, ParseContext, ParseInput, SessionPointId, emitter::CstEmitter,
+  parser::node,
+};
+
+const K_NODE: u16 = 1;
+
+/// A parser that smuggles in an id opened before the bracket that will drive it.
+struct Rollback<'closure> {
+  id: SessionPointId<'closure>,
+}
+
+impl<'inp, L, Ctx> ParseInput<'inp, L, (), Ctx, ()> for Rollback<'_>
+where
+  L: Lexer<'inp>,
+  L::State: Clone,
+  Ctx: ParseContext<'inp, L, ()>,
+{
+  fn parse_input(
+    &mut self,
+    input: &mut InputRef<'inp, '_, L, Ctx, ()>,
+  ) -> Result<(), <Ctx::Emitter as Emitter<'inp, L, ()>>::Error> {
+    // The one offending line, exactly as in the closure case.
+    input.rollback_point(self.id);
+    Ok(())
+  }
+}
+
+// The call site the impl above exists to serve — kept so the case shows the whole shape it
+// refuses, not just an orphan impl. It contributes no error of its own.
+fn drive<'inp, 'closure, L, Ctx>(
+  input: &mut InputRef<'inp, 'closure, L, Ctx, ()>,
+) -> Result<(), <Ctx::Emitter as Emitter<'inp, L, ()>>::Error>
+where
+  L: Lexer<'inp>,
+  L::State: Clone,
+  Ctx: ParseContext<'inp, L, ()>,
+  Ctx::Emitter: CstEmitter<'inp, L, ()>,
+{
+  let id: SessionPointId<'closure> = input.begin_point();
+  node(K_NODE, Rollback { id }).parse_input(input)
+}
+
+fn main() {}

--- a/tokora/tests/ui/session_point_cannot_cross_into_a_bracket_impl.stderr
+++ b/tokora/tests/ui/session_point_cannot_cross_into_a_bracket_impl.stderr
@@ -1,0 +1,45 @@
+error: lifetime may not live long enough
+  --> tests/ui/session_point_cannot_cross_into_a_bracket_impl.rs:44:5
+   |
+33 | impl<'inp, L, Ctx> ParseInput<'inp, L, (), Ctx, ()> for Rollback<'_>
+   |      ---- lifetime `'inp` defined here
+...
+40 |     &mut self,
+   |     --------- has type `&mut Rollback<'1>`
+...
+44 |     input.rollback_point(self.id);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'inp` must outlive `'1`
+   |
+   = note: requirement occurs because of the type `SessionPointId<'_>`, which makes the generic argument `'_` invariant
+   = note: the struct `SessionPointId<'closure>` is invariant over the parameter `'closure`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> tests/ui/session_point_cannot_cross_into_a_bracket_impl.rs:44:5
+   |
+40 |     &mut self,
+   |     --------- has type `&mut Rollback<'1>`
+41 |     input: &mut InputRef<'inp, '_, L, Ctx, ()>,
+   |     ----- has type `&mut InputRef<'_, '2, L, Ctx>`
+...
+44 |     input.rollback_point(self.id);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |
+   = note: requirement occurs because of a mutable reference to `InputRef<'_, '_, L, Ctx>`
+   = note: mutable references are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> tests/ui/session_point_cannot_cross_into_a_bracket_impl.rs:44:5
+   |
+40 |     &mut self,
+   |     --------- has type `&mut Rollback<'1>`
+41 |     input: &mut InputRef<'inp, '_, L, Ctx, ()>,
+   |     ----- has type `&mut InputRef<'_, '2, L, Ctx>`
+...
+44 |     input.rollback_point(self.id);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'2` must outlive `'1`
+   |
+   = note: requirement occurs because of the type `SessionPointId<'_>`, which makes the generic argument `'_` invariant
+   = note: the struct `SessionPointId<'closure>` is invariant over the parameter `'closure`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance

--- a/tokora/tools/mdbook_docs_links.py
+++ b/tokora/tools/mdbook_docs_links.py
@@ -236,6 +236,9 @@ DOCS_RS_MAP = {
   "crate::emitter": "emitter/index.html",
   "crate::emitter::ComposableEmitter": "emitter/trait.ComposableEmitter.html",
   "crate::emitter::CstEmitter": "emitter/trait.CstEmitter.html",
+  # `cst_demote` is the trait's one REQUIRED method, so rustdoc anchors it as `#tymethod.`, not
+  # `#method.` like its four defaulted siblings. Re-defaulting it would move the anchor.
+  "crate::emitter::CstEmitter::cst_demote": "emitter/trait.CstEmitter.html#tymethod.cst_demote",
   "crate::emitter::CstEmitter::cst_mark": "emitter/trait.CstEmitter.html#method.cst_mark",
   "crate::emitter::CstEmitter::cst_start_at": "emitter/trait.CstEmitter.html#method.cst_start_at",
   "crate::emitter::Diagnostic": "emitter/struct.Diagnostic.html",


### PR DESCRIPTION
Closes #169.