### PR TITLE
docs(miri): record why `rowan` is excluded from the Miri matrix (#235)

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -33,6 +33,33 @@ name: Miri
 # The SCHEDULING-not-coverage promise the split was made under is also unchanged by #216. Every
 # job, matrix cell and step below runs what it ran before: same targets, same shards, same
 # `MIRIFLAGS`, same scripts, same 24 cells plus the plan job. Only `runs-on` changed.
+#
+# ── WHAT THESE 24 CELLS DO NOT COVER, AND WHY IT IS NOT AN OVERSIGHT: `rowan` ───────────────
+#
+# Every cell below runs `ci/miri_sb.sh` or `ci/miri_tb.sh`, and those run two feature sets —
+# `logos` and `logos,unstable-raw`. `rowan` is in neither, and it is not in `default`, so no
+# cell in this workflow has ever COMPILED the lossless CST materialization path. Measured on
+# `543ce6d`: 66 mentions of `feature = "rowan"` across 8 files under `tokora/src`, of which 41
+# are `#[cfg]` gates whose code exists only when the feature is on. Across all three targets and
+# both models that is ZERO coverage of that path, not reduced coverage — and it is the path
+# 0.9.0 ships as its lossless story, which is why it is written down rather than left to be
+# rediscovered.
+#
+# Adding `rowan` to the matrices, or to the scripts' feature sets, does not close the gap: it
+# turns these cells red. `rowan 0.16.1` executes undefined behaviour on its ordinary public
+# path, and the two aliasing models find it at two DIFFERENT sites — Stacked Borrows in
+# `arc.rs:260`, Tree Borrows in `cursor.rs:219` — so neither model is clean and there is no
+# one-model half-measure. Both were reproduced on `543ce6d` on 2026-08-07, red on the first of
+# `--test parser_node`'s 24 tests under each model. The defect is rowan's, not tokora's;
+# `tokora/src/cst` contains no `unsafe` at all.
+#
+# What would flip the answer: a published rowan clean at both sites under both models. Upstream
+# has had the reports open since 2021 (rust-analyzer/rowan#108, #163, #192) and the only fix
+# attempt, PR #211, is a draft whose own description says the immutable path still fails, so
+# this is not a wait measured in weeks. The two scripts carry the full account with backtraces
+# and the exact repro command — read `ci/miri_sb.sh` before adding a feature here. Recorded for
+# 0.9.0 by al8n/tokit#235; the sibling notes are in both scripts, in `tokora/Cargo.toml`'s
+# `rowan` feature, and in the changelog's known-limitation entry.
 
 # Triggers, `paths-ignore` and the concurrency rule are deliberately identical to
 # `.github/workflows/ci.yml`; read the comments there for why the ignore list carries no blanket

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1219,6 +1219,53 @@ row on `Cst` takes the pre-existing-owner shape rather than the seven original o
     observable to a consumer — session-absolute after the parse, attempt-relative during it —
     and a door whose docs contradicted six other passages would have been worse than either.
     — *(#224)*
+### Known limitation — Miri does not interpret the `rowan` lossless path at all, and cannot until rowan is fixed
+
+**Zero coverage, not reduced coverage.** The Miri matrices run two feature sets, `logos` and
+`logos,unstable-raw`. `rowan` is in neither and is not in `default`, so across all three targets
+and both aliasing models, no Miri job in this repository has ever *compiled* the lossless CST
+materialization path — the path this release ships as its lossless story. Measured on `543ce6d`:
+`tokora/src` carries 66 mentions of `feature = "rowan"` across 8 files, of which **41 are
+`#[cfg]` gates whose code exists only when the feature is on**. Those 41 are the uncovered set.
+The remaining 25 are not code Miri is missing: 14 are `doc(cfg(...))` docs.rs labels, 10 are
+doc-text alternations, and one is a `not(feature = "rowan")` arm the current runs do compile.
+
+**Enabling `rowan` there is not the fix — it reddens the cells.** `rowan 0.16.1`, the version
+`Cargo.lock` resolves, executes undefined behaviour on its ordinary public path, and the two
+models find it in two *different* places. Neither model is clean, so there is no
+Tree-Borrows-only half-measure:
+
+- **Stacked Borrows** — `rowan-0.16.1/src/arc.rs:260`, `<HeaderSlice<H, [T; 0]> as Deref>::deref`
+  forging a `&HeaderSlice<H, [T]>` over the whole slice out of a `&self` retagged for the header
+  only. Reached here through `cst::sink::finish::replay` → `materialize` → `Cst::finish`, which
+  is to say from building any tree at all.
+- **Tree Borrows** — `rowan-0.16.1/src/cursor.rs:219`, `rowan::cursor::free` dropping a
+  `Box<NodeData>` through a tag an ancestor's `Cell` still holds. Reached from dropping any
+  red-tree `SyntaxNode`.
+
+Both were reproduced on `543ce6d` on 2026-08-07 with
+`cargo miri test --target aarch64-apple-darwin --test parser_node --features logos,rowan`, the
+two runs differing only in `MIRIFLAGS`. Each was red on the **first** of that target's 24 tests.
+
+**The defect is rowan's, not this crate's.** `src/cst` contains no `unsafe` at all. Upstream has
+had it reported since 2021 — rust-analyzer/rowan#108, #163 and #192, all three still open — and
+the only fix attempt, PR #211, is a draft whose own description says the immutable path still
+fails. A version bump is not an answer either: the `arc.rs` construct is present unchanged in
+`0.17.0`, the newest release.
+
+**What this does and does not mean for a consumer.** The lossless path is not untested. It runs
+in `cargo test --all-features` and `cargo test --release --all-features`, and in both sanitizer
+cells, which are `--all-features` as well — so it is exercised, and exercised under ASan and
+TSan. What it has never had is an *aliasing-model* check, which is the one class those gates
+cannot see and Miri exists for. That bound is disclosed here rather than left to be discovered.
+
+**What would flip it.** A published rowan clean at both sites under `-Zmiri-strict-provenance`
+and under `-Zmiri-tree-borrows`. At that point `rowan` joins the feature sets in `ci/miri_sb.sh`
+and `ci/miri_tb.sh`. The reason is written at each place a re-enabler arrives from — both of
+those scripts, `.github/workflows/miri.yml`, and `tokora/Cargo.toml`'s `rowan` feature — so the
+decision does not have to be rederived from this file.
+
+— *(#235)*
 
 ## 0.8.0 (2026-08-04)
 

--- a/ci/miri_sb.sh
+++ b/ci/miri_sb.sh
@@ -114,8 +114,8 @@ cargo miri setup
 #     through a tag an ancestor's `Cell` still holds. Reached from dropping any red-tree
 #     `SyntaxNode`.
 #
-# Reproduced 2026-08-07 on `543ce6d`, each model differing from the line below only in
-# `MIRIFLAGS`:
+# Reproduced 2026-08-07 on `543ce6d`. Both runs used the command below and differed only in
+# `MIRIFLAGS`, exactly as this script and `ci/miri_tb.sh` differ:
 #
 #     cargo miri test --target aarch64-apple-darwin --test parser_node --features logos,rowan
 #

--- a/ci/miri_sb.sh
+++ b/ci/miri_sb.sh
@@ -92,6 +92,51 @@ rustup toolchain install nightly --component miri
 rustup override set nightly
 cargo miri setup
 
+# ── WHAT THE TWO FEATURE SETS BELOW DO NOT COVER: `rowan` ───────────────────────────────────
+#
+# The passes below run `--features logos` and `--features logos,unstable-raw`. `rowan` is in
+# neither and is not in `default`, so no Miri job in this repository has ever COMPILED the
+# lossless CST materialization path — the one 0.9.0 ships as its lossless story. Measured on
+# `543ce6d`: 66 mentions of `feature = "rowan"` across 8 files under `tokora/src`, of which 41
+# are `#[cfg]` gates whose code exists only when the feature is on. Every target, both models:
+# that is ZERO coverage of that path, not reduced coverage.
+#
+# ADDING `rowan` HERE DOES NOT CLOSE THE GAP — IT TURNS THESE CELLS RED. `rowan 0.16.1`, the
+# version `Cargo.lock` resolves, executes undefined behaviour on its ordinary public path, and
+# the two aliasing models find it in two DIFFERENT places. Neither model is clean, so there is
+# no one-model half-measure:
+#
+#   * Stacked Borrows — THIS model — `src/arc.rs:260`, `<HeaderSlice<H, [T; 0]> as Deref>::deref`
+#     forging a `&HeaderSlice<H, [T]>` over the whole slice out of a `&self` retagged for the
+#     header only. Reached through `tokora::cst::sink::finish::replay` → `materialize` →
+#     `Cst::finish`, i.e. from building any tree at all.
+#   * Tree Borrows — `src/cursor.rs:219`, `rowan::cursor::free` dropping a `Box<NodeData>`
+#     through a tag an ancestor's `Cell` still holds. Reached from dropping any red-tree
+#     `SyntaxNode`.
+#
+# Reproduced 2026-08-07 on `543ce6d`, each model differing from the line below only in
+# `MIRIFLAGS`:
+#
+#     cargo miri test --target aarch64-apple-darwin --test parser_node --features logos,rowan
+#
+# Both models red on the FIRST of that target's 24 tests.
+#
+# The defect is rowan's, not tokora's: `tokora/src/cst` contains no `unsafe` at all. Upstream has
+# had it reported since 2021 — rust-analyzer/rowan#108, #163, #192, all three still open — and
+# the only fix attempt, PR #211, is a draft whose own description says the immutable path still
+# fails. Bumping is not a known answer either: the `arc.rs` construct above is present unchanged
+# in `0.17.0`, the newest release, and al8n/smear#77 reproduced both reds against it standalone.
+#
+# WHAT WOULD FLIP THIS ANSWER. A published rowan whose `arc.rs` `Deref` and whose `cursor.rs`
+# `free` are both clean under `-Zmiri-strict-provenance` and under `-Zmiri-tree-borrows`. Then
+# add `rowan` to the feature sets below and to `ci/miri_tb.sh`'s — and extend
+# `ci/miri_shard.py`'s enumeration if any `rowan`-gated test TARGET arrives with it — rather
+# than leaving this note to rot.
+#
+# Recorded for 0.9.0 by al8n/tokit#235. The same answer is written where the other re-enablers
+# arrive from: `ci/miri_tb.sh`, `.github/workflows/miri.yml`, `tokora/Cargo.toml`'s `rowan`
+# feature, and the changelog's known-limitation entry.
+
 export MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-disable-isolation -Zmiri-symbolic-alignment-check"
 export RUSTFLAGS="--cfg test_$CONFIG_FLAGS"
 

--- a/ci/miri_tb.sh
+++ b/ci/miri_tb.sh
@@ -92,6 +92,52 @@ rustup toolchain install nightly --component miri
 rustup override set nightly
 cargo miri setup
 
+# ── WHAT THE TWO FEATURE SETS BELOW DO NOT COVER: `rowan` ───────────────────────────────────
+#
+# The passes below run `--features logos` and `--features logos,unstable-raw`. `rowan` is in
+# neither and is not in `default`, so no Miri job in this repository has ever COMPILED the
+# lossless CST materialization path — the one 0.9.0 ships as its lossless story. Measured on
+# `543ce6d`: 66 mentions of `feature = "rowan"` across 8 files under `tokora/src`, of which 41
+# are `#[cfg]` gates whose code exists only when the feature is on. Every target, both models:
+# that is ZERO coverage of that path, not reduced coverage.
+#
+# ADDING `rowan` HERE DOES NOT CLOSE THE GAP — IT TURNS THESE CELLS RED. `rowan 0.16.1`, the
+# version `Cargo.lock` resolves, executes undefined behaviour on its ordinary public path, and
+# the two aliasing models find it in two DIFFERENT places. Neither model is clean, so there is
+# no one-model half-measure — in particular, this being the newer and more permissive model does
+# NOT make it the survivable one:
+#
+#   * Tree Borrows — THIS model — `src/cursor.rs:219`, `rowan::cursor::free` dropping a
+#     `Box<NodeData>` through a tag an ancestor's `Cell` still holds. Reached from dropping any
+#     red-tree `SyntaxNode`.
+#   * Stacked Borrows — `src/arc.rs:260`, `<HeaderSlice<H, [T; 0]> as Deref>::deref` forging a
+#     `&HeaderSlice<H, [T]>` over the whole slice out of a `&self` retagged for the header only.
+#     Reached through `tokora::cst::sink::finish::replay` → `materialize` → `Cst::finish`, i.e.
+#     from building any tree at all.
+#
+# Reproduced 2026-08-07 on `543ce6d`, each model differing from the line below only in
+# `MIRIFLAGS`:
+#
+#     cargo miri test --target aarch64-apple-darwin --test parser_node --features logos,rowan
+#
+# Both models red on the FIRST of that target's 24 tests.
+#
+# The defect is rowan's, not tokora's: `tokora/src/cst` contains no `unsafe` at all. Upstream has
+# had it reported since 2021 — rust-analyzer/rowan#108, #163, #192, all three still open — and
+# the only fix attempt, PR #211, is a draft whose own description says the immutable path still
+# fails. Bumping is not a known answer either: the `arc.rs` construct above is present unchanged
+# in `0.17.0`, the newest release, and al8n/smear#77 reproduced both reds against it standalone.
+#
+# WHAT WOULD FLIP THIS ANSWER. A published rowan whose `arc.rs` `Deref` and whose `cursor.rs`
+# `free` are both clean under `-Zmiri-strict-provenance` and under `-Zmiri-tree-borrows`. Then
+# add `rowan` to the feature sets below and to `ci/miri_sb.sh`'s — and extend
+# `ci/miri_shard.py`'s enumeration if any `rowan`-gated test TARGET arrives with it — rather
+# than leaving this note to rot.
+#
+# Recorded for 0.9.0 by al8n/tokit#235. The same answer is written where the other re-enablers
+# arrive from: `ci/miri_sb.sh`, `.github/workflows/miri.yml`, `tokora/Cargo.toml`'s `rowan`
+# feature, and the changelog's known-limitation entry.
+
 export MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-disable-isolation -Zmiri-symbolic-alignment-check -Zmiri-tree-borrows"
 export RUSTFLAGS="--cfg test_$CONFIG_FLAGS"
 

--- a/ci/miri_tb.sh
+++ b/ci/miri_tb.sh
@@ -115,8 +115,8 @@ cargo miri setup
 #     Reached through `tokora::cst::sink::finish::replay` → `materialize` → `Cst::finish`, i.e.
 #     from building any tree at all.
 #
-# Reproduced 2026-08-07 on `543ce6d`, each model differing from the line below only in
-# `MIRIFLAGS`:
+# Reproduced 2026-08-07 on `543ce6d`. Both runs used the command below and differed only in
+# `MIRIFLAGS`, exactly as this script and `ci/miri_sb.sh` differ:
 #
 #     cargo miri test --target aarch64-apple-darwin --test parser_node --features logos,rowan
 #

--- a/tokora/Cargo.toml
+++ b/tokora/Cargo.toml
@@ -143,8 +143,10 @@ fuzz = ["std"]
 
 # The lossless CST tower (`tokora::cst`): the event stream, the recording `Sink`, and the
 # materialization of both into a `rowan` green/red tree. Off by default; enabling it compiles 41
-# `#[cfg]`-gated code sites across 8 files under `src/` (66 mentions of `feature = "rowan"` in
-# all, the rest being `doc(cfg(...))` labels, doc-text alternations and one `not(...)` arm).
+# `#[cfg]`-gated code sites, in 6 files under `src/`. Counted on `543ce6d`, and the two figures
+# are different questions: `src/` carries 66 mentions of `feature = "rowan"` across 8 files, of
+# which those 41 are the gates whose CODE exists only when the feature is on. The other 25 are 14
+# `doc(cfg(...))` docs.rs labels, 10 doc-text alternations and one `not(...)` arm.
 #
 # ── THIS FEATURE IS NOT INTERPRETED BY MIRI, AND THAT IS DELIBERATE ─────────────────────────
 #

--- a/tokora/Cargo.toml
+++ b/tokora/Cargo.toml
@@ -141,6 +141,34 @@ conformance = ["alloc"]
 # `fuzz` module, which runs as ordinary `#[test]`s on stable Rust.
 fuzz = ["std"]
 
+# The lossless CST tower (`tokora::cst`): the event stream, the recording `Sink`, and the
+# materialization of both into a `rowan` green/red tree. Off by default; enabling it compiles 41
+# `#[cfg]`-gated code sites across 8 files under `src/` (66 mentions of `feature = "rowan"` in
+# all, the rest being `doc(cfg(...))` labels, doc-text alternations and one `not(...)` arm).
+#
+# ── THIS FEATURE IS NOT INTERPRETED BY MIRI, AND THAT IS DELIBERATE ─────────────────────────
+#
+# The Miri matrices run `--features logos` and `--features logos,unstable-raw`; `rowan` is in
+# neither, and not in `default`, so those 41 sites have never been COMPILED under Miri on any
+# target under either aliasing model. Zero coverage of the path 0.9.0 ships as its lossless
+# story — not reduced coverage.
+#
+# Enabling it there does not close the gap, it reddens the cells. `rowan 0.16.1`, the version
+# `Cargo.lock` resolves, executes undefined behaviour on its ordinary public path, and the two
+# models find it at two DIFFERENT sites, so neither is clean and no one-model half-measure
+# exists: Stacked Borrows at `arc.rs:260` (`<HeaderSlice<H, [T; 0]> as Deref>::deref` forging a
+# whole-slice reference from a header-only retag), reached through `cst::sink::finish::replay`
+# from building any tree; Tree Borrows at `cursor.rs:219` (`rowan::cursor::free`), reached from
+# dropping any red-tree `SyntaxNode`. Both reproduced on `543ce6d` on 2026-08-07, red on the
+# first of `--test parser_node`'s 24 tests under each model.
+#
+# The defect is rowan's: `src/cst` contains no `unsafe` at all. It is unfixed upstream since
+# 2021 (rust-analyzer/rowan#108, #163, #192, all open; the one fix attempt, PR #211, is a draft
+# whose own description says the immutable path still fails), and the `arc.rs` construct is
+# present unchanged in `0.17.0`, the newest release — so RAISING THE REQUIREMENT BELOW IS NOT A
+# FIX. The answer flips when a published rowan is clean at both sites under both models; at that
+# point add `rowan` to the feature sets in `ci/miri_sb.sh` and `ci/miri_tb.sh`, which carry the
+# full account. Recorded for 0.9.0 by al8n/tokit#235.
 rowan = ["dep:rowan", "std"]
 
 bytes = ["bytes_1"]
@@ -209,6 +237,9 @@ logos_0_15 = { package = "logos", version = "0.15", default-features = false, op
 logos_0_16 = { package = "logos", version = "0.16", default-features = false, optional = true, features = [
   "export_derive",
 ] }
+# Bumping this to `0.17` does NOT buy a Miri-clean lossless path, if that is what sent you here:
+# the `arc.rs` Stacked-Borrows construct is present unchanged in `0.17.0`. See the `rowan`
+# feature's note above for the two sites, the repro and what a real fix would look like.
 rowan = { version = "0.16", optional = true }
 
 # ── NO `criterion` HERE, AND NO `[[bench]]` — BOTH ARE LOAD-BEARING ABSENCES ────────────────


### PR DESCRIPTION
Closes #235.