### PR TITLE
fix(lexer): a terminal stop the return type can express, a trip that outranks its error, and a JSON example that is one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,32 @@ and will red until they do.
   that section stopped one step short of — the diagnostic is not hidden, the return value cannot
   distinguish, and `peek_with_emitter_terminal` or `peek_map` is what can.
 
+### Fixed
+
+- **A `logos` error no longer suppresses a state-limit trip that landed on the same item.**
+  `LogosLexer`'s "Limit-error latching" contract is that a limit error from `Lexer::check` is
+  returned **once** after a scan and then latches, so an error-recovery loop over untrusted input
+  cannot be made to scan past the configured limit. The post-scan check ran only on the
+  `Some(Ok(token))` arm.
+
+  A `logos` callback is free to mutate `extras` *and* return `Err` for the same matched item, and
+  that item is a completed scan too — the tally moved. When both happened at once the raw `logos`
+  error was forwarded with the state never consulted: `lex` kept answering `Some(Err(logos))` for
+  every remaining match, `poisoned` was never set, and the scan count went on growing past the
+  limit. All three supported `logos` majors shared the defect, because the adapter is one macro.
+
+  The check now runs once, outside the `Ok`/`Err` split, and ranks the two: a tripped state
+  outranks the raw `logos` error it arrived with, because the tally is monotone and no later input
+  can clear it while a lexer error is a fact about one item. A raw `logos` error whose `check()` is
+  still `Ok` is forwarded exactly as before, and the `None` arm is untouched.
+
+  `InputRef` was never unbounded here — classification asks `check()` itself and records a poison
+  boundary, so that path stayed latched — but it builds its trip verdict out of the error `lex`
+  returned, so a trip that arrived wearing a `logos` error was latched correctly and **diagnosed
+  wrongly**. Fixing the adapter fixes the payload on the complete and partial-frontier paths with
+  no change at the input layer. Reported by an external audit at `7789dcd`.
+
+
 ## 0.9.1 (2026-08-08)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,46 @@ red the day this section became `0.9.0`. `ci/changelog_structure.sh` enforces ev
 and will red until they do.
 -->
 
+## Unreleased
+
+### Added
+
+- **`InputRef::peek_map` — a windowed read whose return type can express a terminal stop.** The
+  terminal-aware reads this crate shipped were all **head-only**: `peek_kind`, `head_satisfies` and
+  `peek_head_map` raise on a resource-limit trip or a latched poison boundary and reserve
+  `Ok(None)` for a genuine end of input. A production needing *two* tokens of lookahead had only
+  `peek::<W>`, which answers a terminal stop with `Ok` holding a shorter window — the same value a
+  genuinely short input produces, and there is nothing in it to tell them apart.
+
+  **The gap was the return type, not the documentation.** `peek`'s Partial-mode section already
+  recorded that a limit trip "emits its diagnostic and latches the poison boundary before the
+  holdback is consulted, so a peek can no more hide a tripped limit than a consume can" — true of
+  the diagnostic, and never a claim about the value. With a **fatal** emitter the difference is
+  invisible, because the trip's diagnostic ends the parse either way; with a **non-fatal** emitter
+  that accepts it, the caller is handed `Ok` with fewer tokens than it asked for and reads that as
+  a grammar fact. A production distinguishing `other + fill` from `other + fill(0) x` on the second
+  token gets a silently different parse rather than an error.
+
+  `peek_map::<W, _, _>(f)` is `peek_head_map`'s treatment at an arbitrary width: `f` sees the
+  filled window and its value is returned; a window short because the input genuinely ended, or
+  because a `Partial` frontier withheld the rest, is handed to `f` like any other and is `Ok`; a
+  window cut short by a terminal stop raises the terminal end-of-input error and `f` does not run.
+  It rides the existing `peek_with_emitter_terminal` fill, so it reserves the same one owned window
+  and panics on the same broken-`Cache` condition.
+
+  One contract difference from `peek_head_map` is deliberate: there `Ok(None)` is the genuine end
+  of input and `f` does not run, while here `f` runs on the window whatever its length. A head read
+  has two lengths and can lift the empty one out; a `W`-wide window has `W + 1`, and folding every
+  short one into a single `None` would discard the tokens that *are* there. The `Option` belongs to
+  the caller's projection — `peek_map::<U2, _, _>(|w| w.iter().nth(1).map(|t| t.token().kind()))` —
+  and `peek_map::<W, _, _>(|w| w)` recovers the unmapped read with the stop moved into the error
+  arm.
+
+  **`peek::<W>` is unchanged.** It is public, its Partial-mode contract is documented and tested,
+  and a caller relying on the short window is not wrong. Its documentation now draws the conclusion
+  that section stopped one step short of — the diagnostic is not hidden, the return value cannot
+  distinguish, and `peek_with_emitter_terminal` or `peek_map` is what can.
+
 ## 0.9.1 (2026-08-08)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,22 @@ and will red until they do.
   wrongly**. Fixing the adapter fixes the payload on the complete and partial-frontier paths with
   no change at the input layer. Reported by an external audit at `7789dcd`.
 
+- **`examples/json.rs` accepted lone surrogates, so the shipped JSON demonstration accepted
+  invalid JSON.** The string rule spelled its unicode escape `u[a-fA-F0-9]{4}`, which admits the
+  surrogate range `D800`–`DFFF`. RFC 8259 §7 admits a surrogate code unit only as the matching half
+  of a high/low pair, so `"\uD800"`, `"\uDC00"` and `"\uD800A"` are not JSON and the example
+  accepted all three. It is the example, not the library — but a lexer example's whole job is to be
+  a correct model of the language it names, and this one was already being copied as a reference
+  JSON lexer.
+
+  Surrogate pairing is now spelled in the regex rather than validated in a callback, and the rule
+  is split into `Token::String` (`" char* "`) and `Token::EscapedString` (`" char* esc
+  (char|esc)* "`) — disjoint by construction, so the DFA needs no priority tie-break. Both report
+  `TokenKind::String`, so the grammar and every diagnostic it raises are unchanged; what the split
+  buys is the fact a consumer wants, which is whether the slice needs decoding before use.
+
+  Measured over the bundled 107 KB `sample.json`, interleaved in one process against the rule as it
+  shipped: a validating callback costs **1.65×**, the folded regex **1.02–1.07×**.
 
 ## 0.9.1 (2026-08-08)
 

--- a/tokora/examples/json.rs
+++ b/tokora/examples/json.rs
@@ -217,8 +217,36 @@ enum Token<'a> {
   #[regex(r"-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?", |lex| lex.slice().parse::<f64>().map_err(|e| JsonLexerError::ParseFloat(Spanned::new(lex.span().into(), e))))]
   Number(f64),
 
-  #[regex(r#""([^"\\\x00-\x1F]|\\(["\\bnfrt/]|u[a-fA-F0-9]{4}))*""#, |lex| lex.slice())]
+  // ── Strings, with surrogate pairing folded into the DFA ─────────────────────────────────
+  //
+  // RFC 8259 §7 admits a `\uXXXX` escape only when `XXXX` is *not* a surrogate, or when a high
+  // surrogate (`D800`–`DBFF`) is immediately followed by a `\u` low surrogate (`DC00`–`DFFF`).
+  // `u[a-fA-F0-9]{4}` admits every code unit including the halves, so it accepts `"\uD800"`,
+  // `"\uDC00"` and `"\uD800A"` — none of which are JSON.
+  //
+  // Validating the escape in a callback is the obvious repair and the wrong one: it re-reads
+  // the slice the DFA has already walked. Spelling the pairing rule as a regex costs nothing at
+  // run time, because the automaton is deciding those bytes anyway.
+  //
+  //   char = [^"\\\x00-\x1F]
+  //   esc  = \\ ( ["\\bnfrt/] | u nonsurrogate | u high \\ u low )
+  //     nonsurrogate = a first nibble that is not D, or D followed by 0–7
+  //     high         = D followed by 8–B          low = D followed by C–F
+  //
+  // TWO RULES, ONE KIND. `String` is `" char* "` and `EscapedString` is
+  // `" char* esc (char|esc)* "`: disjoint by construction (one forbids a backslash, the other
+  // requires one), so the DFA needs no priority tie-break and the split is free. What it buys is
+  // the fact a consumer actually wants — whether the slice needs unescaping before use, which is
+  // the difference between borrowing from the source and allocating. Both report
+  // `TokenKind::String`, so the grammar below and every diagnostic it raises are unchanged.
+  #[regex(r#""[^"\\\x00-\x1F]*""#, |lex| lex.slice())]
   String(&'a str),
+
+  #[regex(
+    r#""[^"\\\x00-\x1F]*\\(?:["\\bnfrt/]|u(?:[0-9a-cA-Ce-fE-F][0-9a-fA-F]{3}|[Dd][0-7][0-9a-fA-F]{2}|[Dd][89abAB][0-9a-fA-F]{2}\\u[Dd][c-fC-F][0-9a-fA-F]{2}))(?:[^"\\\x00-\x1F]|\\(?:["\\bnfrt/]|u(?:[0-9a-cA-Ce-fE-F][0-9a-fA-F]{3}|[Dd][0-7][0-9a-fA-F]{2}|[Dd][89abAB][0-9a-fA-F]{2}\\u[Dd][c-fC-F][0-9a-fA-F]{2})))*""#,
+    |lex| lex.slice()
+  )]
+  EscapedString(&'a str),
 }
 
 impl core::fmt::Display for Token<'_> {
@@ -233,12 +261,12 @@ impl core::fmt::Display for Token<'_> {
       Token::Comma => write!(f, ","),
       Token::Null => write!(f, "null"),
       Token::Number(n) => write!(f, "{}", n),
-      Token::String(s) => write!(f, "\"{}\"", s),
+      Token::String(s) | Token::EscapedString(s) => write!(f, "\"{}\"", s),
     }
   }
 }
 
-impl Token<'_> {
+impl<'a> Token<'a> {
   #[inline]
   fn is_value_start(&self) -> bool {
     matches!(
@@ -247,9 +275,23 @@ impl Token<'_> {
         | Token::Null
         | Token::Number(_)
         | Token::String(_)
+        | Token::EscapedString(_)
         | Token::BraceOpen
         | Token::BracketOpen
     )
+  }
+
+  /// The raw source slice of either string variant, quotes included.
+  ///
+  /// A consumer that needs the *decoded* value branches on the variant instead: `String` can be
+  /// used as it stands, and only `EscapedString` has to allocate. That is the whole payoff of
+  /// splitting the rule, and it is why this accessor is the only place the split is flattened.
+  #[inline]
+  fn as_json_string(&self) -> Option<&'a str> {
+    match self {
+      Token::String(s) | Token::EscapedString(s) => Some(s),
+      _ => None,
+    }
   }
 }
 
@@ -322,7 +364,9 @@ impl From<&Token<'_>> for TokenKind {
       Token::Comma => TokenKind::Comma,
       Token::Null => TokenKind::Null,
       Token::Number(_) => TokenKind::Number,
-      Token::String(_) => TokenKind::String,
+      // Both string variants answer the same kind: the escape split is a lexer fact, and the
+      // grammar's expected-sets should go on saying "string".
+      Token::String(_) | Token::EscapedString(_) => TokenKind::String,
     }
   }
 }
@@ -484,13 +528,16 @@ where
   Ctx::Emitter: Emitter<'inp, JsonLexer<'inp>, Error = JsonError<'inp>>,
 {
   expect(|t: &Token<'inp>| {
-    if matches!(t, Token::String(_)) {
+    if matches!(t, Token::String(_) | Token::EscapedString(_)) {
       Ok(())
     } else {
       Err(Expected::one(TokenKind::String))
     }
   })
-  .map(Token::unwrap_string)
+  .map(|t: Token<'inp>| {
+    t.as_json_string()
+      .expect("`expect` accepted only a string token")
+  })
   .parse_input(inp)
 }
 
@@ -581,7 +628,7 @@ where
             Token::Bool(_) => Branch::B0,
             Token::Null => Branch::B1,
             Token::Number(_) => Branch::B2,
-            Token::String(_) => Branch::B3,
+            Token::String(_) | Token::EscapedString(_) => Branch::B3,
             Token::BracketOpen => Branch::B4,
             Token::BraceOpen => Branch::B5,
             _ => return Ok(None),
@@ -626,7 +673,7 @@ where
             Token::Bool(_) => Ok(Branch::B0),
             Token::Null => Ok(Branch::B1),
             Token::Number(_) => Ok(Branch::B2),
-            Token::String(_) => Ok(Branch::B3),
+            Token::String(_) | Token::EscapedString(_) => Ok(Branch::B3),
             Token::BracketOpen => Ok(Branch::B4),
             Token::BraceOpen => Ok(Branch::B5),
             tok => Err(JsonError::UnexpectedToken(
@@ -659,12 +706,83 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-  use super::{JsonError, TokenKind};
+  use super::{JsonError, Token, TokenKind};
   use tokora::error::UnexpectedEot;
 
   #[test]
   fn test_example() {
     super::main();
+  }
+
+  /// The one token `src` is, or `None` if `src` is not exactly one token.
+  ///
+  /// This is the question RFC 8259 asks of the grammar and the one the parser cannot ask on its
+  /// own behalf: a source the string rule rejects still *parses* — as a lexer error the emitter
+  /// may recover from — so "the parse failed" is a weaker claim than "the text is not a string".
+  fn sole_token(src: &str) -> Option<Token<'_>> {
+    use tokora::logos::Logos;
+
+    let mut lexer = Token::lexer(src);
+    let first = lexer.next()?.ok()?;
+    if lexer.span() != (0..src.len()) || lexer.next().is_some() {
+      return None;
+    }
+    Some(first)
+  }
+
+  // A lone surrogate is not JSON (RFC 8259 §7): a surrogate code unit is admissible only as the
+  // matching half of a `\uD800`–`\uDBFF` / `\uDC00`–`\uDFFF` pair. The three the issue named are
+  // the first three here; the rest are the mismatches that a rule checking only the *high* half
+  // would still let through.
+  #[test]
+  fn lone_surrogate_escapes_are_rejected() {
+    for src in [
+      r#""\uD800""#,       // a lone high surrogate
+      r#""\uDC00""#,       // a lone low surrogate
+      r#""\uD800A""#,      // a high surrogate followed by something that is not a low one
+      r#""\uD800\u0041""#, // ... including a perfectly valid escape that is not a low one
+      r#""\uDBFF\uDBFF""#, // two highs
+      r#""\uDC00\uDFFF""#, // a low leading the pair
+      r#""\uD800\\""#,     // a high followed by an escape that is not a `\u` at all
+    ] {
+      assert!(
+        sole_token(src).is_none(),
+        "{src} is not JSON, but the lexer accepted it"
+      );
+    }
+  }
+
+  // The other side, which is what makes the rejection above a repair rather than a blanket ban:
+  // every well-formed escape still lexes, and the pair range is closed at both ends.
+  #[test]
+  fn paired_surrogates_and_ordinary_escapes_are_accepted() {
+    for src in [
+      r#""\uD83D\uDE00""#, // a paired surrogate: one astral code point
+      r#""\uD800\uDC00""#, // the lowest pair
+      r#""\uDBFF\uDFFF""#, // the highest pair
+      r#""\uD7FF""#,       // the code unit just below the surrogate range
+      r#""\uE000""#,       // and the one just above it
+      r#""\u0041""#,       // a plain BMP escape
+      r#""a\tb\u00e9""#,   // a mix of escapes among ordinary characters
+      r#""\\""#,           // a lone escaped backslash
+    ] {
+      assert!(
+        matches!(sole_token(src), Some(Token::EscapedString(_))),
+        "{src} is JSON, and it carries an escape"
+      );
+    }
+  }
+
+  // The split is disjoint, and it is what recovers `escaped` for free: the rule that matched says
+  // whether the slice needs decoding before use.
+  #[test]
+  fn the_two_string_rules_partition_by_whether_an_escape_is_present() {
+    assert!(matches!(sole_token(r#""abc""#), Some(Token::String(_))));
+    assert!(matches!(sole_token(r#""""#), Some(Token::String(_))));
+    assert!(matches!(
+      sole_token(r#""ab\ncd""#),
+      Some(Token::EscapedString(_))
+    ));
   }
 
   // The `Kind`-table spelling of end-of-input reaches `JsonError` with its position intact.

--- a/tokora/src/guide/ch14_json_example.md
+++ b/tokora/src/guide/ch14_json_example.md
@@ -18,6 +18,15 @@ borrow for scalars, but `List(Vec<JsonValue<'inp>>)` and
 `Object(Vec<(&'inp str, JsonValue<'inp>)>)` allocate their container nodes. The lexer maps
 punctuation through `PunctuatorToken` so the delimiter types can remain generic.
 
+Strings arrive as **two** token variants, `String` and `EscapedString`, both reporting
+`TokenKind::String`. The split is what spelling RFC 8259's surrogate-pairing rule as a regex — a
+`\uXXXX` escape is admissible only outside `D800`–`DFFF`, or as a high half immediately followed
+by a `\u` low half — buys for nothing: the two rules are disjoint (one forbids a backslash, the
+other requires one), so the automaton is already deciding which applies. A consumer that needs
+the decoded value therefore knows from the variant whether the slice can be used as it borrows or
+has to be unescaped into an owned `String`. Validating the escape in a callback instead measured
+1.65× the shipped rule over the bundled `sample.json`; the folded regex measures 1.02–1.07×.
+
 ```rust
 use tokora::{
   Token as TokenT,

--- a/tokora/src/input/input_ref/fast_path_tests.rs
+++ b/tokora/src/input/input_ref/fast_path_tests.rs
@@ -37,6 +37,15 @@
 //! end-of-input error rather than the `Ok(None)` that means a genuine end of input. Both are
 //! pinned below.
 //!
+//! [`peek_map`](InputRef::peek_map) is those same two edges one window wide, plus the third state a
+//! head read cannot have — a window that came back **part** resident — and it is pinned in the same
+//! place for that reason rather than because it has a fast path (it has none). What it does share
+//! with the pair above is the thing that decides whether any of it is observable: the **emitter**.
+//! A trip-truncated window and a genuinely short one are the same value, so only an emitter that
+//! ACCEPTS the trip's diagnostic leaves a caller holding it — under a fatal one the parse is over
+//! either way. Every cell there runs under `Verbose`, with one fatal cell beside them whose whole
+//! job is to show that it cannot see the difference.
+//!
 //! # And what the observable tuple cannot see: the caller code each route runs
 //!
 //! Agreeing on every value a caller can read back is **not** the same as running the same code.
@@ -61,11 +70,11 @@
 //! from shipped code, over the same stream, in the same residency, with nothing varying but the
 //! entry point.
 
-use generic_arraydeque::typenum::{U1, U2, U3};
+use generic_arraydeque::typenum::{U1, U2, U3, U4};
 
 use crate::{
   InputRef, Token,
-  cache::{Cache, CachedTokenOf, DefaultCache},
+  cache::{Cache, CachedTokenOf, DefaultCache, PeekedTokenExt as _},
   emitter::Verbose,
   input::Input,
   span::SimpleSpan,
@@ -82,6 +91,13 @@ use super::{
 type OneSlot<'a> = Option<CachedTokenOf<'a, BalLexer<'a>>>;
 
 type BalCtx<'a> = (Verbose<ByValErr>, DefaultCache<'a, BalLexer<'a>>);
+
+/// The same fixture with the one thing that decides whether a folded terminal stop is visible
+/// changed: an emitter that REJECTS the diagnostic rather than accepting it.
+type BalFatalCtx<'a> = (
+  crate::emitter::Fatal<ByValErr>,
+  DefaultCache<'a, BalLexer<'a>>,
+);
 
 /// What one run observed. `offset()`, [`is_eoi`](InputRef::is_eoi), the cache depth and the
 /// lexer's token tally are deliberately absent: those are **frontier** facts, and a prefill
@@ -625,6 +641,267 @@ fn peek_head_map_raises_on_a_latched_boundary_with_nothing_resident() {
     inp.next().unwrap().is_none(),
     "the drain stops at the latched boundary"
   );
+}
+
+// ── The same two edges, one window wide: `peek_map` ───────────────────────────────────────────
+//
+// `peek_head_map` has no fast path to defend at width > 1, so these cells are not about a route.
+// They are here because they are the WINDOWED FORM of the two edges pinned directly above, and
+// they add the third state a head read cannot have: a window that came back **part** resident.
+//
+//   width 1                                          width W
+//   ─────────────────────────────────────────────    ─────────────────────────────────────────
+//   the head is resident        → served, latch      the whole window is resident → served
+//   or no latch                                      (the fill's `want == 0` arm returns before
+//                                                     the boundary is consulted, exactly as for
+//                                                     the head)
+//   nothing resident, latched   → raises             SOME of it resident            → raises
+//                                                    none of it resident            → raises
+//
+// The middle row is the whole reason `peek_map` exists. `peek::<W>` answers it `Ok` with a short
+// window, and that value is byte-for-byte the one a genuinely short input produces — so a caller
+// deciding on the window's LENGTH reads a halted scanner as a grammar fact.
+//
+// WHICH EMITTER THESE RUN UNDER IS LOAD-BEARING, and it is why the fatal cell below exists beside
+// the rest. `BalCtx` is `Verbose`, which ACCEPTS a diagnostic and returns `Ok` from the emit, so
+// the fill comes back with a short window and a raise is the only thing that can turn it into an
+// `Err`. Under a **fatal** emitter the fill's own emit returns `Err` first and every shape in this
+// section passes for the wrong reason: `peek` and `peek_map` return the same value, and a fold
+// would too.
+
+/// The fatal twin of [`tripping_input`], for the control cell below: the emit that a trip performs
+/// REJECTS the diagnostic, so the fill fails before the terminal flag is ever read.
+fn fatal_tripping_input(src: &str, limit: usize) -> Input<'_, BalLexer<'_>, BalFatalCtx<'_>, ()> {
+  Input::with_state_and_context(
+    src,
+    TokenLimiter::with_limitation(limit),
+    crate::input::InputContext::new(
+      crate::emitter::Fatal::<ByValErr>::new(),
+      DefaultCache::<'_, BalLexer<'_>>::default(),
+    ),
+  )
+}
+
+/// Trips `"1 2 3 4"` at a budget of three and leaves the input at the latch with `1 2 3` cached:
+/// the `U4` fill lexes three tokens into the `U3` cache and the fourth trips, so the poison
+/// boundary lands on the end of `3` — which is also `offset()`, the back of the cache.
+///
+/// From there a `U3` request is already met and a `U4` request is not, which is the pair of states
+/// the two latched cells below need.
+fn latched_with_three_cached(src: &str) -> Input<'_, BalLexer<'_>, BalCtx<'_>, ()> {
+  let mut input = tripping_input(src, 3);
+  {
+    let mut inp = input.as_ref();
+    assert_eq!(
+      inp.peek::<U4>().map(|w| w.len()),
+      Ok(3),
+      "the wide fill trips on the fourth token and hands back the three it retained"
+    );
+  }
+  input
+}
+
+#[test]
+fn peek_map_serves_a_fully_resident_window_at_a_latched_boundary() {
+  // The windowed form of `peek_head_map_serves_a_resident_head_at_a_latched_boundary`, and the
+  // same reason it must hold: the fill's `want == 0` arm returns before the boundary is consulted,
+  // so a request the front of the stream already meets is answered whatever the latch says. A
+  // `peek_map` that probed the latch first would raise on a window it is holding.
+  let mut input = latched_with_three_cached("1 2 3 4");
+  let mut inp = input.as_ref();
+
+  assert_eq!(
+    inp.peek_map::<U3, _, _>(|w| w.len()),
+    Ok(3),
+    "a window the front of the stream already fills is served, latched or not"
+  );
+  assert_eq!(
+    inp.peek_map::<U3, _, _>(|w| w.iter().map(|t| *t.span()).collect::<std::vec::Vec<_>>()),
+    Ok(std::vec![
+      SimpleSpan::new(0, 1),
+      SimpleSpan::new(2, 3),
+      SimpleSpan::new(4, 5)
+    ]),
+    "and it is the same window `peek` reports, in stream order"
+  );
+  // Nothing was consumed by either read.
+  assert_eq!(
+    inp.next().unwrap().map(|t| *t.span_ref()),
+    Some(SimpleSpan::new(0, 1)),
+    "a read consumes nothing, latched or not"
+  );
+}
+
+#[test]
+fn peek_map_raises_when_a_latched_boundary_leaves_the_window_part_resident() {
+  // The middle row of the table above, and the state a head read cannot reach. Three of the four
+  // slots are sitting in the cache; the fourth is past a latched boundary and can never be lexed.
+  // `peek::<U4>` calls that `Ok` with three tokens — which is exactly what `"1 2 3"` under no
+  // budget at all produces (the control at the bottom of this file's next cell).
+  let mut input = latched_with_three_cached("1 2 3 4");
+  let mut inp = input.as_ref();
+
+  let ran = core::cell::Cell::new(0usize);
+  assert_eq!(
+    inp.peek_map::<U4, _, _>(|w| {
+      ran.set(ran.get() + 1);
+      w.len()
+    }),
+    Err(ByValErr::Lex),
+    "a window truncated by a latched boundary is a terminal stop, not a short input"
+  );
+  assert_eq!(
+    ran.get(),
+    0,
+    "`f` never sees a truncated window — a decision taken on one is a decision taken on a halt"
+  );
+  // Sticky, exactly as the head read's latch is.
+  assert_eq!(inp.peek_map::<U4, _, _>(|w| w.len()), Err(ByValErr::Lex));
+
+  // THE BEHAVIOUR THAT MUST NOT CHANGE. `peek::<U4>` is public, its Partial-mode contract is
+  // documented and tested, and a caller relying on the short window is not wrong today.
+  assert_eq!(
+    inp.peek::<U4>().map(|w| w.len()),
+    Ok(3),
+    "`peek` still hands the short window back; `peek_map` is an addition, not an alteration"
+  );
+}
+
+#[test]
+fn peek_map_tells_a_fresh_trip_apart_from_a_genuinely_short_input() {
+  // THE PROPERTY, on the fill's other terminal route: a fresh trip mid-window rather than a
+  // boundary latched before the call. Two streams, the same request, the same window length back
+  // from `peek` — and `peek_map` separates them.
+  fn window_len<'a>(
+    inp: &mut InputRef<'a, '_, BalLexer<'a>, BalCtx<'a>, ()>,
+  ) -> (Result<usize, ByValErr>, Result<usize, ByValErr>) {
+    (
+      inp.peek::<U3>().map(|w| w.len()),
+      inp.peek_map::<U3, _, _>(|w| w.len()),
+    )
+  }
+
+  // (a) the scanner halts while the window fills: `1` and `2` scan, `3` trips the budget.
+  let mut tripped = tripping_input("1 2 3 4", 2);
+  assert_eq!(
+    window_len(&mut tripped.as_ref()),
+    (Ok(2), Err(ByValErr::Lex)),
+    "a trip-truncated window is `Ok(2)` from `peek` and an error from `peek_map`"
+  );
+
+  // (b) the input genuinely ends after two tokens. `peek` cannot be told from (a), and `peek_map`
+  //     reserves the short `Ok` window for exactly this.
+  let mut short = tripping_input("1 2", usize::MAX);
+  assert_eq!(
+    window_len(&mut short.as_ref()),
+    (Ok(2), Ok(2)),
+    "a genuinely short input is a short window, not an error"
+  );
+
+  // (c) the control at full width: a met request is `Ok` on both.
+  let mut full = tripping_input("1 2 3 4", usize::MAX);
+  assert_eq!(window_len(&mut full.as_ref()), (Ok(3), Ok(3)));
+
+  // And the identity closure recovers `peek` itself, terminal stop aside — so nothing the unmapped
+  // read can express is lost by taking an `f`.
+  let mut same = tripping_input("1 2 3 4", usize::MAX);
+  let mut inp = same.as_ref();
+  assert_eq!(
+    inp.peek_map::<U3, _, _>(|w| w.iter().map(|t| *t.span()).collect::<std::vec::Vec<_>>()),
+    Ok(std::vec![
+      SimpleSpan::new(0, 1),
+      SimpleSpan::new(2, 3),
+      SimpleSpan::new(4, 5)
+    ])
+  );
+}
+
+#[test]
+fn the_second_token_projection_from_peek_maps_documentation_compiles_and_decides() {
+  // The shape `peek_map`'s doc comment shows, run rather than asserted — a doc that misdescribes
+  // an API is a contract defect, and a fenced `text` block is not compiled by anything else.
+  //
+  // It is also the motivating consumer: `other + fill` (an addition of a selector named `fill`)
+  // against `other + fill(0) x` (a fill modifier), where the token in second position is the only
+  // separator. Here `(` versus `;` stands in for it.
+  fn second_kind<'a>(
+    inp: &mut InputRef<'a, '_, BalLexer<'a>, BalCtx<'a>, ()>,
+  ) -> Result<Option<BalKind>, ByValErr> {
+    inp.peek_map::<U2, _, _>(|w| w.iter().nth(1).map(|t| t.token().kind()))
+  }
+
+  let mut modifier = tripping_input("1 ( 2", usize::MAX);
+  assert_eq!(
+    second_kind(&mut modifier.as_ref()),
+    Ok(Some(BalKind::LParen)),
+    "the second token decides the production"
+  );
+
+  let mut addition = tripping_input("1 ; 2", usize::MAX);
+  assert_eq!(second_kind(&mut addition.as_ref()), Ok(Some(BalKind::Semi)));
+
+  let mut ends = tripping_input("1", usize::MAX);
+  assert_eq!(
+    second_kind(&mut ends.as_ref()),
+    Ok(None),
+    "the input genuinely ends after the head — `None` is the caller's own projection"
+  );
+
+  // And the case the primitive exists for: the scanner halts while the second slot fills. `peek`
+  // answers this exactly as it answers the line above.
+  let mut halted = tripping_input("1 ( 2", 1);
+  assert_eq!(
+    halted.as_ref().peek::<U2>().map(|w| w.len()),
+    Ok(1),
+    "`peek` reports one token, the same as an input that genuinely ends after the head"
+  );
+  let mut halted = tripping_input("1 ( 2", 1);
+  assert_eq!(
+    second_kind(&mut halted.as_ref()),
+    Err(ByValErr::Lex),
+    "and the projection raises rather than answering `None` and picking the other production"
+  );
+}
+
+#[test]
+fn a_fatal_emitter_cannot_tell_the_two_apart_at_all() {
+  // THE CONTROL FOR THE THREE CELLS ABOVE, and the reason they are written against `Verbose`.
+  //
+  // Here the trip's diagnostic is REJECTED, so the fill returns the emitter's own error — a
+  // `Limit`, converted from the lexer error, and not the `Lex` that `From<UnexpectedEot>` produces
+  // above. `peek` and `peek_map` therefore agree, and a `peek_map` that folded the terminal stop
+  // into a short window would agree too. This cell is blind to the defect by construction; that is
+  // what it is here to show.
+  //
+  // A FRESH INPUT PER READ, deliberately. Two reads on one input do not compare the two
+  // primitives: the first read trips and LATCHES, so the second takes the boundary arm — which
+  // emits nothing, and where `peek_map` raises `Lex` under a fatal emitter exactly as it does
+  // under `Verbose`. That is the case named at the bottom of this cell, and running it here by
+  // accident is how a control quietly stops being one.
+  let mut by_peek = fatal_tripping_input("1 2 3 4", 2);
+  assert_eq!(
+    by_peek.as_ref().peek::<U3>().map(|w| w.len()),
+    Err(ByValErr::Limit),
+    "the fatal emit fails the fill itself, before any terminal flag is read"
+  );
+  let mut by_map = fatal_tripping_input("1 2 3 4", 2);
+  assert_eq!(
+    by_map.as_ref().peek_map::<U3, _, _>(|w| w.len()),
+    Err(ByValErr::Limit),
+    "so `peek_map` propagates the same value, and carries no terminal mark of its own"
+  );
+
+  // The genuinely short input is `Ok` on both here too — a fatal emitter changes nothing about the
+  // half of the distinction that was never in question.
+  let mut short = fatal_tripping_input("1 2", usize::MAX);
+  let mut inp = short.as_ref();
+  assert_eq!(inp.peek::<U3>().map(|w| w.len()), Ok(2));
+  assert_eq!(inp.peek_map::<U3, _, _>(|w| w.len()), Ok(2));
+
+  // WHAT IS DELIBERATELY NOT IN THIS CELL: an already-latched boundary. A fatal emitter is blind
+  // only on the EMITTING path — at a latch the fill emits nothing and returns `Ok` with the flag
+  // set, so `peek_map` raises there under a fatal emitter as readily as under `Verbose`. Putting
+  // that case here would make this cell able to see the defect, which would defeat its purpose.
 }
 
 // ── The two things leaving the scanner had to re-establish: the latch, and the unwind ─────────

--- a/tokora/src/input/input_ref/peek/mod.rs
+++ b/tokora/src/input/input_ref/peek/mod.rs
@@ -118,6 +118,28 @@ where
   /// holdback is consulted, so a peek can no more hide a tripped limit than a consume can. See
   /// [terminal beats incomplete](crate::input#terminal-beats-incomplete-and-they-never-substitute).
   ///
+  /// ## What that leaves: the return value cannot tell the three apart
+  ///
+  /// The paragraph above is about the **diagnostic**, and it is the whole truth about the
+  /// diagnostic. It is not a statement about this **return type**. A full window, a genuinely short
+  /// one, a partial-input frontier holdback and a terminal stop all arrive here as `Ok` holding a
+  /// window, and the last two are the same length for the same reason nothing distinguishes them:
+  /// the short window *is* the value. A production that decides on the width — *"is the second
+  /// token a `(`?"* — therefore reads a halted scanner as a grammar fact and picks the other
+  /// production, which is [`peek_one`](Self::peek_one)'s `Ok(None)` fold one width up.
+  ///
+  /// With a **fatal** emitter that is invisible, because the trip's own diagnostic ends the parse
+  /// either way. With a **non-fatal** emitter that accepts it, the caller is handed `Ok` with fewer
+  /// tokens than it asked for and no way to ask why — a silently different parse rather than a
+  /// stopped one.
+  ///
+  /// Two things can express it. [`peek_with_emitter_terminal`](Self::peek_with_emitter_terminal)
+  /// reports it as a flag beside the window, for a caller that wants the short window *and* the
+  /// reason; [`peek_map`](Self::peek_map) puts it in the error arm, reserving a short `Ok` window
+  /// for a genuine end of input, which is what [`peek_head_map`](Self::peek_head_map),
+  /// [`peek_kind`](Self::peek_kind) and [`head_satisfies`](Self::head_satisfies) do at the head.
+  /// Prefer one of them wherever the window's *length* decides a production.
+  ///
   /// # Stack footprint: one window, cache hit or miss
   ///
   /// The window this returns is the **only** `W::CAPACITY`-sized owned token storage a peek
@@ -702,7 +724,104 @@ where
     }
   }
 
+  /// Windowed observation in grammar vocabulary, terminal-aware by construction — the
+  /// [`peek::<W>`](Self::peek) analogue of [`peek_head_map`](Self::peek_head_map).
+  ///
+  /// `f` sees the filled window and its value is returned. A window that came back **short**
+  /// because the input genuinely ended — or because a non-final [`Partial`](crate::input::Partial)
+  /// frontier withheld the rest — is handed to `f` like any other, and is `Ok`. A window cut short
+  /// by a **terminal stop** — a resource-limit trip during the fill, or a latched poison boundary
+  /// at the cursor — raises the same terminal end-of-input error the `_or_stop` family raises, and
+  /// `f` does not run.
+  ///
+  /// That distinction is the whole of what this adds to [`peek::<W>`](Self::peek), and it is not
+  /// something a caller can recover afterwards. `peek` returns `Ok` in both cases, holding a window
+  /// of the same length, so a production that decides on the width — *"is the second token a
+  /// `(`?"* — reads a halted scanner as a grammar fact and picks the other production. The
+  /// diagnostic is not lost either way (see [`peek`](Self::peek)'s Partial-mode section); what is
+  /// lost is the *return value's* ability to say which of the two happened, and with a non-fatal
+  /// emitter that accepts the diagnostic, the difference is a silently different parse rather than
+  /// a stopped one.
+  ///
+  /// The mark carries the same qualification [`peek_head_map`](Self::peek_head_map)'s does: it is
+  /// what an **accepting** emitter earns, after the trip's own diagnostic has gone to it. A fatal
+  /// emitter's rejection of that diagnostic still propagates — from the fill here rather than from
+  /// a scan — but as *that emitter's* value, converted from the lexer error, so it carries **no**
+  /// terminal mark. (A fatal emitter is blind to the difference only on the *emitting* path: at an
+  /// already-latched boundary the fill emits nothing, so even there the short window is raised
+  /// rather than returned.)
+  ///
+  /// # The one contract difference from `peek_head_map`
+  ///
+  /// [`peek_head_map`](Self::peek_head_map) answers `Ok(None)` at a genuine end of input and does
+  /// not run `f`; here `f` runs on the window whatever its length, including an empty one. A head
+  /// read has two lengths and can lift the empty one into `None`; a `W`-wide window has `W + 1`,
+  /// and folding every short one into a single `None` would throw away the tokens that *are* there
+  /// — which for a two-token decision is the head the caller already committed to. So the `Option`
+  /// belongs to the caller's own projection, not to this return type:
+  ///
+  /// ```text
+  /// // "the second token's kind, if there is a second token"
+  /// inp.peek_map::<U2, _, _>(|w| w.iter().nth(1).map(|t| t.token().kind()))
+  /// //  Ok(Some(kind)) — a second token
+  /// //  Ok(None)       — the input genuinely ends after the head
+  /// //  Err(..)        — the scanner stopped while the window was filling
+  /// ```
+  ///
+  /// `f` may also hand the window straight back — `peek_map::<W, _, _>(|w| w)` is exactly
+  /// [`peek::<W>`](Self::peek) with the terminal stop moved into the error arm — so nothing the
+  /// unmapped form can express is lost. Taking `f` rather than returning the window is what lets
+  /// `O` be free of the borrow: the window borrows the cache for as long as it lives, and a
+  /// grammar that only wants a kind or a boolean out of it can go on using the input immediately.
+  ///
+  /// # What is guaranteed to `f`, and the condition on the caller
+  ///
+  /// `f` runs **exactly once** when it runs at all, is handed the window this call filled, and
+  /// nothing is consumed, committed or latched on its behalf. There is one route here and no fast
+  /// path, so the two-route reconciliation under *"what is guaranteed identical"* on
+  /// [`peek_head_map`](Self::peek_head_map) has no counterpart — but the **second clause of its
+  /// condition on the caller** applies verbatim, and for the same mechanism: this call takes
+  /// `self.span().end()` before the fill, for the terminal
+  /// end-of-input error, and [`peek::<W>`](Self::peek) does not. That is one caller-supplied
+  /// `L::Offset::clone` that the unmapped read never runs. An `f` that answers from the *values* of
+  /// the window it is handed cannot see it; an `f` that measures the input layer can, and is asking
+  /// which primitive this crate reached the window through rather than what the window holds.
+  ///
+  /// # Footprint and panics
+  ///
+  /// Rides the same fill as [`peek`](Self::peek), through
+  /// [`peek_with_emitter_terminal`](Self::peek_with_emitter_terminal): it reserves the same one
+  /// owned window, cache hit or miss, and panics on the same broken-[`Cache`](crate::cache::Cache)
+  /// condition. See [`peek`](Self::peek)'s stack-footprint and panics sections.
+  #[inline]
+  pub fn peek_map<'p, W, O, F>(
+    &'p mut self,
+    f: F,
+  ) -> Result<O, <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error>
+  where
+    W: Window,
+    F: FnOnce(Peeked<'p, 'inp, L, W>) -> O,
+    <Ctx::Emitter as Emitter<'inp, L, Lang>>::Error: From<UnexpectedEot<L::Offset, Lang>>,
+  {
+    // Hoisted before the fill, exactly as `peek_head_map` hoists it: the committed span does not
+    // move under a pure peek, and the window borrow (`peeked` ties to `&'p mut self`) must not
+    // overlap the read.
+    let end = self.span().end();
+    let (peeked, terminal, _emitter) = self.peek_with_emitter_terminal::<W>()?;
+    if terminal {
+      // The fill met the request short *because the scanner stopped*. Handing the window back
+      // here is the whole defect this exists to close: it is byte-for-byte what a genuinely
+      // short input produces, so the caller would read a halt as a grammar fact. `f` does not
+      // run — a decision taken on this window is a decision taken on a truncated one.
+      return Err(UnexpectedEot::eot_of(end).into_terminal().into());
+    }
+    Ok(f(peeked))
+  }
+
   /// Width-1 head observation in grammar vocabulary, terminal-aware by construction.
+  ///
+  /// The head-only sibling of [`peek_map`](Self::peek_map), which is the same treatment at an
+  /// arbitrary window width.
   ///
   /// `f` sees the head as `Spanned<&Token, &Span>` and its value is returned. `Ok(None)`
   /// is genuine end of input; a **terminal stop** — a resource-limit trip or a latched

--- a/tokora/src/lexer/logos/mod.rs
+++ b/tokora/src/lexer/logos/mod.rs
@@ -34,11 +34,19 @@ macro_rules! bail {
     /// # Limit-error latching
     ///
     /// When the lexer state (`extras`) reports a limit error from
-    /// [`check`](Lexer::check) after a token is scanned, [`lex`](Lexer::lex) returns that
+    /// [`check`](Lexer::check) after an item is scanned, [`lex`](Lexer::lex) returns that
     /// error **once** and then latches: every subsequent [`lex`](Lexer::lex) returns
     /// `None`, exactly as if the input were exhausted. This bounds the work an
     /// error-recovery caller performs on untrusted input — once the limiter trips the
     /// lexer stops scanning rather than re-failing on every remaining token.
+    ///
+    /// **An *item*, not a token.** A `logos` callback is free to update `extras` and return
+    /// `Err` for the same matched input, so a scan that lands on a lexer error is a completed
+    /// scan whose state must be checked too. When both happen at once the state error wins and
+    /// latches; the raw `logos` error is forwarded only when [`check`](Lexer::check) is `Ok`.
+    /// A tripped limit is a fact about the accumulated tally, which no later input can clear,
+    /// while a lexer error is a fact about one item — the same ranking the input layer applies
+    /// when a trip meets an incomplete frontier.
     ///
     /// After latching, [`span`](Lexer::span), [`slice`](Lexer::slice) and
     /// [`bump`](Lexer::bump) continue to delegate to the inner lexer, which is positioned
@@ -185,14 +193,26 @@ macro_rules! bail {
           return None;
         }
         match self.inner.next() {
-          Some(Ok(tok)) => match self.check() {
-            Ok(_) => Some(Ok(T::from_logos(tok))),
+          // ONE post-scan check, outside the `Ok`/`Err` split. A logos callback may mutate
+          // `extras` and *still* return `Err` for the same matched item, so an item that arrives
+          // as a lexer error is a completed scan exactly as a token is. Asking `check` only on
+          // the token arm treats it as if nothing had been scanned: a limit trip that coincides
+          // with a lexer error is then reported as the raw lexer error, latches nothing, and a
+          // recovery loop keeps scanning past the configured limit.
+          //
+          // The check therefore also *ranks* the two. A tripped state outranks the raw lexer
+          // error it arrived with, for the reason it outranks everything else: the tally is
+          // monotone and no further input can clear it, while a lexer error is a fact about one
+          // item. That is the same precedence the input layer applies one level up, where a
+          // tripped limit outranks an incomplete frontier.
+          Some(scanned) => match self.check() {
+            Ok(()) => Some(scanned.map(T::from_logos).map_err(Into::into)),
             Err(e) => {
               self.poisoned = true;
               Some(Err(e))
             }
           },
-          Some(Err(err)) => Some(Err(err.into())),
+          // Untouched: no item was scanned, so there is no post-scan state to rank against.
           None => None,
         }
       }

--- a/tokora/src/lexer/logos/tests.rs
+++ b/tokora/src/lexer/logos/tests.rs
@@ -296,3 +296,335 @@ fn logos_lexer_latch_inherited_by_lex_spanned() {
     "bounded work: scanning stopped at the trip point"
   );
 }
+
+// ── A logos error that COINCIDES with a state trip (#267) ────────────────
+//
+// The section above is the whole precedence question asked of a *token*: the item scanned
+// cleanly, `check()` failed after it, and the state error replaces it. A logos callback is
+// equally free to mutate `extras` and then return `Err` for the SAME matched item, and that
+// item is a completed scan too — the tally moved. The defect this fixture pins is the
+// asymmetry: a post-scan check placed inside the token arm treats a lexer error as if nothing
+// had been scanned, so the two events happening at once report the *lexer* error, latch
+// nothing, and let a recovery loop go on scanning past the configured limit.
+//
+// SIMULTANEITY IS THE DEFECT'S NAME. Each half alone is already covered — a clean token that
+// trips is `logos_lexer_latches_after_limit_error`, and a lexer error that trips nothing is
+// `logos_error_without_a_trip_stays_recoverable` below — and each half alone passes under the
+// defect. Only the cell where both land on one item separates the two implementations.
+
+/// The precedence fixture's error type. It is also the `logos(error = ...)` type, because the
+/// witness needs a callback that can *return* one, and it keeps the two classes apart by value
+/// so a test can say which of them was reported rather than only that something failed.
+#[derive(Debug, Clone, Default, PartialEq)]
+enum TripErr {
+  #[default]
+  Lex,
+  Limit(TokenLimitExceeded),
+  Incomplete,
+}
+
+impl From<TokenLimitExceeded> for TripErr {
+  fn from(e: TokenLimitExceeded) -> Self {
+    TripErr::Limit(e)
+  }
+}
+
+impl<'a, T, Kind: Clone, S, Lang: ?Sized>
+  From<crate::error::token::UnexpectedToken<'a, T, Kind, S, Lang>> for TripErr
+{
+  fn from(_: crate::error::token::UnexpectedToken<'a, T, Kind, S, Lang>) -> Self {
+    TripErr::Lex
+  }
+}
+
+impl<O, Lang: ?Sized> From<crate::error::UnexpectedEot<O, Lang>> for TripErr {
+  fn from(_: crate::error::UnexpectedEot<O, Lang>) -> Self {
+    TripErr::Lex
+  }
+}
+
+impl From<crate::error::Incomplete<usize>> for TripErr {
+  fn from(_: crate::error::Incomplete<usize>) -> Self {
+    TripErr::Incomplete
+  }
+}
+
+impl crate::error::MaybeIncomplete for TripErr {
+  fn is_incomplete(&self) -> bool {
+    matches!(self, TripErr::Incomplete)
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, logos::Logos)]
+#[logos(crate = logos, extras = TokenLimiter, error = TripErr, skip r"[ \t\r\n]+")]
+enum TripTok {
+  /// THE WITNESS. One legal callback that both bumps the limiter and fails for the same
+  /// matched item, which is the coincidence the adapter has to rank.
+  #[regex(r"x", |lex| { lex.extras.increase(); Err::<(), TripErr>(TripErr::Lex) })]
+  X,
+
+  /// A lexer error that leaves the state alone — the control for "a raw logos error whose
+  /// `check()` is still `Ok` stays an ordinary, recoverable error".
+  #[regex(r"e", |_| { Err::<(), TripErr>(TripErr::Lex) })]
+  E,
+
+  /// A clean item that only counts, for arranging a trip without a lexer error.
+  #[regex(r"n", |lex| { lex.extras.increase(); })]
+  N,
+}
+
+impl core::fmt::Display for TripTok {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    write!(f, "{}", self.kind())
+  }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum TripKind {
+  X,
+  E,
+  N,
+}
+
+impl core::fmt::Display for TripKind {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    f.write_str(match self {
+      TripKind::X => "x",
+      TripKind::E => "e",
+      TripKind::N => "n",
+    })
+  }
+}
+
+impl TokenTrait<'_> for TripTok {
+  type Kind = TripKind;
+  type Error = TripErr;
+
+  fn kind(&self) -> TripKind {
+    match self {
+      TripTok::X => TripKind::X,
+      TripTok::E => TripKind::E,
+      TripTok::N => TripKind::N,
+    }
+  }
+
+  fn is_trivia(&self) -> bool {
+    false
+  }
+}
+
+type TripLexer<'a> = super::LogosLexer<'a, TripTok>;
+
+/// Drains a lexer to exhaustion (or to its latch), returning what each call answered and the
+/// scan tally the callbacks left behind. `cap` bounds the drain so an unlatched lexer under a
+/// tripped limit — the defective behaviour — reports its unbounded scanning as a long list
+/// rather than hanging the suite.
+fn drain(lexer: &mut TripLexer<'_>, cap: usize) -> (std::vec::Vec<Option<TripErr>>, usize) {
+  let mut seen = std::vec::Vec::new();
+  for _ in 0..cap {
+    match lexer.lex() {
+      None => {
+        seen.push(None);
+        break;
+      }
+      Some(Ok(_)) => seen.push(Some(TripErr::default())),
+      Some(Err(e)) => seen.push(Some(e)),
+    }
+  }
+  let tokens = lexer.state().tokens();
+  (seen, tokens)
+}
+
+#[test]
+fn logos_error_and_simultaneous_trip_returns_the_state_error_and_latches() {
+  // The audit's own witness, spelled as it filed it: source `"xx"`, limit zero, a callback that
+  // increments extras past the limit and returns a raw logos error for the same matched `x`.
+  //
+  // What it observed at the audited revision, and what this cell now refuses:
+  //
+  //   lex #1       -> Some(Err(TripErr::Lex))     <- the raw logos error, state never consulted
+  //   state.check  -> Err(TokenLimitExceeded)     <- tripped, and nothing latched
+  //   lex #2       -> Some(Err(TripErr::Lex))     <- scanning continues past the limit
+  //   scan count   -> 2
+  let mut lexer = TripLexer::with_state("xx", TokenLimiter::with_limitation(0));
+
+  let first = lexer.lex();
+  assert!(
+    matches!(first, Some(Err(TripErr::Limit(_)))),
+    "the tripped state outranks the raw logos error it arrived with, got {first:?}"
+  );
+
+  let tokens_at_trip = lexer.state().tokens();
+  assert_eq!(tokens_at_trip, 1, "exactly one item was scanned");
+
+  for _ in 0..5 {
+    assert_eq!(
+      lexer.lex(),
+      None,
+      "latched to EOF, exactly as the token arm latches"
+    );
+  }
+  assert_eq!(
+    lexer.state().tokens(),
+    tokens_at_trip,
+    "bounded work: no further scanning after the latch"
+  );
+}
+
+#[test]
+fn logos_error_without_a_trip_stays_recoverable() {
+  // The other half of the ranking, and the reason the repair cannot be "latch on any error":
+  // an `e` fails without touching the limiter, so `check()` is `Ok` and the raw logos error is
+  // forwarded unchanged. A recovery caller sees every one of them and end of input after.
+  let mut lexer = TripLexer::with_state("ee", TokenLimiter::with_limitation(usize::MAX));
+  let (seen, tokens) = drain(&mut lexer, 8);
+
+  assert_eq!(
+    seen,
+    std::vec![Some(TripErr::Lex), Some(TripErr::Lex), None],
+    "two ordinary lexer errors, then a genuine end of input — no latch"
+  );
+  assert_eq!(tokens, 0, "neither error touched the limiter");
+}
+
+#[test]
+fn a_pre_tripped_state_outranks_a_raw_logos_error() {
+  // The trip need not happen ON the failing item: a state already over its limit when the scan
+  // begins is the same terminal fact, so the first completed scan reports it whatever that scan
+  // produced. Here the item is an `e`, whose callback never touches extras — so the ONLY thing
+  // that can turn this into a limit error is a post-scan check that runs on the error arm.
+  let mut lexer = TripLexer::with_state("ee", TokenLimiter::with_limitation(0));
+  lexer.state_mut().increase();
+  assert!(lexer.check().is_err(), "the fixture starts out tripped");
+
+  let (seen, _) = drain(&mut lexer, 8);
+  assert!(
+    matches!(seen.as_slice(), [Some(TripErr::Limit(_)), None]),
+    "the state error is reported once and the lexer latches, got {seen:?}"
+  );
+}
+
+#[test]
+fn a_clean_token_that_trips_is_unchanged() {
+  // The existing control, re-run on THIS fixture so the two arms are compared over one lexer:
+  // `n` scans cleanly and trips, and that has always reported the state error. A repair that
+  // only moved the check must leave this exactly where it was.
+  let mut lexer = TripLexer::with_state("nn", TokenLimiter::with_limitation(0));
+  let (seen, tokens) = drain(&mut lexer, 8);
+
+  assert!(
+    matches!(seen.as_slice(), [Some(TripErr::Limit(_)), None]),
+    "a token that trips reports the state error and latches, got {seen:?}"
+  );
+  assert_eq!(tokens, 1, "bounded work on the token arm too");
+}
+
+// ── The same precedence, seen through `InputRef` ─────────────────────────
+//
+// `InputRef` rebuilds a lexer per operation, so it never inherits the adapter's own latch: it
+// asks `check()` itself and records a poison boundary. That half was already right. What it
+// could not do was report the *value*, because it builds its trip verdict out of the error
+// `lex` already returned — so a trip that arrived wearing a logos error was latched correctly
+// and diagnosed wrongly. These two cells read the retained diagnostic rather than the boundary
+// for exactly that reason.
+
+type TripCtx<'a> = (
+  crate::emitter::Verbose<TripErr>,
+  crate::cache::DefaultCache<'a, TripLexer<'a>>,
+);
+
+fn tripping_input(
+  src: &str,
+  limit: usize,
+) -> crate::input::Input<'_, TripLexer<'_>, TripCtx<'_>, ()> {
+  crate::input::Input::with_state_and_context(
+    src,
+    TokenLimiter::with_limitation(limit),
+    crate::input::InputContext::new(
+      crate::emitter::Verbose::<TripErr>::new(),
+      crate::cache::DefaultCache::<'_, TripLexer<'_>>::default(),
+    ),
+  )
+}
+
+/// `(ordinary lexer diagnostics, limit diagnostics)` retained by the verbose emitter.
+fn retained<'a, Cmpl>(
+  input: &crate::input::Input<'a, TripLexer<'a>, TripCtx<'a>, (), Cmpl>,
+) -> (usize, usize)
+where
+  Cmpl: crate::input::Completeness,
+{
+  let all = input.emitter().errors();
+  let lex = all
+    .values()
+    .flatten()
+    .filter(|e| matches!(e, TripErr::Lex))
+    .count();
+  let limit = all
+    .values()
+    .flatten()
+    .filter(|e| matches!(e, TripErr::Limit(_)))
+    .count();
+  (lex, limit)
+}
+
+#[test]
+fn a_complete_scan_diagnoses_the_trip_with_the_state_error() {
+  let mut input = tripping_input("xx", 0);
+  {
+    let mut inp = input.as_ref();
+    let before = inp.scanner_trip_snapshot();
+    assert_eq!(
+      inp.next(),
+      Ok(None),
+      "the trip is terminal: the scan ends rather than yielding a token"
+    );
+    assert!(
+      inp.scanner_tripped_during_attempt(before),
+      "and the terminal probe fired, so the poison boundary latched"
+    );
+  }
+  assert_eq!(
+    retained(&input),
+    (0, 1),
+    "the terminal diagnostic is the STATE error, not the logos error the item arrived with"
+  );
+}
+
+#[test]
+fn a_partial_frontier_diagnoses_the_trip_with_the_state_error() {
+  // The frontier case the terminal-first ranking exists for, now with the payload attached:
+  // the tripping item ends exactly at a non-final buffer end, where the holdback would
+  // otherwise withhold it as `Incomplete`. It is reported as a trip — carrying the state error.
+  let mut input = crate::input::Input::<
+    TripLexer<'_>,
+    TripCtx<'_>,
+    (),
+    crate::input::Partial,
+  >::with_state_and_context(
+    "x",
+    TokenLimiter::with_limitation(0),
+    crate::input::InputContext::new(
+      crate::emitter::Verbose::<TripErr>::new(),
+      crate::cache::DefaultCache::<'_, TripLexer<'_>>::default(),
+    ),
+  );
+  {
+    let mut inp = input.as_ref();
+    let before = inp.scanner_trip_snapshot();
+    assert_eq!(
+      inp.next(),
+      Ok(None),
+      "terminal beats incomplete: the trip is not withheld for more bytes"
+    );
+    assert!(
+      inp.scanner_tripped_during_attempt(before),
+      "and the terminal probe fired at the frontier"
+    );
+  }
+  assert_eq!(
+    retained(&input),
+    (0, 1),
+    "the frontier path reports the state payload too"
+  );
+}


### PR DESCRIPTION
Closes #273, #267 and #272.