### PR TITLE
chore(pre-tag): state the probe's trust boundary, pin the demote forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -976,6 +976,66 @@ with it. `ci/changelog_structure.sh` enforces every clause above and will red un
     brand-new line, so the header says to name the targets instead.
     — *(#220)*
 
+22. **The in-crate model of the wrapper hazard was unexercised on `cst_demote` — the one CST
+    method whose loss is silent.** `NonForwardingWrapper` in `src/cst/sink/tests.rs` is the
+    fixture that pins what a consumer-shaped emitter wrapper costs, and its `cst_demote`
+    forward was dead code under the suite: pin 5 drives `cst_start`/`cst_finish` only, and
+    every other demote exercise in the tree is direct-on-sink, through `ParseState`, or through
+    the view/handle forwarding surfaces — none interposes a wrapper. Demonstrated rather than
+    asserted, in the shape this repository requires: emptying that forward to a discard left
+    the lib suite at **1747 passed, 0 failed**.
+
+    That matters because of *which* method it is. `CstEmitter::cst_demote`'s *Required, not
+    defaulted* section grades the five CST methods by failure direction — the four defaulted
+    ones fail toward a loud, typed absence (`OrphanFinish`/`MismatchedFinish`/`UnclosedNodes`,
+    or the inert-mark identity wall), while a swallowed demote fails toward a silent
+    **presence**: the `StartNode` stays open and a sink cannot tell a swallowed demote from a
+    legal panic residue. Requiredness, new in this release, closed the *inherited* discard —
+    the empty impl no longer compiles — and left the population this gap covers untouched: a
+    discard written deliberately, visible in a diff, and wrong.
+
+    One cell closes it. `a_wrapper_forwards_the_node_brackets_failing_exit` opens the up-front
+    bracket through the wrapper, keeps the handback, commits a token, abandons the bracket
+    through the wrapper, and materializes through **strict** `finish` — asserting
+    `demote_materialises_as_inert`'s outcome reached through a forwarder: the abandoned node
+    materializes into nothing and the token survives loose beside it. Its falsifying edit was
+    run in both directions before it landed, which is the only thing that makes a cell like
+    this worth having: with the forward emptied it reds loudly and typed —
+    `Err(FinishError::UnclosedNodes { open: 1 })`, and **1747 passed, 1 failed**, so the new
+    cell is the sole detector — and with it restored the suite is **1748 passed, 0 failed**.
+    Test-only; no shipped surface changed.
+    — *(#226)*
+
+23. **The name-collision probe's `TRAITS` records are trusted, not verified, and the harness
+    said so everywhere except where records are authored.** A trait row names the receiver its
+    probe rides (`recvr`), and no run can check that the named value implements the trait: a
+    subject that does *not* constructs no collision and reports a clean run, byte-identical to
+    the clean run a correct subject produces whenever the consumer's item wins at an earlier
+    pick. Measured for the shape it bites hardest — a `&mut self` trait method on a non-deref
+    subject, where the consumer's blanket `impl<T>` claims every pick and tokora's item is
+    never a candidate — swapping the blessed receiver for one that implements nothing produced
+    the identical `7u8` from the consumer's item and the identical `CONSUMER-CALLS` witness on
+    both sides, a byte-identical `ok*`. Such a row cannot be falsified by running it, so its
+    `no_collision.txt` justification and the reviewer who agrees with it are the whole of its
+    protection.
+
+    This is a property of **method resolution**, not a gap in the templates, so no amount of
+    generator work converts it into machine detection — which is why it lands as prose in three
+    places rather than as a fix. `gen_probe.py`'s `TRAITS` table now carries the trust boundary
+    above the rows themselves, with the measurement and the rule for picking a subject;
+    `ci/name_collision/README.md`'s "What this harness does NOT test" gains the bound, stated
+    as what it costs a reviewer — approving a record is a review act, not a mechanical one;
+    and the generator's `no argument template` refusal now says the multi-argument support is
+    **declined, not missing**, names the reopen condition (a traced-trait method whose shape
+    the templates cannot express *and* whose pick analysis is not foreknown-vacuous), and
+    routes the author who lands there to the ruling instead of into an unbounded enumeration.
+
+    Comments and prose only, with zero verdict changes: driving both generators over 2,182
+    invocations spanning every category, spelling, `TRAITS` owner and templated name produced
+    **0** differences in exit status and **0** in generated probe source. Only the refusal
+    text on stderr differs, which `run.sh` echoes into its log line and never matches.
+    — *(#225)*
+
 ## 0.8.0 (2026-08-04)
 
 The whole of a 52-defect audit campaign lands in one release. Entries are grouped by **kind**, not by the round that produced them: a reader upgrading wants every breaking change in one place. Round provenance rides as an inline tag — *(R7, #117)* — and the pull-request bodies carry the full trail.

--- a/ci/name_collision/README.md
+++ b/ci/name_collision/README.md
@@ -305,6 +305,21 @@ Two things follow, and neither is a bug to be fixed by another round of generato
    project has now lost five times. The harness stays at the shape it can express, and the
    gap is disclosed instead of papered over.
 
+**It does not test its own `TRAITS` records — they are trusted, not verified.** A trait row
+names the receiver its probe rides (`recvr` in `gen_probe.py`), and no run can check that the
+named value implements the trait: a subject that does *not* constructs no collision and reports
+a clean run, which is byte-identical to the clean run a correct subject produces whenever the
+consumer's item wins at an earlier pick. Measured, for the worst shape — a `&mut self` trait
+method on a non-deref subject, where the consumer's blanket item claims every pick and tokora's
+is never a candidate: swapping in a receiver that implements nothing produced the identical
+`7u8` from the consumer's item and the identical `CONSUMER-CALLS` witness on both sides — a
+byte-identical `ok*`, with no column in which the two differ. Such a row **cannot be falsified
+by running it**, so its `no_collision.txt` justification, and the reviewer who agrees with it, are
+the whole of its protection. That is a property of method resolution rather than a gap in the
+templates, which is why it appears here as a bound and not on a fix list. Approving a record is
+therefore a **review act, not a mechanical one**: read the pick analysis, not the verdict
+column, and never take a green `ok*` on such a row as evidence that its subject was right.
+
 ## Categories and spellings
 
 | category | spellings | why |

--- a/ci/name_collision/gen_probe.py
+++ b/ci/name_collision/gen_probe.py
@@ -334,6 +334,40 @@ pub fn emitter_value() -> Silent<PErr> {
 #            nothing — so a new trait is reached through a module glob, which is a legal
 #            consumer spelling on both sides.
 #   fixture  extra source the subject needs, or `None`.
+#
+# ── THE TRUST BOUNDARY: `recvr` IS NOT POLICED BY THE RUN ─────────────────────────────────
+#
+# Read this before adding or editing a row. Nothing below is checked by anything; the table is
+# an assertion its author makes, and for some row shapes it is the ONLY protection there is.
+#
+# The run cannot verify that `recvr` names a value the trait is actually implemented for. It
+# has no witness to key on: a subject that does NOT implement the trait constructs no collision
+# and reports a clean run, which is byte-identical to the clean run a correct subject produces
+# whenever the consumer's item wins at an earlier pick. Both score `ok*`, both sides agree, and
+# both leave the same `CONSUMER-CALLS` witness — there is no column in which they differ.
+#
+# That is not a hypothesis. It was MEASURED (issue #225) for the shape it bites hardest:
+#
+#   A `&mut self` trait method on a NON-DEREF subject. The consumer is `impl<T> ConsumerComb
+#   for T`, so it supplies a candidate at every pick, and `trait_method`'s three spellings
+#   declare `self` or `&self` — both EARLIER than `&mut`, and on a non-deref value there is no
+#   later step to fall through to. The consumer's item therefore claims the call at pick one or
+#   two and tokora's is never a candidate, no matter WHAT the receiver is. Swapping
+#   `emitter_value()` for a receiver that implements nothing produced the identical `7u8` from
+#   the consumer's item and the identical witness on both sides — a byte-identical `ok*`. The
+#   row cannot be falsified by running it.
+#
+# So for such rows the blessed record is TRUSTED, NOT VERIFIED, and the written justification in
+# `no_collision.txt` — read by a human who agrees with it — is the entire mechanism. The only
+# consumer that would genuinely compete declares `&mut self`, collides at the same pick, and is
+# E0034-loud; `trait_method` cannot generate it. This is a property of METHOD RESOLUTION, not a
+# gap in the templates, so no amount of generator work converts it into machine detection —
+# see issue #225's ruling, which declines exactly that work and records why.
+#
+# What follows for an author: pick `recvr` from a type tokora demonstrably implements the trait
+# for (the fixture's own types, not a convenient one), say in the row's `no_collision.txt` entry
+# WHY the subject satisfies the bound, and never read a green `ok*` on a `&mut`-self row as
+# evidence that the subject was right. `EMITTER_SUBJECT_FIXTURE` above is the worked example.
 TRAITS = {
     "ParseInput": {
         "recvr": "parse_num",
@@ -1101,7 +1135,21 @@ def trait_method(name, owner, spelling):
             "tokora::span::Spanned::new(tokora::SimpleSpan::new(0, 1), PErr)",
     }.get(name)
     if args is None:
-        sys.exit(f"gen_probe: no argument template for trait method {name!r} on {owner!r}")
+        # The pointer matters more than the refusal. An author who lands here reads "add a
+        # template" and starts extending — which is the search issue #225 declines by name.
+        sys.exit(
+            f"gen_probe: no argument template for trait method {name!r} on {owner!r}. "
+            "DECLINED, not missing: multi-argument support is deliberately unbuilt — see issue "
+            "#225's ruling BEFORE extending this. Its grounds: for the shapes that reach here "
+            "today every row the extension could produce is foreknown-vacuous (a `&mut self` "
+            "trait method on a non-deref subject loses every pick to the consumer's blanket "
+            "item, so the row would agree while measuring nothing), and generating cells whose "
+            "outcome is known in advance is 'extend the generator until the probe goes green' "
+            "wearing a work order. The reopen condition is a traced-trait method whose shape "
+            "these templates cannot express AND whose pick analysis is NOT foreknown-vacuous. "
+            "Until you hold one: justify the row in no_collision.txt, or state in the PR why "
+            "the name cannot collide. Do not delete the row."
+        )
     # The parameter type is built outside the f-string on purpose. An escaped quote inside
     # an f-string expression is a SyntaxError before Python 3.12 (PEP 701 relaxed it), and
     # this file must parse under the `python3` CI happens to have — which is 3.9 on stock

--- a/tokora/src/cst/sink/tests.rs
+++ b/tokora/src/cst/sink/tests.rs
@@ -6609,6 +6609,10 @@ impl<'inp> crate::Emitter<'inp, MiniLexer<'inp>> for NonForwardingWrapper<'_, 'i
 /// way, so what the three cells below pin is unchanged. What is gone is the *silent* half of the
 /// same shape on the CST surface: a wrapper can still discard the failing exit, but only by
 /// writing the discard where its own reviewer reads it.
+///
+/// The `cst_demote` line below is pinned by `a_wrapper_forwards_the_node_brackets_failing_exit`,
+/// and needs to be: emptying it once left the whole lib suite green, because pin 5 drives
+/// `cst_start`/`cst_finish` only and every other demote exercise bypasses a wrapper entirely.
 impl<'inp> CstEmitter<'inp, MiniLexer<'inp>> for NonForwardingWrapper<'_, 'inp> {
   fn cst_start(&mut self, kind: u16) -> EventMark {
     self.0.cst_start(kind)
@@ -7299,6 +7303,71 @@ fn a_structured_all_diagnostic_parse_through_a_non_forwarding_wrapper_is_not_cau
      text is the sink's \"XY\" — the shape the unqualified wall refused, accepted now, and by \
      accident either way"
   );
+}
+
+/// **THE WRAPPER HAZARD, THE OTHER HALF: the forward that is load-bearing.**
+///
+/// The three cells above pin what a wrapper's *omission* costs. This one pins the opposite
+/// direction — that `NonForwardingWrapper`'s `cst_demote` line does something — and it exists
+/// because nothing in the tree drove the node bracket's **failing** exit through a wrapper at
+/// all. Pin 5 drives `cst_start`/`cst_finish` only, and every other demote exercise is
+/// direct-on-sink, through `ParseState`, or through the view/handle forwarding surfaces — none
+/// interposes a consumer-shaped wrapper. So flipping that fixture's `cst_demote` body to a
+/// discard left the whole lib suite green, and the in-crate model of the wrapper hazard was
+/// unexercised on the one method whose loss is *silent*.
+///
+/// **Why demote alone earns a cell.** [`CstEmitter::cst_demote`]'s *Required, not defaulted*
+/// grades the five by failure direction: the four defaulted methods fail toward a loud, typed
+/// absence, and demote fails toward a silent **presence** — a swallowed demote leaves the
+/// `StartNode` open, and a sink cannot tell a swallowed demote from a legal panic residue.
+/// Requiredness (0.9.0) closed the *inherited* discard; a discard written deliberately still
+/// compiles, and that is the population this cell is against.
+///
+/// **Its falsifying edit, which is the acceptance it landed under.** Empty the forward at
+/// `impl CstEmitter for NonForwardingWrapper` and this cell goes red loudly and typed — strict
+/// `finish` answers `Err(FinishError::UnclosedNodes { open: 1 })`, because the demote never
+/// reached the sink. Restore it and the cell greens. A check that has only ever been green over
+/// a correct wrapper proves nothing, so the flip was run in both directions before this landed.
+///
+/// The pairing is the matching-source control's, not the residue cells' — one buffer on both
+/// sides — so what is measured here is the forward and nothing else.
+#[test]
+fn a_wrapper_forwards_the_node_brackets_failing_exit() {
+  let buf = std::string::String::from("a");
+  let src: &str = &buf;
+  let mut sink: SesSink<'_> = Sink::new(src, Verbose::new(), profile());
+  {
+    let mut input =
+      crate::input::Input::<MiniLexer<'_>, NonFwdCtx<'_, '_>, ()>::with_state_and_context(
+        src,
+        (),
+        crate::input::InputContext::new(
+          NonForwardingWrapper(&mut sink),
+          DefaultCache::<'_, MiniLexer<'_>>::default(),
+        ),
+      );
+    let mut inp = input.as_ref();
+    // The up-front bracket, opened through the wrapper and abandoned through it. The handback
+    // is the *inner sink's* mark — a wrapper can mint none of its own — so only the forward
+    // returns it to the buffer that issued it.
+    let mark = inp.emitter().cst_start(K_NODE);
+    while let Ok(Some(_)) = inp.next() {}
+    inp.emitter().cst_demote(mark, K_NODE);
+  }
+
+  let (green, _emitter) = sink.finish(K_ROOT);
+  let green = green.expect(
+    "the demote arrived, so the buffer is balanced and STRICT finish materializes — a wrapper \
+     that discarded it answers UnclosedNodes here instead, which is this cell's red",
+  );
+  assert_eq!(
+    shape(&green),
+    r#"Root[Tok"a"]"#,
+    "`demote_materialises_as_inert`'s outcome, reached through a wrapper: canonicalization \
+     tombstones the slot, so the abandoned node materializes into nothing and the committed \
+     token survives loose beside it"
+  );
+  assert_eq!(text(green), "a", "the demote costs the tree no text");
 }
 
 /// **A PIN OF A KNOWN-OPEN DEFECT.** Duplicated **zero-width** token events survive: the


### PR DESCRIPTION
Closes #225. Closes #226.